### PR TITLE
Add message_type field to the schema attribute validator

### DIFF
--- a/cloudamqp/resource_alarm.go
+++ b/cloudamqp/resource_alarm.go
@@ -77,7 +77,7 @@ func resourceAlarm() *schema.Resource {
 
 func resourceAlarmCreate(d *schema.ResourceData, meta interface{}) error {
 	api := meta.(*api.API)
-	keys := []string{"type", "enabled", "value_threshold", "time_threshold", "vhost_regex", "queue_regex", "recipients"}
+	keys := []string{"type", "enabled", "value_threshold", "time_threshold", "vhost_regex", "queue_regex", "message_type", "recipients"}
 	params := make(map[string]interface{})
 	for _, k := range keys {
 		if v := d.Get(k); v != nil {
@@ -138,7 +138,7 @@ func resourceAlarmRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAlarmUpdate(d *schema.ResourceData, meta interface{}) error {
 	api := meta.(*api.API)
-	keys := []string{"type", "enabled", "value_threshold", "time_threshold", "vhost_regex", "queue_regex", "recipients"}
+	keys := []string{"type", "enabled", "value_threshold", "time_threshold", "vhost_regex", "queue_regex", "message_type", "recipients"}
 	params := make(map[string]interface{})
 	params["id"] = d.Id()
 	log.Printf("[DEBUG] cloudamqp::resource::alarm::update params: %v", params)
@@ -181,6 +181,7 @@ func validateSchemaAttribute(key string) bool {
 		"time_threshold",
 		"vhost_regex",
 		"queue_regex",
+		"message_type",
 		"recipients":
 		return true
 	}


### PR DESCRIPTION
After updating to the latest release (v1.4.1), we still got the same errors we had in #43 

After investigating, I realized that I had forgotten to had the `message_type` field to the `keys` slice in `resourceAlarmCreate` and `resourceAlarmUpdate`, effectively leaving the `message_type` out of our creation POST/PUT requests. 

Additionally, I added the `message_type` field to the `validateSchemaAttribute` method.

After building my changes, I was able to successfully apply my changes.

@tbroden84 FYI