### PR TITLE
Disk resize

### DIFF
--- a/cloudamqp/data_source_cloudamqp_nodes.go
+++ b/cloudamqp/data_source_cloudamqp_nodes.go
@@ -51,6 +51,14 @@ func dataSourceNodes() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						"disk_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"additional_disk_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -98,7 +106,9 @@ func validateNodesSchemaAttribute(key string) bool {
 		"erlang_version",
 		"hipe",
 		"configured",
-		"rmq_version":
+		"rmq_version",
+		"disk_size",
+		"additional_disk_size":
 		return true
 	}
 	return false

--- a/cloudamqp/provider.go
+++ b/cloudamqp/provider.go
@@ -45,6 +45,7 @@ func Provider(v string) *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"cloudamqp_alarm":                  resourceAlarm(),
 			"cloudamqp_custom_domain":          resourceCustomDomain(),
+			"cloudamqp_extra_disk_size":        resourceExtraDiskSize(),
 			"cloudamqp_instance":               resourceInstance(),
 			"cloudamqp_integration_log":        resourceIntegrationLog(),
 			"cloudamqp_integration_metric":     resourceIntegrationMetric(),

--- a/cloudamqp/resource_cloudamqp_extra_disk_size.go
+++ b/cloudamqp/resource_cloudamqp_extra_disk_size.go
@@ -32,15 +32,7 @@ func resourceExtraDiskSize() *schema.Resource {
 
 func resourceExtraDiskSizeUpdate(d *schema.ResourceData, meta interface{}) error {
 	api := meta.(*api.API)
-	keys := []string{"extra_disk_size"}
-	params := make(map[string]interface{})
-	for _, k := range keys {
-		if v := d.Get(k); v != nil {
-			params[k] = v
-		}
-	}
-
-	_, err := api.ResizeDisk(d.Get("instance_id").(int), params)
+	_, err := api.ResizeDisk(d.Get("instance_id").(int), d.Get("extra_disk_size").(int))
 	if err != nil {
 		return err
 	}

--- a/cloudamqp/resource_cloudamqp_extra_disk_size.go
+++ b/cloudamqp/resource_cloudamqp_extra_disk_size.go
@@ -45,40 +45,6 @@ func resourceExtraDiskSizeRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-// Need to fetch the extra disk size? Otherwise present in data source for nodes.
-
-// func resourceExtraDiskSizeRead(d *schema.ResourceData, meta interface{}) error {
-// 	// if strings.Contains(d.Id(), ",") {
-// 	// 	s := strings.Split(d.Id(), ",")
-// 	// 	d.SetId(s[0])
-// 	// 	d.Set("name", s[0])
-// 	// 	instanceID, _ := strconv.Atoi(s[1])
-// 	// 	d.Set("instance_id", instanceID)
-// 	// }
-// 	// if d.Get("instance_id").(int) == 0 {
-// 	// 	return errors.New("Missing instance identifier: {resource_id},{instance_id}")
-// 	// }
-
-// 	// api := meta.(*api.API)
-// 	// data, err := api.ReadWebhook(d.Get("instance_id").(int), d.Id())
-
-// 	// if err != nil {
-// 	// 	return err
-// 	// }
-
-// 	// for k, v := range data {
-// 	// 	if validateWebhookSchemaAttribute(k) {
-// 	// 		err = d.Set(k, v)
-
-// 	// 		if err != nil {
-// 	// 			return fmt.Errorf("error setting %s for resource %s: %s", k, d.Id(), err)
-// 	// 		}
-// 	// 	}
-// 	// }
-
-// 	return nil
-// }
-
 func resourceExtraDiskSizeDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }

--- a/cloudamqp/resource_cloudamqp_extra_disk_size.go
+++ b/cloudamqp/resource_cloudamqp_extra_disk_size.go
@@ -1,0 +1,92 @@
+package cloudamqp
+
+import (
+	"github.com/84codes/go-api/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceExtraDiskSize() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceExtraDiskSizeUpdate,
+		Read:   resourceExtraDiskSizeRead,
+		Delete: resourceExtraDiskSizeDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:        schema.TypeInt,
+				ForceNew:    true,
+				Required:    true,
+				Description: "Instance identifier",
+			},
+			"extra_disk_size": {
+				Type:        schema.TypeInt,
+				ForceNew:    true,
+				Required:    true,
+				Description: "Extra disk size in GB",
+			},
+		},
+	}
+}
+
+func resourceExtraDiskSizeUpdate(d *schema.ResourceData, meta interface{}) error {
+	api := meta.(*api.API)
+	keys := []string{"extra_disk_size"}
+	params := make(map[string]interface{})
+	for _, k := range keys {
+		if v := d.Get(k); v != nil {
+			params[k] = v
+		}
+	}
+
+	_, err := api.ResizeDisk(d.Get("instance_id").(int), params)
+	if err != nil {
+		return err
+	}
+
+	d.SetId("NA")
+	return nil
+}
+
+func resourceExtraDiskSizeRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+// Need to fetch the extra disk size? Otherwise present in data source for nodes.
+
+// func resourceExtraDiskSizeRead(d *schema.ResourceData, meta interface{}) error {
+// 	// if strings.Contains(d.Id(), ",") {
+// 	// 	s := strings.Split(d.Id(), ",")
+// 	// 	d.SetId(s[0])
+// 	// 	d.Set("name", s[0])
+// 	// 	instanceID, _ := strconv.Atoi(s[1])
+// 	// 	d.Set("instance_id", instanceID)
+// 	// }
+// 	// if d.Get("instance_id").(int) == 0 {
+// 	// 	return errors.New("Missing instance identifier: {resource_id},{instance_id}")
+// 	// }
+
+// 	// api := meta.(*api.API)
+// 	// data, err := api.ReadWebhook(d.Get("instance_id").(int), d.Id())
+
+// 	// if err != nil {
+// 	// 	return err
+// 	// }
+
+// 	// for k, v := range data {
+// 	// 	if validateWebhookSchemaAttribute(k) {
+// 	// 		err = d.Set(k, v)
+
+// 	// 		if err != nil {
+// 	// 			return fmt.Errorf("error setting %s for resource %s: %s", k, d.Id(), err)
+// 	// 		}
+// 	// 	}
+// 	// }
+
+// 	return nil
+// }
+
+func resourceExtraDiskSizeDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/cloudamqp/resource_cloudamqp_extra_disk_size.go
+++ b/cloudamqp/resource_cloudamqp_extra_disk_size.go
@@ -1,6 +1,8 @@
 package cloudamqp
 
 import (
+	"strconv"
+
 	"github.com/84codes/go-api/api"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -32,12 +34,14 @@ func resourceExtraDiskSize() *schema.Resource {
 
 func resourceExtraDiskSizeUpdate(d *schema.ResourceData, meta interface{}) error {
 	api := meta.(*api.API)
-	_, err := api.ResizeDisk(d.Get("instance_id").(int), d.Get("extra_disk_size").(int))
+	params := make(map[string]interface{})
+	params["extra_disk_size"] = d.Get("extra_disk_size")
+	_, err := api.ResizeDisk(d.Get("instance_id").(int), params)
 	if err != nil {
 		return err
 	}
-
-	d.SetId("NA")
+	id := strconv.Itoa(d.Get("instance_id").(int))
+	d.SetId(id)
 	return nil
 }
 

--- a/docs/resources/extra_disk_size.md
+++ b/docs/resources/extra_disk_size.md
@@ -7,7 +7,7 @@ description: |-
 
 # cloudamqp_extra_disk_size
 
-This resource allows you to expand the disk with additional storage capacity.
+This resource allows you to expand the disk with additional storage capacity. There is no downtime when expanding the disk.
 
 Only available for dedicated subscription plans hosted at Amazon Web Services (AWS) at this time.
 

--- a/docs/resources/extra_disk_size.md
+++ b/docs/resources/extra_disk_size.md
@@ -1,0 +1,50 @@
+---
+layout: "cloudamqp"
+page_title: "CloudAMQP: cloudamqp_extra_disk_size"
+description: |-
+  Resize the disk with extra storage capacity.
+---
+
+# cloudamqp_extra_disk_size
+
+This resource allows you to expand the disk with additional storage capacity.
+
+Only available for dedicated subscription plans hosted at Amazon Web Services.
+
+⚠️  Due to underlying time restriction to expand disk at Amazon Web Services. It's only possible to resize the disk every 8 hours!
+
+## Example Usage
+
+```hcl
+# Configure CloudAMQP provider
+provider "cloudamqp" {
+  apikey = var.cloudamqp_customer_api_key
+}
+
+# Instance
+resource "cloudamqp_instance" "instance" {
+  name   = "Instance"
+  plan   = "squirrel-1"
+  region = "amazon-web-services::us-west-2"
+  rmq_version = "3.10.1"
+}
+
+data "cloudamqp_nodes" "nodes" {
+  instance_id = cloudamqp_instance.instance.id
+}
+
+# Resize disk with 5 extra GB
+resource "cloudamqp_extra_disk_size" "resize_disk" {
+  instance_id = cloudamqp_instance.instance.id
+  extra_disk_size = 5
+}
+```
+
+## Argument Reference
+
+* `instance_id`       - (Required/ForceNew) The CloudAMQP instance ID.
+* `extra_disk_size`   - (Required/ForceNew) Extra disk size in GB.
+
+## Import
+
+Not possible to import this resource.

--- a/docs/resources/extra_disk_size.md
+++ b/docs/resources/extra_disk_size.md
@@ -13,6 +13,8 @@ Only available for dedicated subscription plans hosted at Amazon Web Services (A
 
 ⚠️  Due to restrictions from cloud providers, it's only possible to resize the disk every 8 hours.
 
+Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/).
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/extra_disk_size.md
+++ b/docs/resources/extra_disk_size.md
@@ -35,9 +35,6 @@ resource "cloudamqp_instance" "instance" {
 resource "cloudamqp_extra_disk_size" "resize_disk" {
   instance_id = cloudamqp_instance.instance.id
   extra_disk_size = 25
-  depends_on = [
-    cloudamqp_instance.instance,
-  ]
 }
 
 # Refresh nodes info after disk resize

--- a/docs/resources/extra_disk_size.md
+++ b/docs/resources/extra_disk_size.md
@@ -29,21 +29,28 @@ resource "cloudamqp_instance" "instance" {
   rmq_version = "3.10.1"
 }
 
-data "cloudamqp_nodes" "nodes" {
-  instance_id = cloudamqp_instance.instance.id
-}
-
-# Resize disk with 5 extra GB
+# Resize disk with 25 extra GB
 resource "cloudamqp_extra_disk_size" "resize_disk" {
   instance_id = cloudamqp_instance.instance.id
-  extra_disk_size = 5
+  extra_disk_size = 25
+  depends_on = [
+    cloudamqp_instance.instance,
+  ]
+}
+
+# Refresh nodes info after disk resize
+data "cloudamqp_nodes" "nodes" {
+  instance_id = cloudamqp_instance.instance.id
+  depends_on = [
+    cloudamqp_extra_disk_size.resize_disk,
+  ]
 }
 ```
 
 ## Argument Reference
 
 * `instance_id`       - (Required/ForceNew) The CloudAMQP instance ID.
-* `extra_disk_size`   - (Required/ForceNew) Extra disk size in GB.
+* `extra_disk_size`   - (Required/ForceNew) Extra disk size in GB. Supported values: 25, 50, 100, 250, 500, 1000, 2000
 
 ## Import
 

--- a/docs/resources/extra_disk_size.md
+++ b/docs/resources/extra_disk_size.md
@@ -9,9 +9,9 @@ description: |-
 
 This resource allows you to expand the disk with additional storage capacity.
 
-Only available for dedicated subscription plans hosted at Amazon Web Services.
+Only available for dedicated subscription plans hosted at Amazon Web Services (AWS) at this time.
 
-⚠️  Due to underlying time restriction to expand disk at Amazon Web Services. It's only possible to resize the disk every 8 hours!
+⚠️  Due to restrictions from cloud providers, it's only possible to resize the disk every 8 hours.
 
 ## Example Usage
 


### PR DESCRIPTION
Handle resizing the disk.

- Updated data_source/nodes to display disk size information
- Added resource/extra_disk_size to trigger resize of the disk
    - ForceNew on each change on either instance_id or extra_disk_size
    - Read doesn't do anything, but is needed.
    - Delete just remove the resource from state file

Also forward API response as error when trying to resize disk too soon.

Need to add documentation, before being approved!