### PR TITLE
Add a link to the API location

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,14 @@ It’s possible to change between shared and dedicated plans (or vice versa). Th
 
 Import existing infrastructure into state and bring the resource under Terraform management. Information about the resource will be added to the terraform.state file. Then add manually the given information to the .tf file. Once this is done, run terraform plan to see that the resource is under Terraform management. From here it's possible to add more resources such as alarm.
 
+You'll need to determine the `resource_id` and other identifiers for the items you intend to import. You can do this using the CloudAMQP API, which is documented here https://docs.cloudamqp.com/#instances. Use a token found on this page https://customer.cloudamqp.com/apikeys.
+
 ### Instance:
 
 Import cloudamqp instance and bring it under Terraform management. First declare an empty instance resource in the .tf file. Followed by running the terraform import command
 
 ```sh
-resource "cloudamqp_instance"."rmq_url" {}
+resource "cloudamqp_instance" "rmq_url" {}
 ```
 
 Generic form of terraform import command


### PR DESCRIPTION
So I can determine the `resource_id` to import, I've added a link to the API docs.

I also corrected a small typo on the import template structure. I believe `rmq_url` is not an intention revealing name to be used to name an instance (it sounds like a param) but I'll leave that to someone else to update if they want.