### PR TITLE
fix(plugin): add additional computed fields to plugins resources

### DIFF
--- a/cloudamqp/resource_cloudamqp_plugin.go
+++ b/cloudamqp/resource_cloudamqp_plugin.go
@@ -113,7 +113,9 @@ func resourcePluginDelete(d *schema.ResourceData, meta interface{}) error {
 func validatePluginSchemaAttribute(key string) bool {
 	switch key {
 	case "name",
-		"enabled":
+		"enabled",
+		"description",
+		"version":
 		return true
 	}
 	return false

--- a/cloudamqp/resource_cloudamqp_plugin.go
+++ b/cloudamqp/resource_cloudamqp_plugin.go
@@ -35,6 +35,16 @@ func resourcePlugin() *schema.Resource {
 				Required:    true,
 				Description: "If the plugin is enabled",
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the plugin",
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The version of the plugin",
+			},
 		},
 	}
 }

--- a/cloudamqp/resource_cloudamqp_plugin_community.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community.go
@@ -35,6 +35,16 @@ func resourcePluginCommunity() *schema.Resource {
 				Required:    true,
 				Description: "If the plugin is enabled",
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the plugin",
+			},
+			"require": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Required version of RabbitMQ",
+			},
 		},
 	}
 }

--- a/cloudamqp/resource_cloudamqp_plugin_community.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community.go
@@ -51,12 +51,25 @@ func resourcePluginCommunity() *schema.Resource {
 
 func resourcePluginCommunityCreate(d *schema.ResourceData, meta interface{}) error {
 	api := meta.(*api.API)
-	_, err := api.EnablePluginCommunity(d.Get("instance_id").(int), d.Get("name").(string))
+	data, err := api.ReadPluginCommunity(d.Get("instance_id").(int), d.Get("name").(string))
+	if err != nil {
+		return err
+	}
+
+	_, err = api.EnablePluginCommunity(d.Get("instance_id").(int), d.Get("name").(string))
 	if err != nil {
 		return err
 	}
 	d.SetId(d.Get("name").(string))
-	return resourcePluginCommunityRead(d, meta)
+
+	for k, v := range data {
+		if validateCommunityPluginSchemaAttribute(k) {
+			if err = d.Set(k, v); err != nil {
+				return fmt.Errorf("error setting %s for resource %s: %s", k, d.Id(), err)
+			}
+		}
+	}
+	return nil
 }
 
 func resourcePluginCommunityRead(d *schema.ResourceData, meta interface{}) error {
@@ -80,6 +93,7 @@ func resourcePluginCommunityRead(d *schema.ResourceData, meta interface{}) error
 	for k, v := range data {
 		if validateCommunityPluginSchemaAttribute(k) {
 			if err = d.Set(k, v); err != nil {
+
 				return fmt.Errorf("error setting %s for resource %s: %s", k, d.Id(), err)
 			}
 		}


### PR DESCRIPTION
This fixes a number of issues arising from some plugins returning fields in the API that are not defined as `computed` in the provider. Some examples are below:

`cloudamqp_plugin_community.rabbitmq_delayed_message_exchange.require`:

```Error: error setting require for resource rabbitmq_delayed_message_exchange: Invalid address to set: []string{"require"}```


`cloudamqp_plugin_community.rabbitmq_delayed_message_exchange.description`:

```Error: error setting description for resource rabbitmq_delayed_message_exchange: Invalid address to set: []string{"description"}```