### PR TITLE
Correct validation for firewall rule attributes

### DIFF
--- a/cloudamqp/resource_cloudamqp_security_firewall.go
+++ b/cloudamqp/resource_cloudamqp_security_firewall.go
@@ -180,16 +180,17 @@ func validateServices() schema.SchemaValidateFunc {
 }
 
 func servicePorts() []ServicePort {
-	return []ServicePort{{Port: 443, Service: "HTTPS"},
-		{Port: 443, Service: "HTTPS"},
-		{Port: 1883, Service: "MQTT"},
-		{Port: 5551, Service: "STREAM_SSL"},
-		{Port: 5552, Service: "STREAM"},
-		{Port: 5671, Service: "AMQPS"},
-		{Port: 5672, Service: "AMQP"},
-		{Port: 8883, Service: "MQTTS"},
-		{Port: 61613, Service: "STOMP"},
-		{Port: 61614, Service: "STOMPS"}}
+	return []ServicePort{
+		{Service: "AMQP", Port: 5672},
+		{Service: "AMQPS", Port: 5671},
+		{Service: "HTTPS", Port: 443},
+		{Service: "MQTT", Port: 1883},
+		{Service: "MQTTS", Port: 8883},
+		{Service: "STOMP", Port: 61613},
+		{Service: "STOMPS", Port: 61614},
+		{Service: "STREAM", Port: 5552},
+		{Service: "STREAM_SSL", Port: 5551},
+	}
 }
 
 func validateServicePort(port int) bool {

--- a/cloudamqp/resource_cloudamqp_security_firewall.go
+++ b/cloudamqp/resource_cloudamqp_security_firewall.go
@@ -55,7 +55,7 @@ func resourceSecurityFirewall() *schema.Resource {
 									if v < 0 || v > 65554 {
 										errs = append(errs, fmt.Errorf("%q must be between 0 and 65554, got: %d", key, v))
 									} else if validateServicePort(v) {
-										errs = append(errs, fmt.Errorf("port %d, pre-defined as service %q", v, portToService(v)))
+										errs = append(errs, fmt.Errorf("Port %d found in \"ports\", needs to be added as %q in \"services\" instead", v, portToService(v)))
 									}
 									return
 								},

--- a/cloudamqp/resource_cloudamqp_security_firewall.go
+++ b/cloudamqp/resource_cloudamqp_security_firewall.go
@@ -55,7 +55,7 @@ func resourceSecurityFirewall() *schema.Resource {
 									if v < 0 || v > 65554 {
 										errs = append(errs, fmt.Errorf("%q must be between 0 and 65554, got: %d", key, v))
 									} else if validateServicePort(v) {
-										errs = append(errs, fmt.Errorf("Port %d found in \"ports\", needs to be added as %q in \"services\" instead", v, portToService(v)))
+										warns = append(warns, fmt.Sprintf("Port %d found in \"ports\", needs to be added as %q in \"services\" instead", v, portToService(v)))
 									}
 									return
 								},

--- a/docs/resources/security_firewall.md
+++ b/docs/resources/security_firewall.md
@@ -81,7 +81,18 @@ If used together with [VPC GPC peering](https://registry.terraform.io/providers/
 
 ## Known issues
 
-### Custom ports trigger new update every time
+<details>
+  <summary>Custom ports trigger new update every time</summary>
+
+  Before release [v1.15.1](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.15.1) using the custom ports can cause a missmatch upon reading data and trigger a new update every time.
+
+  Reason is that there is a bug in validating the response from the underlying API.
+
+  Update the provider to at least v1.15.1 to fix the issue.
+ </details>
+
+<details>
+  <summary>Using pre-defined service port in ports</summary>
 
 Using one of the port from the pre-defined services in ports argument, see example of using port 5671 instead of the service *AMQPS*.
 
@@ -113,4 +124,5 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
 }
 ```
 
-The provider from [v1.16.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.16.0) will start to warn about using this.
+The provider from [v1.15.2](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.16.0) will start to warn about using this.
+ </details>

--- a/docs/resources/security_firewall.md
+++ b/docs/resources/security_firewall.md
@@ -44,10 +44,22 @@ The `rules` block consists of:
 
 * `ip`          - (Required) Source ip and netmask for the rule. (e.g. 10.56.72.0/24)
 * `ports`       - (Optional) Custom ports to be opened
-* `services`    - (Required) Pre-defined service ports
+* `services`    - (Required) Pre-defined service ports, see table below
 * `description` - (Optional) Description name of the rule. e.g. Default.
 
-Supported services: *AMQP*, *AMQPS*, *HTTPS*, *MQTT*, *MQTTS*, *STOMP*, *STOMPS*, *STREAM*, *STREAM\_SSL*
+Pre-defined services:
+
+| Service name | Port  |
+|--------------|-------|
+| AMQP         | 5672  |
+| AMQPS        | 5671  |
+| HTTPS        | 443   |
+| MQTT         | 1883  |
+| MQTTS        | 8883  |
+| STOMP        | 61613 |
+| STOMPS       | 61614 |
+| STREAM       | 5552  |
+| STREAM_SSL   | 5551  |
 
 ## Attributes Reference
 
@@ -66,3 +78,39 @@ If used together with [VPC GPC peering](https://registry.terraform.io/providers/
 `cloudamqp_security_firewall` can be imported using CloudAMQP instance identifier.
 
 `terraform import cloudamqp_security_firewall.firewall <instance_id>`
+
+## Known issues
+
+### Custom ports trigger new update every time
+
+Using one of the port from the pre-defined services in ports argument, see example of using port 5671 instead of the service *AMQPS*.
+
+```hcl
+resource "cloudamqp_security_firewall" "firewall_settings" {
+  instance_id = cloudamqp_instance.instance.id
+
+  rules {
+    ip          = "192.168.0.0/24"
+    ports       = [5671]
+    services    = []
+  }
+}
+```
+
+Will still create the firewall rule for the instance, but will trigger a new update each `plan` or `apply`. Due to a missmatch between state file and underlying API response.
+
+To solve this, edit the configuration file and change port 5671 to service *AMQPS* and run `terraform apply -refresh-only` to only update the state file and remove the missmatch.
+
+```hcl
+resource "cloudamqp_security_firewall" "firewall_settings" {
+  instance_id = cloudamqp_instance.instance.id
+
+  rules {
+    ip          = "192.168.0.0/24"
+    ports       = []
+    services    = ["AMQPS"]
+  }
+}
+```
+
+The provider from [v1.16.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.16.0) will start to warn about using this.


### PR DESCRIPTION
Revert back to validate firewall rule attributes. Failed previous due to typo for 'ports', resulted in removing the validation completely.

Removed in v1.15.1 and commit: [573866a](https://github.com/cloudamqp/terraform-provider-cloudamqp/commit/573866a01a7e4ef1940e24ca0a3dd593d8a80521)
Introduced in v1.9.3 and commit: [a092362](https://github.com/cloudamqp/terraform-provider-cloudamqp/commit/a0923622d99ccbd0330ce642755a0daf01f847a8)

Avoid re-trigger creating new firewall rules when using custom ports: #137