### PR TITLE
Create instance in existing VPC

### DIFF
--- a/cloudamqp/data_source_cloudamqp_instance.go
+++ b/cloudamqp/data_source_cloudamqp_instance.go
@@ -35,6 +35,11 @@ func dataSourceInstance() *schema.Resource {
 				Computed:    true,
 				Description: "Name of the region you want to create your instance in",
 			},
+			"vpc_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The ID of the VPC to create your instance in",
+			},
 			"vpc_subnet": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -111,6 +116,7 @@ func dataSourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	for k, v := range data {
 		if validateInstanceSchemaAttribute(k) {
 			if k == "vpc" {
+				err = d.Set("vpc_id", v.(map[string]interface{})["id"])
 				err = d.Set("vpc_subnet", v.(map[string]interface{})["subnet"])
 			} else if k == "nodes" {
 				plan := d.Get("plan").(string)

--- a/docs/data-sources/instance.md
+++ b/docs/data-sources/instance.md
@@ -29,6 +29,7 @@ All attributes reference are computed
 * `name`        - The name of the CloudAMQP instance.
 * `plan`        - The subscription plan for the CloudAMQP instance.
 * `region`      - The cloud platform and region that host the CloudAMQP instance, `{platform}::{region}`.
+* `vpc_id`      - ID of the VPC configured for the CloudAMQP instance.
 * `vpc_subnet`  - Dedicated VPC subnet configured for the CloudAMQP instance.
 * `nodes`       - Number of nodes in the cluster of the CloudAMQP instance.
 * `rmq_version` - The version of installed Rabbit MQ.

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -42,7 +42,8 @@ The following arguments are supported:
 * `nodes`       - (Computed/Optional) Number of nodes, 1, 3 or 5 depending on plan used. **DEPRECATED. Old subscriptions plan can still change this to scale up or down the instance. New subscriptions plans use the plan to determine number of nodes. In order to change number of nodes the `plan` needs to be updated.**
 * `tags`        - (Optional) One or more tags for the CloudAMQP instance, makes it possible to categories multiple instances in console view. Default there is no tags assigned.
 * `rmq_version` - (Computed/Optional) The Rabbit MQ version. Can be left out, will then be set to default value used by CloudAMQP API. **Note: There is not yet any support in the provider to change the RMQ version. Once it's set in the initial creation, it will remain.**
-* `vpc_subnet`  - (Optional) Creates a dedicated VPC subnet, shouldn't overlap with other VPC subnet, default subnet used 10.56.72.0/24. **NOTE: extra fee will be charged when using VPC, see [CloudAMQP](https://cloudamqp.com) for more information.**
+* `vpc_id`      - (Computed/Optional) The VPC ID. Use this to create your instance in an existing VPC.
+* `vpc_subnet`  - (Computed/Optional) Creates a dedicated VPC subnet, shouldn't overlap with other VPC subnet, default subnet used 10.56.72.0/24. **NOTE: extra fee will be charged when using VPC, see [CloudAMQP](https://cloudamqp.com) for more information.**
 * `no_default_alarms`- (Computed/Optional) Set to true to discard creating default alarms when the instance is created. Can be left out, will then use default value = false.
 
 ## Attributes Reference


### PR DESCRIPTION
Example usage:

```hcl
resource "cloudamqp_instance" "my_instance" {
  name       = "<instance name>"
  plan       = "squirrel-1"
  region     = "amazon-web-services::eu-north-1"
  vpc_id     = 123
}
```

You don't need to supply `vpc_subnet`, but if you supply both, `vpc_id` has preference in the backend API (mismatch with the correct `vpc_subnet` value wont create a new VPC when `vpc_id` is supplied).

Note: The existing VPC you want to use needs to be in the chosen `region`.

You can look up the id (and subnet) of an existing VPC by either instance name or instance ID:

```hcl
# by instance name
locals {
  instance_name = "<instance name>"
}
data "cloudamqp_account" "account" {}
data "cloudamqp_instance" "instance_info" {
  instance_id = [for instance in data.cloudamqp_account.account.instances : instance if instance["name"] == local.instance_name][0].id
}

# by instance ID
data "cloudamqp_instance" "instance_info" {
  instance_id = 123
}

output "vpc_id" {
  value = data.cloudamqp_instance.instance_info.vpc_id
}

output "vpc_subnet" {
  value = data.cloudamqp_instance.instance_info.vpc_subnet
}
```

Close #89