### PR TITLE
Add new attribute, value_calculation, to alarms

### DIFF
--- a/cloudamqp/data_source_cloudamqp_alarm.go
+++ b/cloudamqp/data_source_cloudamqp_alarm.go
@@ -41,6 +41,11 @@ func dataSourceAlarm() *schema.Resource {
 				Computed:    true,
 				Description: "What value to trigger the alarm for",
 			},
+			"value_calculation": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Disk value threshold calculation. Fixed or percentage of disk space remaining",
+			},
 			"time_threshold": {
 				Type:        schema.TypeInt,
 				Computed:    true,

--- a/cloudamqp/resource_cloudamqp_alarm.go
+++ b/cloudamqp/resource_cloudamqp_alarm.go
@@ -43,6 +43,12 @@ func resourceAlarm() *schema.Resource {
 				Optional:    true,
 				Description: "What value to trigger the alarm for",
 			},
+			"value_calculation": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Disk value threshold calculation. Fixed or percentage of disk space remaining",
+				ValidateFunc: validateValueCalculation(),
+			},
 			"time_threshold": {
 				Type:        schema.TypeInt,
 				Optional:    true,
@@ -78,7 +84,7 @@ func resourceAlarm() *schema.Resource {
 
 func resourceAlarmCreate(d *schema.ResourceData, meta interface{}) error {
 	api := meta.(*api.API)
-	keys := []string{"type", "enabled", "value_threshold", "time_threshold", "vhost_regex", "queue_regex", "message_type", "recipients"}
+	keys := alarmAttributeKeys()
 	params := make(map[string]interface{})
 	for _, k := range keys {
 		if v := d.Get(k); v != nil {
@@ -135,7 +141,7 @@ func resourceAlarmRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAlarmUpdate(d *schema.ResourceData, meta interface{}) error {
 	api := meta.(*api.API)
-	keys := []string{"type", "enabled", "value_threshold", "time_threshold", "vhost_regex", "queue_regex", "message_type", "recipients"}
+	keys := alarmAttributeKeys()
 	params := make(map[string]interface{})
 	params["id"] = d.Id()
 	log.Printf("[DEBUG] cloudamqp::resource::alarm::update params: %v", params)
@@ -181,6 +187,7 @@ func validateAlarmSchemaAttribute(key string) bool {
 	case "type",
 		"enabled",
 		"value_threshold",
+		"value_calculation",
 		"time_threshold",
 		"vhost_regex",
 		"queue_regex",
@@ -197,4 +204,25 @@ func validateMessageType() schema.SchemaValidateFunc {
 		"unacked",
 		"ready",
 	}, true)
+}
+
+func validateValueCalculation() schema.SchemaValidateFunc {
+	return validation.StringInSlice([]string{
+		"fixed",
+		"percentage",
+	}, true)
+}
+
+func alarmAttributeKeys() []string {
+	return []string {
+		"type",
+		"enabled",
+		"value_threshold",
+		"value_calculation",
+		"time_threshold",
+		"vhost_regex",
+		"queue_regex",
+		"message_type",
+		"recipients",
+	}
 }

--- a/docs/data-sources/alarm.md
+++ b/docs/data-sources/alarm.md
@@ -22,21 +22,30 @@ data "cloudamqp_alarm" "default_cpu_alarm" {
 
 * `instance_id` - (Required) The CloudAMQP instance identifier.
 * `alarm_id`    - (Optional) The alarm identifier. Either use this or `type` to give `cloudamqp_alarm` necessary information to retrieve the alarm.
-* `type`        - (Optional) The alarm type. Either use this or `alarm_id` to give `cloudamqp_alarm` necessary information when retrieve the alarm.
+* `type`        - (Optional) The alarm type. Either use this or `alarm_id` to give `cloudamqp_alarm` necessary information when retrieve the alarm. Supported [alarm types](#alarm-types)
 
 ## Attributes reference
 
 All attributes reference are computed
 
-* `id`              - The identifier for this resource.
-* `enabled`         - Enable/disable status of the alarm.
-* `value_threshold` - The value threshold that triggers the alarm.
-* `time_threshold`  - The time interval (in seconds) the `value_threshold` should be active before trigger an alarm.
-* `queue_regex`     - Regular expression for which queue to check.
-* `vhost_regex`     - Regular expression for which vhost to check
-* `recipients`      - Identifier for recipient to be notified.
-* `message_type`    - Message type `(total, unacked, ready)` used by queue alarm type.
+* `id`                  - The identifier for this resource.
+* `enabled`             - Enable/disable status of the alarm.
+* `value_threshold`     - The value threshold that triggers the alarm.
+* `reminder_internval`  - The reminder interval (in seconds) to resend the alarm if not resolved. Leave empty or set to 0 to not receive any reminders.
+* `time_threshold`      - The time interval (in seconds) the `value_threshold` should be active before trigger an alarm.
+* `queue_regex`         - Regular expression for which queue to check.
+* `vhost_regex`         - Regular expression for which vhost to check
+* `recipients`          - Identifier for recipient to be notified.
+* `message_type`        - Message type `(total, unacked, ready)` used by queue alarm type.
+
+Specific attribute for `disk` alarm
+
+* `value_calculation`   - Disk value threshold calculation, `(fixed, percentage)` of disk space remaining.
 
 ## Dependency
 
 This data source depends on CloudAMQP instance identifier, `cloudamqp_instance.instance.id`.
+
+## Alarm types
+
+`cpu, memory, disk, queue, connection, consumer, netsplit, server_unreachable, notice`

--- a/docs/resources/alarm.md
+++ b/docs/resources/alarm.md
@@ -49,15 +49,19 @@ resource "cloudamqp_alarm" "memory_alarm" {
 
 The following arguments are supported:
 
-* `instance_id`     - (Required) The CloudAMQP instance ID.
-* `type`            - (Required) The alarm type, see valid options below.
-* `enabled`         - (Required) Enable or disable the alarm to trigger.
-* `value_threshold` - (Optional) The value to trigger the alarm for.
-* `time_threshold`  - (Optional) The time interval (in seconds) the `value_threshold` should be active before triggering an alarm.
-* `queue_regex`     - (Optional) Regex for which queue to check.
-* `vhost_regex`     - (Optional) Regex for which vhost to check
-* `recipients`      - (Optional) Identifier for recipient to be notified. Leave empty to notify all recipients.
-* `message_type`    - (Optional) Message type `(total, unacked, ready)` used by queue alarm type.
+* `instance_id`         - (Required) The CloudAMQP instance ID.
+* `type`                - (Required) The alarm type, see valid options below.
+* `enabled`             - (Required) Enable or disable the alarm to trigger.
+* `value_threshold`     - (Optional) The value to trigger the alarm for.
+* `time_threshold`      - (Optional) The time interval (in seconds) the `value_threshold` should be active before triggering an alarm.
+* `queue_regex`         - (Optional) Regex for which queue to check.
+* `vhost_regex`         - (Optional) Regex for which vhost to check
+* `recipients`          - (Optional) Identifier for recipient to be notified. Leave empty to notify all recipients.
+* `message_type`        - (Optional) Message type `(total, unacked, ready)` used by queue alarm type.
+
+Specific argument for `disk` alarm
+
+* `value_calculation`   - (Optional) Disk value threshold calculation, `fixed, percentage` of disk space remaining.
 
 Based on alarm type, different arguments are flagged as required or optional.
 
@@ -69,10 +73,10 @@ All attributes reference are computed
 
 ## Alarm Type reference
 
-Valid options for notification type.
+Supported alarm types: `cpu, memory, disk, queue, connection, consumer, netsplit, server_unreachable, notice`
 
-Required arguments for all alarms: *instance_id*, *type* and *enabled*
-Optional argument for all alarms: *tags*, *queue_regex*, *vhost_regex*
+Required arguments for all alarms: `instance_id, type, enabled`<br>
+Optional argument for all alarms: `tags, queue_regex, vhost_regex`
 
 | Name | Type | Shared | Dedicated | Required arguments |
 | ---- | ---- | ---- | ---- | ---- |


### PR DESCRIPTION
New attribute `value_calculation` used for disk alarms. Defines if value threshold should be calculated from  `fixed` or `percentage` of disk space remaining.

Close #136 
