### PR TITLE
Add `host_internal` instance attribute

### DIFF
--- a/cloudamqp/data_source_cloudamqp_instance.go
+++ b/cloudamqp/data_source_cloudamqp_instance.go
@@ -78,7 +78,12 @@ func dataSourceInstance() *schema.Resource {
 			"host": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Host name for the CloudAMQP instance",
+				Description: "External hostname for the CloudAMQP instance",
+			},
+			"host_internal": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Internal hostname for the CloudAMQP instance",
 			},
 			"vhost": {
 				Type:        schema.TypeString,
@@ -134,6 +139,14 @@ func dataSourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("error setting %s for resource %s: %s", k, d.Id(), err)
 			}
 		}
+	}
+
+	if err = d.Set("host", data["hostname_external"].(string)); err != nil {
+		return fmt.Errorf("error setting host for resource %s: %s", d.Id(), err)
+	}
+
+	if err = d.Set("host_internal", data["hostname_internal"].(string)); err != nil {
+		return fmt.Errorf("error setting host for resource %s: %s", d.Id(), err)
 	}
 
 	if data["no_default_alarms"] == nil {

--- a/cloudamqp/resource_cloudamqp_instance.go
+++ b/cloudamqp/resource_cloudamqp_instance.go
@@ -87,7 +87,12 @@ func resourceInstance() *schema.Resource {
 			"host": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Host name for the CloudAMQP instance",
+				Description: "External hostname for the CloudAMQP instance",
+			},
+			"host_internal": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Internal hostname for the CloudAMQP instance",
 			},
 			"vhost": {
 				Type:        schema.TypeString,
@@ -197,6 +202,14 @@ func resourceRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	if err = d.Set("host", data["hostname_external"].(string)); err != nil {
+		return fmt.Errorf("error setting host for resource %s: %s", d.Id(), err)
+	}
+
+	if err = d.Set("host_internal", data["hostname_internal"].(string)); err != nil {
+		return fmt.Errorf("error setting host for resource %s: %s", d.Id(), err)
+	}
+
 	planType, _ := getPlanType(d.Get("plan").(string))
 	dedicated := planType == "dedicated"
 	if err = d.Set("dedicated", dedicated); err != nil {
@@ -254,7 +267,6 @@ func validateInstanceSchemaAttribute(key string) bool {
 		"url",
 		"apikey",
 		"tags",
-		"host",
 		"vhost",
 		"no_default_alarms",
 		"ready":

--- a/docs/data-sources/instance.md
+++ b/docs/data-sources/instance.md
@@ -33,8 +33,9 @@ All attributes reference are computed
 * `vpc_subnet`  - Dedicated VPC subnet configured for the CloudAMQP instance.
 * `nodes`       - Number of nodes in the cluster of the CloudAMQP instance.
 * `rmq_version` - The version of installed Rabbit MQ.
-* `url`         - (Sensitive) The AMQP url, used by clients to connect for pub/sub.
+* `url`         - (Sensitive) The AMQP URL (uses the internal hostname if the instance was created with VPC), used by clients to connect for pub/sub.
 * `apikey`      - (Sensitive) The API key to secondary API handing alarms, integration etc.
 * `tags`        - Tags the CloudAMQP instance with categories.
-* `host`        - The hostname for the CloudAMQP instance.
+* `host`        - The external hostname for the CloudAMQP instance.
+* `host_internal` - The internal hostname for the CloudAMQP instance.
 * `vhost`       - The virtual host configured in Rabbit MQ.

--- a/docs/data-sources/nodes.md
+++ b/docs/data-sources/nodes.md
@@ -32,7 +32,7 @@ ___
 
 The `nodes` block consist of
 
-* `hostname`          - Hostname assigned to the node.
+* `hostname`          - External hostname assigned to the node.
 * `name`              - Name of the node.
 * `running`           - Is the node running?
 * `rabbitmq_version`  - Currently configured Rabbit MQ version on the node.

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -51,9 +51,10 @@ The following arguments are supported:
 All attributes reference are computed
 
 * `id`      - The identifier (instance_id) for this resource, used as a reference by almost all other resource and data sources
-* `url`     - AMQP server endpoint. `amqps://{username}:{password}@{hostname}/{vhost}`
+* `url`     - The AMQP URL (uses the internal hostname if the instance was created with VPC). Has the format: `amqps://{username}:{password}@{hostname}/{vhost}`
 * `apikey`  - API key needed to communicate to CloudAMQP's second API. The second API is used to manage alarms, integration and more, full description [CloudAMQP API](https://docs.cloudamqp.com/cloudamqp_api.html).
-* `host`    - The host name for the CloudAMQP instance.
+* `host`    - The external hostname for the CloudAMQP instance.
+* `host_internal` - The internal hostname for the CloudAMQP instance.
 * `vhost`   - The virtual host used by Rabbit MQ.
 
 ## Import


### PR DESCRIPTION
Make the existing attribute `host` always return the external hostname.

Close #92
Close #125