### PR TITLE
Add VPC peer configuration and info for Google Cloud Platform

### DIFF
--- a/cloudamqp/data_source_cloudamqp_vpc_gcp_info.go
+++ b/cloudamqp/data_source_cloudamqp_vpc_gcp_info.go
@@ -1,0 +1,74 @@
+package cloudamqp
+
+import (
+	"fmt"
+
+	"github.com/84codes/go-api/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceVpcGcpInfo() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVpcGcpInfoRead,
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "Instance identifier",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "VPC name",
+			},
+			"vpc_subnet": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "VPC subnet",
+			},
+			"network": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "VPC network uri",
+			},
+		},
+	}
+}
+
+func dataSourceVpcGcpInfoRead(d *schema.ResourceData, meta interface{}) error {
+	api := meta.(*api.API)
+	data, err := api.ReadVpcGcpInfo(d.Get("instance_id").(int))
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(data["name"].(string))
+
+	for k, v := range data {
+		if validateVpcGcpInfoSchemaAttribute(k) {
+			if k == "subnet" {
+				err = d.Set("vpc_subnet", v)
+			} else {
+				err = d.Set(k, v)
+			}
+
+			if err != nil {
+				return fmt.Errorf("error setting %s for resource %s: %s", k, d.Id(), err)
+			}
+		}
+	}
+	return nil
+}
+
+func validateVpcGcpInfoSchemaAttribute(key string) bool {
+	switch key {
+	case "name",
+		"subnet",
+		"vpc_subnet",
+		"network":
+		return true
+	}
+	return false
+}

--- a/cloudamqp/provider.go
+++ b/cloudamqp/provider.go
@@ -36,6 +36,7 @@ func Provider(v string) *schema.Provider {
 			"cloudamqp_plugins":           dataSourcePlugins(),
 			"cloudamqp_plugins_community": dataSourcePluginsCommunity(),
 			"cloudamqp_notification":      dataSourceNotification(),
+			"cloudamqp_vpc_gcp_info":      dataSourceVpcGcpInfo(),
 			"cloudamqp_vpc_info":          dataSourceVpcInfo(),
 			"cloudamqp_nodes":             dataSourceNodes(),
 		},

