### PR TITLE
fix typo in docs for cloudamqp_integration_metric resource

### DIFF
--- a/docs/resources/integration_metrics.md
+++ b/docs/resources/integration_metrics.md
@@ -22,7 +22,7 @@ resource "cloudamqp_integration_metric" "cloudwatch" {
   region = var.aws_region
 }
 
-resource "cloudamqo_integration_metric" "datadog" {
+resource "cloudamqp_integration_metric" "datadog" {
   instance_id = cloudamqp_instance.instance.id
   name = "datadog"
   api_key = var.datadog_api_key


### PR DESCRIPTION
Ported from https://github.com/hashicorp/terraform-provider-cloudamqp/pull/1/; also addresses https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/86