### PR TITLE
Add configurable timeout for accept VPC peering extension

### DIFF
--- a/cloudamqp/resource_cloudamqp_vpc_peering.go
+++ b/cloudamqp/resource_cloudamqp_vpc_peering.go
@@ -41,13 +41,13 @@ func resourceVpcPeering() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     60,
-				Description: "Configurable sleep time in seconds between retries",
+				Description: "Configurable sleep time in seconds between retries for accepting or removing peering",
 			},
 			"timeout": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     3600,
-				Description: "Configurable timeout time in seconds",
+				Description: "Configurable timeout time in seconds for accepting or removing peering",
 			},
 		},
 	}
@@ -123,9 +123,11 @@ func resourceVpcPeeringDelete(d *schema.ResourceData, meta interface{}) error {
 	if d.Get("instance_id") == 0 && d.Get("vpc_id") == nil {
 		return errors.New("You need to specify either instance_id or vpc_id")
 	} else if d.Get("instance_id") != 0 {
-		return api.RemoveVpcPeering(d.Get("instance_id").(int), d.Get("peering_id").(string))
+		return api.RemoveVpcPeering(d.Get("instance_id").(int), d.Get("peering_id").(string),
+			d.Get("sleep").(int), d.Get("timeout").(int))
 	} else if d.Get("vpc_id") != nil {
-		return api.RemoveVpcPeeringWithVpcId(d.Get("vpc_id").(string), d.Get("peering_id").(string))
+		return api.RemoveVpcPeeringWithVpcId(d.Get("vpc_id").(string), d.Get("peering_id").(string),
+			d.Get("sleep").(int), d.Get("timeout").(int))
 	}
 	return errors.New("")
 }

--- a/cloudamqp/resource_cloudamqp_vpc_peering.go
+++ b/cloudamqp/resource_cloudamqp_vpc_peering.go
@@ -37,6 +37,18 @@ func resourceVpcPeering() *schema.Resource {
 				Computed:    true,
 				Description: "VPC peering status",
 			},
+			"sleep": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     60,
+				Description: "Configurable sleep time in seconds between retries",
+			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     3600,
+				Description: "Configurable timeout time in seconds",
+			},
 		},
 	}
 }
