### PR TITLE
Force recreate instances if switching plan from shared to dedicated or vice versa

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/cloudamqp/terraform-provider-cloudamqp
 
 go 1.12
 
-replace github.com/84codes/go-api => ../../84codes/go-api
-
 require (
 	github.com/84codes/go-api v1.2.0
 	github.com/hashicorp/terraform-plugin-sdk v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -291,6 +291,7 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 h1:HyfiK1WMnHj5FXFXatD+Qs1A/
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa h1:KIDDMLT1O0Nr7TSxp8xM5tJcdn8tgyAONntO829og1M=
 golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This PR intends on fixing this error:
```shell

[2020-04-03T09:12:39.202Z] Error: UpdateInstance failed, status: 422, message: map[error:Sorry, you can't move to a shared plan automatically. Please create a new instance.]

[2020-04-03T09:12:39.202Z] 

[2020-04-03T09:12:39.202Z]   on .terraform/modules/cloudamqp/modules/cloudamqp-cluster/main.tf line 29, in resource "cloudamqp_instance" "rmq_cluster":

[2020-04-03T09:12:39.202Z]   29: resource "cloudamqp_instance" "rmq_cluster" {}
```

In this case, I think it makes sense to force replacement if we switch from dedicated to shared plans, or vice versa.

i.e : switching from a `bunny` plan to a `tiger` should recreate the `cloudamqp_instance`

After writing those changes, I tested them with the code base that encountered the aforementioned error:

```
  # module.cloudamqp.cloudamqp_instance.rmq_cluster must be replaced
-/+ resource "cloudamqp_instance" "rmq_cluster" {
      ~ apikey      = (sensitive value)
      ~ host        = "eloquent-cat.rmq.cloudamqp.com" -> (known after apply)
      ~ id          = "90763" -> (known after apply)
        name        = "myservice"
        nodes       = 1
      ~ plan        = "bunny" -> "tiger" # forces replacement
      + ready       = (known after apply)
        region      = "amazon-web-services::ap-south-1"
        rmq_version = "3.7.21"
      ~ url         = (sensitive value)
      ~ vhost       = "ddqzsxzi" -> (known after apply)
    }
```