### PR TITLE
Update workflow for changing RabbitMQ configuration

### DIFF
--- a/cloudamqp/resource_cloudamqp_rabbitmq_configuration.go
+++ b/cloudamqp/resource_cloudamqp_rabbitmq_configuration.go
@@ -136,7 +136,6 @@ func resourceRabbitMqConfiguration() *schema.Resource {
 }
 
 func resourceRabbitMqConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
-
 	api := meta.(*api.API)
 	keys := rabbitMqConfigurationWriteAttributeKeys()
 	params := make(map[string]interface{})
@@ -157,7 +156,6 @@ func resourceRabbitMqConfigurationCreate(d *schema.ResourceData, meta interface{
 		}
 		params["rabbit."+k] = v
 	}
-	log.Printf("[DEBUG] cloudamqp::resource::rabbitmq_config::create params: %v", params)
 	err := api.UpdateRabbitMqConfiguration(d.Get("instance_id").(int), params)
 	if err != nil {
 		return err
@@ -211,8 +209,6 @@ func resourceRabbitMqConfigurationUpdate(d *schema.ResourceData, meta interface{
 	params := make(map[string]interface{})
 	for _, k := range keys {
 		v := d.Get(k)
-		// How to handle channel_max, where 0 means "no limit". Needs to be able to update too.
-		// 	if v == nil  || v == 0 || v == 0.0 || v == ""
 		if v == nil {
 			continue
 		} else if k == "connection_max" {
@@ -228,7 +224,6 @@ func resourceRabbitMqConfigurationUpdate(d *schema.ResourceData, meta interface{
 		}
 		params["rabbit."+k] = v
 	}
-	log.Printf("[DEBUG] cloudamqp::resource::rabbitmq_config::update params: %v", params)
 	err := api.UpdateRabbitMqConfiguration(d.Get("instance_id").(int), params)
 	if err != nil {
 		return err

--- a/docs/resources/rabbitmq_configuration.md
+++ b/docs/resources/rabbitmq_configuration.md
@@ -75,7 +75,7 @@ resource "cloudamqp_node_actions" "node_action" {
 <details>
   <summary>
     <b>
-      <i>Only change log level for exchange. All other values will be read from the configuration.</i>
+      <i>Only change log level for exchange. All other values will be read from the RabbitMQ configuration.</i>
     </b>
   </summary>
 

--- a/docs/resources/rabbitmq_configuration.md
+++ b/docs/resources/rabbitmq_configuration.md
@@ -75,7 +75,7 @@ resource "cloudamqp_node_actions" "node_action" {
 <details>
   <summary>
     <b>
-      <i>Only change log level for exchange. All other values will be set to default, see table below.</i>
+      <i>Only change log level for exchange. All other values will be read from the configuration.</i>
     </b>
   </summary>
 
@@ -93,14 +93,14 @@ resource "cloudamqp_rabbitmq_configuration" "rabbit_config" {
 The following arguments are supported:
 
 * `instance_id`                   - (Required) The CloudAMQP instance ID.
-* `heartbeat`                     - (Optional) Set the server AMQP 0-9-1 heartbeat timeout in seconds.
-* `connection_max`                - (Optional) Set the maximum permissible number of connection.
-* `channel_max`                   - (Optional) Set the maximum permissible number of channels per connection.
-* `consumer_timeout`              - (Optional) A consumer that has recevied a message and does not acknowledge that message within the timeout in milliseconds
-* `vm_memory_high_watermark`      - (Optional) When the server will enter memory based flow-control as relative to the maximum available memory.
-* `queue_index_embed_msgs_below`  - (Optional) Size in bytes below which to embed messages in the queue index.
-* `max_message_size`              - (Optional) The largest allowed message payload size in bytes.
-* `log_exchange_level`            - (Optional) Log level for the logger used for log integrations and the CloudAMQP Console log view.
+* `heartbeat`                     - (Computed/Optional) Set the server AMQP 0-9-1 heartbeat timeout in seconds.
+* `connection_max`                - (Computed/Optional) Set the maximum permissible number of connection.
+* `channel_max`                   - (Computed/Optional) Set the maximum permissible number of channels per connection.
+* `consumer_timeout`              - (Computed/Optional) A consumer that has recevied a message and does not acknowledge that message within the timeout in milliseconds
+* `vm_memory_high_watermark`      - (Computed/Optional) When the server will enter memory based flow-control as relative to the maximum available memory.
+* `queue_index_embed_msgs_below`  - (Computed/Optional) Size in bytes below which to embed messages in the queue index.
+* `max_message_size`              - (Computed/Optional) The largest allowed message payload size in bytes.
+* `log_exchange_level`            - (Computed/Optional) Log level for the logger used for log integrations and the CloudAMQP Console log view.
 
   ***Note: Requires a restart of RabbitMQ to be applied.***
 


### PR DESCRIPTION
To be able to only change one or multiple configurations, without needing to add all to the configuration file. 

Previous need to add all arguments to update configuration: 
```hcl
resource "cloudamqp_rabbitmq_configuration" "rabbit_config" {
  instance_id = cloudamqp_instance.instance.id
  channel_max = 0
  connection_max = -1
  consumer_timeout = -1
  heartbeat = 120
  log_exchange_level = "error"
  max_message_size = 134217728
  queue_index_embed_msgs_below = 4096
  vm_memory_high_watermark = 0.81
}
```

Change all arguments to also be computed, so each argument can be either used or left out in the providers configuration file. 

- If used, the RabbitMQ configuration will be updated with the argument. 
- Left out, argument will be read from the RabbitMQ configuration and populate the state file. 

```hcl
resource "cloudamqp_rabbitmq_configuration" "rabbit_config" {
  instance_id = cloudamqp_instance.instance.id
  consumer_timeout = -1
  heartbeat = 60
}
```

Next update: 
```hcl
resource "cloudamqp_rabbitmq_configuration" "rabbit_config" {
  instance_id = cloudamqp_instance.instance.id
  consumer_timeout = 10000
  heartbeat = 120
}
```
