### PR TITLE
Add vpc_subnet and rmq_version parameters when creating instances

### DIFF
--- a/resource_instance.go
+++ b/resource_instance.go
@@ -62,7 +62,7 @@ func resourceInstance() *schema.Resource {
 
 func resourceCreate(d *schema.ResourceData, meta interface{}) error {
 	api := meta.(*api.API)
-	keys := []string{"name", "plan", "region", "nodes"}
+	keys := []string{"name", "plan", "region", "nodes", "vpc_subnet", "rmq_version"}
 	params := make(map[string]interface{})
 	for _, k := range keys {
 		if v := d.Get(k); v != nil {


### PR DESCRIPTION
This is a preliminary pull request. I have not yet tested this, because I don't have billing set up yet,  I can't create dedicated instances that allow `rmq_version` and `vpc_subnet` parameters.

I should be able to test it out early next week.