### PR TITLE
Add required field message_type

### DIFF
--- a/cloudamqp/resource_alarm.go
+++ b/cloudamqp/resource_alarm.go
@@ -57,6 +57,12 @@ func resourceAlarm() *schema.Resource {
 				Optional:    true,
 				Description: "Regex for which queues to check",
 			},
+			"message_type": {
+				Type: schema.TypeString,
+				Optional: true,
+				Description: "Message types (total, unacked, ready) of the queue to trigger the alarm",
+				ValidateFunc: validateMessageType(),
+			}
 			"recipients": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -179,4 +185,12 @@ func validateSchemaAttribute(key string) bool {
 		return true
 	}
 	return false
+}
+
+func validateMessageType() schema.SchemaValidateFunc {
+	return validation.StringInSlice([]string{
+		"total",
+		"unacked",
+		"ready",
+	}, true)
 }

--- a/sample/alarm/main.tf
+++ b/sample/alarm/main.tf
@@ -12,37 +12,49 @@ resource "cloudamqp_instance" "rmq_bunny" {
 // Notification and recipient
 resource "cloudamqp_notification" "recipient_01" {
   instance_id = cloudamqp_instance.rmq_bunny.id
-  type = "email"
-  value = "alarm@example.com"
+  type        = "email"
+  value       = "alarm@example.com"
 }
 
 resource "cloudamqp_notification" "recipient_02" {
   instance_id = cloudamqp_instance.rmq_bunny.id
-  type = "email"
-  value = "notification@example.com"
+  type        = "email"
+  value       = "notification@example.com"
 }
 
 // Alarm
 resource "cloudamqp_alarm" "alarm_01" {
-  instance_id = cloudamqp_instance.rmq_bunny.id
-  type = "cpu"
+  instance_id     = cloudamqp_instance.rmq_bunny.id
+  type            = "cpu"
   value_threshold = 90
-  time_threshold = 600
-  notifications = [cloudamqp_notification.recipient_01.id, cloudamqp_notification.recipient_02]
+  time_threshold  = 600
+  recipients      = [cloudamqp_notification.recipient_01.id, cloudamqp_notification.recipient_02]
 }
 
 resource "cloudamqp_alarm" "alarm_02" {
-  instance_id = cloudamqp_instance.rmq_bunny.id
-  type = "memory"
+  instance_id     = cloudamqp_instance.rmq_bunny.id
+  type            = "memory"
   value_threshold = 90
-  time_threshold = 600
-  notifications = [cloudamqp_notification.recipient_01.id, cloudamqp_notification.recipient_02]
+  time_threshold  = 600
+  recipients      = [cloudamqp_notification.recipient_01.id, cloudamqp_notification.recipient_02]
 }
 
 resource "cloudamqp_alarm" "alarm_03" {
-  instance_id = cloudamqp_instance.rmq_bunny.id
-  type = "disk"
+  instance_id     = cloudamqp_instance.rmq_bunny.id
+  type            = "disk"
   value_threshold = 10
-  time_threshold = 600
-  notifications = [cloudamqp_notification.recipient_01.id]
+  time_threshold  = 600
+  recipients      = [cloudamqp_notification.recipient_01.id]
+}
+
+resource "cloudamqp_alarm" "alarm_04" {
+  instance_id     = cloudamqp_instance.rmq_bunny.id
+  type            = "queue"
+  value_threshold = 120
+  time_threshold  = 120
+  enabled         = true
+  queue_regex     = ".*"
+  vhost_regex     = ".*"
+  message_type    = "total"
+  recipients      = [cloudamqp_notification.recipient_01.id]
 }


### PR DESCRIPTION
Hello,

Since upgrading to the latest version of the provider (because of the API changes), we've been hitting this error with some `cloudamqp_alarm` alarms:
```
[2020-03-04T11:27:09.965Z] Error: Alarms::UpdateAlarm failed, status: 400, message: map[errors:[map[message_type:Field is required]]]

[2020-03-04T11:27:09.965Z] 

[2020-03-04T11:27:09.965Z]   on .terraform/modules/eng-hermes-pesa-cloudamqp/modules/jumo-cloudamqp-cluster/main.tf line 63, in resource "cloudamqp_alarm" "queue_alarms":

[2020-03-04T11:27:09.965Z]   63: resource "cloudamqp_alarm" "queue_alarms" {
```

Here is a rough definition of the alarm we were creating:

```hcl
resource "cloudamqp_alarm" "my_alarm" {
  instance_id     = cloudamqp_instance.rmq_bunny.id
  type            = "queue"
  value_threshold = 120
  time_threshold  = 120
  enabled         = true
  queue_regex     = ".*"
  vhost_regex     = ".*"
  recipients      = [cloudamqp_notification.myrecipient.id]
}
```

In this PR, I added the `message_type` field to the schema, as well as a validation function for this field, so as to respect the constraints described in the documentation: https://docs.cloudamqp.com/cloudamqp_api.html#alarms

Please also note that the Terraform provider documentation needs to be updated: https://docs.cloudamqp.com/cloudamqp_terraform.html#resource
I wasn't able to find a file where this document is generated from, so I assume you create it on your side.

Please let me know if anything is missing,

Cheers

Matthieu