@@ -47,7 +59,8 @@ func resourceVpcPeeringAccept(d *schema.ResourceData, meta interface{}) error {
 	if d.Get("instance_id") == 0 && d.Get("vpc_id") == nil {
 		return errors.New("You need to specify either instance_id or vpc_id")
 	} else if d.Get("instance_id") != 0 {
-		_, err = api.AcceptVpcPeering(d.Get("instance_id").(int), d.Get("peering_id").(string))
+		_, err = api.AcceptVpcPeering(d.Get("instance_id").(int), d.Get("peering_id").(string),
+			d.Get("sleep").(int), d.Get("timeout").(int))
 	} else if d.Get("vpc_id") != nil {
 		_, err = api.AcceptVpcPeeringWithVpcId(d.Get("vpc_id").(string), d.Get("peering_id").(string))
 	}
@@ -59,7 +72,7 @@ func resourceVpcPeeringAccept(d *schema.ResourceData, meta interface{}) error {
 		d.SetId(d.Get("peering_id").(string))
 	}
 
-	return nil
+	return resourceVpcPeeringRead(d, meta)
 }
 
 func resourceVpcPeeringRead(d *schema.ResourceData, meta interface{}) error {

--- a/cloudamqp/resource_cloudamqp_vpc_peering.go
+++ b/cloudamqp/resource_cloudamqp_vpc_peering.go
@@ -62,7 +62,8 @@ func resourceVpcPeeringAccept(d *schema.ResourceData, meta interface{}) error {
 		_, err = api.AcceptVpcPeering(d.Get("instance_id").(int), d.Get("peering_id").(string),
 			d.Get("sleep").(int), d.Get("timeout").(int))
 	} else if d.Get("vpc_id") != nil {
-		_, err = api.AcceptVpcPeeringWithVpcId(d.Get("vpc_id").(string), d.Get("peering_id").(string))
+		_, err = api.AcceptVpcPeeringWithVpcId(d.Get("vpc_id").(string), d.Get("peering_id").(string),
+			d.Get("sleep").(int), d.Get("timeout").(int))
 	}
 
 	if err != nil {

--- a/docs/resources/vpc_peering.md
+++ b/docs/resources/vpc_peering.md
@@ -205,8 +205,8 @@ resource "aws_route" "accepter_route" {
  ***Note: Introduced as optional in version v1.16.0, will be required in next major version (v2.0)***
 
 * `peering_id` - (Required) Peering identifier created by AW peering request.
-* `sleep` - (Optional) Configurable sleep time in seconds between retries, default set to 60 seconds.
-* `timeout` - (Optional) - Configurable timeout time in seconds, default set to 3600.
+* `sleep` - (Optional) Configurable sleep time (seconds) between retries for accepting or removing peering. Default set to 60 seconds.
+* `timeout` - (Optional) - Configurable timeout time (seconds) for accepting or removing peering. Default set to 3600 seconds.
 
 ## Attributes Reference
 

--- a/docs/resources/vpc_peering.md
+++ b/docs/resources/vpc_peering.md
@@ -172,6 +172,8 @@ resource "cloudamqp_vpc_peering" "vpc_accept_peering" {
   # vpc_id prefered over instance_id
   # instance_id = cloudamqp_instance.instance.id
   peering_id = aws_vpc_peering_connection.aws_vpc_peering.id
+  sleep = 30
+  timeout = 600
 }
 
 # AWS - retrieve the route table created in AWS
@@ -203,12 +205,15 @@ resource "aws_route" "accepter_route" {
  ***Note: Introduced as optional in version v1.16.0, will be required in next major version (v2.0)***
 
 * `peering_id` - (Required) Peering identifier created by AW peering request.
+* `sleep` - (Optional) Configurable sleep time in seconds between retries, default set to 60 seconds.
+* `timeout` - (Optional) - Configurable timeout time in seconds, default set to 3600.
 
 ## Attributes Reference
 
 All attributes reference are computed
 
 * `id`  - The identifier for this resource.
+* `status`- VPC peering status
 
 ## Depedency
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/cloudamqp/terraform-provider-cloudamqp
 
 go 1.17
 
-require github.com/84codes/go-api v1.7.0
+require github.com/84codes/go-api v1.8.0
 
 require github.com/hashicorp/terraform-plugin-sdk v1.17.2
 
@@ -88,4 +88,4 @@ require (
 	google.golang.org/protobuf v1.25.0 // indirect
 )
 
-//replace github.com/84codes/go-api => ../../84codes/go-api
+// replace github.com/84codes/go-api => ../../84codes/go-api

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0 h1:STgFzyU5/8miMl0//zKh2aQeTyeaUH3WN9bSUiJ09bA=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/84codes/go-api v1.7.0 h1:aFUPJRPa8AOCZXWnYz5y99Cp5H+hWShfTZA5VNvJFxA=
-github.com/84codes/go-api v1.7.0/go.mod h1:tn30UAxVRjmXztEc22AJ/Mc4XAeJuxNb7PlwtDrI3c0=
+github.com/84codes/go-api v1.8.0 h1:7QcUsKrcZIwNw+b1aWw/SUAovVu+VDKBkIpDB437bVM=
+github.com/84codes/go-api v1.8.0/go.mod h1:tn30UAxVRjmXztEc22AJ/Mc4XAeJuxNb7PlwtDrI3c0=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=


### PR DESCRIPTION
Failing doing multiple accept VPC peering request, due to firewall still being configured.

- Adds configurable attributes for sleep and timeout.

Dependency: https://github.com/84codes/go-api/pull/20
Issue: https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/152