--- a/cloudamqp/provider.go
+++ b/cloudamqp/provider.go
@@ -49,6 +49,7 @@ func Provider(v string) *schema.Provider {
 			"cloudamqp_plugin_community":   resourcePluginCommunity(),
 			"cloudamqp_security_firewall":  resourceSecurityFirewall(),
 			"cloudamqp_vpc_peering":        resourceVpcPeering(),
+			"cloudamqp_vpc_gcp_peering":    resourceVpcGcpPeering(),
 			"cloudamqp_integration_log":    resourceIntegrationLog(),
 			"cloudamqp_integration_metric": resourceIntegrationMetric(),
 			"cloudamqp_webhook":            resourceWebhook(),

--- a/cloudamqp/resource_cloudamqp_vpc_gcp_peering.go
+++ b/cloudamqp/resource_cloudamqp_vpc_gcp_peering.go
@@ -1,0 +1,125 @@
+package cloudamqp
+
+import (
+	"log"
+
+	"github.com/84codes/go-api/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceVpcGcpPeering() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCreateVpcGcpPeering,
+		Read:   resourceReadVpcGcpPeering,
+		Update: resourceUpdateVpcGcpPeering,
+		Delete: resourceDeleteVpcGcpPeering,
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "Instance identifier",
+			},
+			"peer_subnet": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "VPC subnet",
+			},
+			"peer_network_uri": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "VPC network uri",
+			},
+			"state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "VPC peering state",
+			},
+			"state_details": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "VPC peering state details",
+			},
+			"auto_create_routes": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "VPC peering auto created routes",
+			},
+		},
+	}
+}
+
+func resourceCreateVpcGcpPeering(d *schema.ResourceData, meta interface{}) error {
+	api := meta.(*api.API)
+	keys := []string{"peer_subnet", "peer_network_uri"}
+	params := make(map[string]interface{})
+	for _, k := range keys {
+		if v := d.Get(k); v != nil && v != "" {
+			params[k] = v
+		}
+	}
+
+	data, err := api.RequestVpcGcpPeering(d.Get("instance_id").(int), params)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range data {
+		if k == "peering" {
+			d.SetId(v.(string))
+		}
+	}
+
+	return resourceReadVpcGcpPeering(d, meta)
+}
+
+func resourceReadVpcGcpPeering(d *schema.ResourceData, meta interface{}) error {
+	api := meta.(*api.API)
+	data, err := api.ReadVpcGcpPeering(d.Get("instance_id").(int), d.Id())
+	log.Printf("[DEBUG] cloudamqp::vpc_gcp_peering::read data: %v", data)
+
+	if err != nil {
+		return err
+	}
+
+	rows := data["rows"].([]interface{})
+	if len(rows) > 0 {
+		for _, row := range rows {
+			tempRow := row.(map[string]interface{})
+			if tempRow["name"] != d.Id() {
+				continue
+			}
+			for k, v := range tempRow {
+				if validateGcpPeeringSchemaAttribute(k) {
+					if k == "stateDetails" {
+						d.Set("state_details", v.(string))
+					} else if k == "autoCreateRoutes" {
+						d.Set("auto_create_routes", v.(bool))
+					} else {
+						d.Set(k, v.(string))
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceUpdateVpcGcpPeering(d *schema.ResourceData, meta interface{}) error {
+	return resourceReadVpcGcpPeering(d, meta)
+}
+
+func resourceDeleteVpcGcpPeering(d *schema.ResourceData, meta interface{}) error {
+	api := meta.(*api.API)
+	return api.RemoveVpcGcpPeering(d.Get("instance_id").(int), d.Id())
+}
+
+func validateGcpPeeringSchemaAttribute(key string) bool {
+	switch key {
+	case "state",
+		"stateDetails",
+		"autoCreateRoutes":
+		return true
+	}
+	return false
+}

--- a/docs/data-sources/vpc_gcp_info.md
+++ b/docs/data-sources/vpc_gcp_info.md
@@ -20,7 +20,6 @@ data "cloudamqp_vpc_gcp_info" "vpc_info" {
 ## Argument reference
 
 * `instance_id` - (Required) The CloudAMQP instance identifier.
-* `peer_subnet` - (Required)
 
 ## Attributes reference
 

--- a/docs/data-sources/vpc_gcp_info.md
+++ b/docs/data-sources/vpc_gcp_info.md
@@ -1,0 +1,36 @@
+---
+layout: "cloudamqp"
+page_title: "CloudAMQP: data source vpc_gcp_info"
+description: |-
+  Get information about VPC hosted in GCP.
+---
+
+# cloudamqp_vpc_gcp_info
+
+Use this data source to retrieve information about VPC for a CloudAMQP instance hosted in GCP.
+
+## Example Usage
+
+```hcl
+data "cloudamqp_vpc_gcp_info" "vpc_info" {
+  instance_id = cloudamqp_instance.instance.id
+}
+```
+
+## Argument reference
+
+* `instance_id` - (Required) The CloudAMQP instance identifier.
+* `peer_subnet` - (Required)
+
+## Attributes reference
+
+All attributes reference are computed
+
+* `id`                  - The identifier for this resource.
+* `name`                - The name of the VPC.
+* `vpc_subnet`          - Dedicated VPC subnet.
+* `network`             - VPC network uri.
+
+## Dependency
+
+This data source depends on CloudAMQP instance identifier, `cloudamqp_instance.instance.id`.

--- a/docs/resources/vpc_gcp_peering.md
+++ b/docs/resources/vpc_gcp_peering.md
@@ -1,0 +1,63 @@
+---
+layout: "cloudamqp"
+page_title: "CloudAMQP: cloudamqp_vpc_gcp_peering"
+description: |-
+  Create VPC peering configuration to another VPC network hosted in GCP
+---
+
+# cloudamqp_vpc_gcp_peering
+
+This resouce creates a VPC peering configuration for the CloudAMQP instance. The configuration will connect to another VPC network hosted in GCP. More information to create VPC peering configuration for [GCP](https://cloud.google.com/vpc/docs/using-vpc-peering).
+
+Only available for dedicated subscription plans.
+
+## Example Usage
+
+```hcl
+# Configure CloudAMQP provider
+provider "cloudamqp" {
+  apikey = var.cloudamqp_customer_api_key
+}
+
+# CloudAMQP instance
+resource "cloudamqp_instance" "instance" {
+  name   = "terraform-vpc-peering"
+  plan   = "bunny-1"
+  region = "google-compute-engine::europe-north1"
+  nodes  = 1
+  tags   = ["terraform"]
+  rmq_version = "3.8.4"
+  vpc_subnet = "10.40.72.0/24"
+}
+
+# VPC information
+data "cloudamqp_vpc_gcp info" "vpc_info" {
+  instance_id = cloudamqp_instance.instance.id
+}
+
+# VPC peering configuration
+resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
+  instance_id = cloudamqp_instance.instance.id
+  peer_subnet = cloudamqp_instance.instance.vpc_subnet
+  peer_network_uri = "https://www.googleapis.com/compute/v1/projects/<PROJECT-NAME>/global/networks/<NETWORK-NAME>"
+}
+```
+
+## Argument Reference
+
+* `instance_id` - (Required) The CloudAMQP instance ID.
+* `peer_network_uri`- (Required) Network uri of the VPC network to which you will peer with.
+* `peer_subnet` - (Required) VPC subnet
+
+## Attributes Reference
+
+All attributes reference are computed
+
+* `id` - The identifier for this resource.
+* `state` - VPC peering state
+* `state_details` - VPC peering state details
+* `auto_create_routes` - VPC peering auto created routes
+
+## Depedency
+
+This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.instance.id`.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudamqp/terraform-provider-cloudamqp
 go 1.17
 
 require (
-	github.com/84codes/go-api v1.5.2
+	github.com/84codes/go-api v1.5.3
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
 )
 


### PR DESCRIPTION
- Fetch VPC information for VPCs hosted at Google Cloud Platform.
- Enable VPC peer configuration request for VPCs hosted at Google Cloud Platform.
