### PR TITLE
Fix compiler issues on MacBook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,19 @@
+## Check if a 64 bit kernel is running
+UNAME_M := $(shell uname -m)
+
 UNAME_P := $(shell uname -p)
 ifeq ($(UNAME_P),i386)
-    GOARCH += 386
+	ifeq ($(UNAME_M),x86_64)
+		GOARCH += amd64
+	else
+		GOARCH += i386
+	endif
 else
     ifeq ($(UNAME_P),AMD64)
         GOARCH += amd64
     endif
-
 endif
+
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)


### PR DESCRIPTION
There is some compilation errors on some MacBook when the cpu type doesn't match with the kernel version. eg. if the cpu is i386 but the kernel is 64bit (x86_64), the build will be i386 and terraform will not work.

Fix the terraform error: 
Error: Failed to instantiate provider "cloudamqp" to obtain schema: fork/exec /Users/username/.terraform.d/plugins/terraform-provider-cloudamqp: bad CPU type in executable