### PR TITLE
Add support for PrivateLink for AWS and Azure

### DIFF
--- a/cloudamqp/provider.go
+++ b/cloudamqp/provider.go
@@ -53,6 +53,8 @@ func Provider(v string) *schema.Provider {
 			"cloudamqp_notification":           resourceNotification(),
 			"cloudamqp_plugin_community":       resourcePluginCommunity(),
 			"cloudamqp_plugin":                 resourcePlugin(),
+			"cloudamqp_privatelink_aws":        resourcePrivateLinkAws(),
+			"cloudamqp_privatelink_azure":      resourcePrivateLinkAzure(),
 			"cloudamqp_rabbitmq_configuration": resourceRabbitMqConfiguration(),
 			"cloudamqp_security_firewall":      resourceSecurityFirewall(),
 			"cloudamqp_upgrade_rabbitmq":       resourceUpgradeRabbitMQ(),

--- a/cloudamqp/resource_cloudamqp_privatelink_aws.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_aws.go
@@ -88,20 +88,13 @@ func resourcePrivateLinkAwsCreate(d *schema.ResourceData, meta interface{}) erro
 		params     = make(map[string][]interface{})
 	)
 
-	err := api.EnablePrivatelink(instanceID, sleep, timeout)
+	params["allowed_principals"] = d.Get("allowed_principals").([]interface{})
+	err := api.EnablePrivatelink(instanceID, params, sleep, timeout)
 	if err != nil {
 		return err
 	}
 
 	d.SetId(fmt.Sprintf("%d", instanceID))
-	params["allowed_principals"] = d.Get("allowed_principals").([]interface{})
-	if len(params) > 0 {
-		err := api.UpdatePrivatelink(instanceID, params)
-		if err != nil {
-			return err
-		}
-	}
-
 	return resourcePrivateLinkAwsRead(d, meta)
 }
 

--- a/cloudamqp/resource_cloudamqp_privatelink_aws.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_aws.go
@@ -1,0 +1,51 @@
+package cloudamqp
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourcePrivateLinkAws() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePrivateLinkAwsCreate,
+		Read:   resourcePrivateLinkAwsRead,
+		Update: resourcePrivateLinkAwsUpdate,
+		Delete: resourcePrivateLinkAwsDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "The CloudAMQP instance identifier",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Status of the PrivateLink [enabled, pending, disabled]",
+			},
+			"service_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Service name of the PrivateLink, needed when creating the endpoint",
+			},
+			"allowed_principals": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed:    true,
+				Optional:    true,
+				Description: "...",
+			},
+			"active_zones": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed:    true,
+				Description: "...",
+			},
+		},
+	}
+}

--- a/cloudamqp/resource_cloudamqp_privatelink_aws.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_aws.go
@@ -2,9 +2,11 @@ package cloudamqp
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 
 	"github.com/84codes/go-api/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -63,6 +65,17 @@ func resourcePrivateLinkAws() *schema.Resource {
 				Description: "Configurable timeout in seconds when enable PrivateLink",
 			},
 		},
+		CustomizeDiff: customdiff.All(
+			customdiff.ValidateValue("allowed_principals", func(value, meta interface{}) error {
+				for _, v := range value.([]interface{}) {
+					re := regexp.MustCompile(`^arn:aws:iam::\d{12}:(root|user/.+|role/.+)$`)
+					if !re.MatchString(v.(string)) {
+						return fmt.Errorf("Invalid ARN : %v", v)
+					}
+				}
+				return nil
+			}),
+		),
 	}
 }
 

--- a/cloudamqp/resource_cloudamqp_privatelink_aws.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_aws.go
@@ -40,7 +40,7 @@ func resourcePrivateLinkAws() *schema.Resource {
 				},
 				Computed:    true,
 				Optional:    true,
-				Description: "Allowed principals that have access to connect to this endpoint service",
+				Description: "Allowed principals to access the endpoint service",
 			},
 			"active_zones": {
 				Type: schema.TypeList,

--- a/cloudamqp/resource_cloudamqp_privatelink_aws.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_aws.go
@@ -75,14 +75,16 @@ func resourcePrivateLinkAwsCreate(d *schema.ResourceData, meta interface{}) erro
 		params     = make(map[string][]interface{})
 	)
 
-	if err := api.EnablePrivatelink(instanceID, sleep, timeout); err != nil {
+	err := api.EnablePrivatelink(instanceID, sleep, timeout)
+	if err != nil {
 		return err
 	}
 
 	d.SetId(fmt.Sprintf("%d", instanceID))
 	params["allowed_principals"] = d.Get("allowed_principals").([]interface{})
 	if len(params) > 0 {
-		if err := api.UpdatePrivatelink(instanceID, params); err != nil {
+		err := api.UpdatePrivatelink(instanceID, params)
+		if err != nil {
 			return err
 		}
 	}
@@ -94,11 +96,10 @@ func resourcePrivateLinkAwsRead(d *schema.ResourceData, meta interface{}) error 
 	var (
 		api           = meta.(*api.API)
 		instanceID, _ = strconv.Atoi(d.Id()) // Uses d.Id() to allow import
-		data          map[string]interface{}
-		err           error
 	)
 
-	if data, err = api.ReadPrivatelink(instanceID); err != nil {
+	data, err := api.ReadPrivatelink(instanceID)
+	if err != nil {
 		return err
 	}
 
@@ -118,7 +119,8 @@ func resourcePrivateLinkAwsUpdate(d *schema.ResourceData, meta interface{}) erro
 	)
 
 	params["allowed_principals"] = d.Get("allowed_principals").([]interface{})
-	if err := api.UpdatePrivatelink(instanceID, params); err != nil {
+	err := api.UpdatePrivatelink(instanceID, params)
+	if err != nil {
 		return err
 	}
 	return nil
@@ -130,7 +132,8 @@ func resourcePrivateLinkAwsDelete(d *schema.ResourceData, meta interface{}) erro
 		instanceID = d.Get("instance_id").(int)
 	)
 
-	if err := api.DisablePrivatelink(instanceID); err != nil {
+	err := api.DisablePrivatelink(instanceID)
+	if err != nil {
 		return err
 	}
 	return nil

--- a/cloudamqp/resource_cloudamqp_privatelink_aws.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_aws.go
@@ -40,8 +40,7 @@ func resourcePrivateLinkAws() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Computed:    true,
-				Optional:    true,
+				Required:    true,
 				Description: "Allowed principals to access the endpoint service",
 			},
 			"active_zones": {

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -114,7 +114,7 @@ func resourcePrivateLinkAzureUpdate(d *schema.ResourceData, meta interface{}) er
 		params     = make(map[string][]interface{})
 	)
 
-	params["allowed_principals"] = d.Get("allowed_principals").([]interface{})
+	params["approved_subscriptions"] = d.Get("approved_subscriptions").([]interface{})
 	if err := api.UpdatePrivatelink(instanceID, params); err != nil {
 		return err
 	}

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -45,7 +45,7 @@ func resourcePrivateLinkAzure() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Optional:    true,
+				Required:    true,
 				Description: "Approved subscriptions to access the endpoint service",
 			},
 			"sleep": {

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -64,7 +64,7 @@ func resourcePrivateLinkAzure() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			customdiff.ValidateValue("approved_subscriptions", func(value, meta interface{}) error {
 				for _, v := range value.([]interface{}) {
-					re := regexp.MustCompile(`/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/`)
+					re := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 					if !re.MatchString(v.(string)) {
 						return fmt.Errorf("Invalid ARN : %v", v)
 					}

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -84,20 +84,13 @@ func resourcePrivateLinkAzureCreate(d *schema.ResourceData, meta interface{}) er
 		params     = make(map[string][]interface{})
 	)
 
-	err := api.EnablePrivatelink(instanceID, sleep, timeout)
+	params["approved_subscriptions"] = d.Get("approved_subscriptions").([]interface{})
+	err := api.EnablePrivatelink(instanceID, params, sleep, timeout)
 	if err != nil {
 		return err
 	}
 
 	d.SetId(fmt.Sprintf("%d", instanceID))
-	params["approved_subscriptions"] = d.Get("approved_subscriptions").([]interface{})
-	if len(params) > 0 {
-		err := api.UpdatePrivatelink(instanceID, params)
-		if err != nil {
-			return err
-		}
-	}
-
 	return resourcePrivateLinkAzureRead(d, meta)
 }
 

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -1,0 +1,47 @@
+package cloudamqp
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourcePrivateLinkAzure() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePrivateLinkAzureCreate,
+		Read:   resourcePrivateLinkAzureRead,
+		Update: resourcePrivateLinkAzureUpdate,
+		Delete: resourcePrivateLinkAzureDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "The CloudAMQP instance identifier",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Status of the PrivateLink [enabled, pending, disabled]",
+			},
+			"service_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Service name of the PrivateLink, needed when creating the endpoint",
+			},
+			"alias": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "...",
+			},
+			"approved_subscriptions": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional:    true,
+				Description: "...",
+			},
+		},
+	}
+}

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -2,9 +2,11 @@ package cloudamqp
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 
 	"github.com/84codes/go-api/api"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -59,6 +61,17 @@ func resourcePrivateLinkAzure() *schema.Resource {
 				Description: "Configurable timeout in seconds when enable PrivateLink",
 			},
 		},
+		CustomizeDiff: customdiff.All(
+			customdiff.ValidateValue("approved_subscriptions", func(value, meta interface{}) error {
+				for _, v := range value.([]interface{}) {
+					re := regexp.MustCompile(`/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/`)
+					if !re.MatchString(v.(string)) {
+						return fmt.Errorf("Invalid ARN : %v", v)
+					}
+				}
+				return nil
+			}),
+		),
 	}
 }
 

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -91,10 +91,12 @@ func resourcePrivateLinkAzureRead(d *schema.ResourceData, meta interface{}) erro
 		api           = meta.(*api.API)
 		instanceID, _ = strconv.Atoi(d.Id()) // Uses d.Id() to allow import
 	)
+
 	data, err := api.ReadPrivatelink(instanceID)
 	if err != nil {
 		return err
 	}
+
 	for k, v := range data {
 		if validatePrivateLinkAzureSchemaAttribute(k) {
 			if k == "alias" {
@@ -126,6 +128,7 @@ func resourcePrivateLinkAzureDelete(d *schema.ResourceData, meta interface{}) er
 		api        = meta.(*api.API)
 		instanceID = d.Get("instance_id").(int)
 	)
+
 	if err := api.DisablePrivatelink(instanceID); err != nil {
 		return err
 	}

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -66,7 +66,7 @@ func resourcePrivateLinkAzure() *schema.Resource {
 				for _, v := range value.([]interface{}) {
 					re := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 					if !re.MatchString(v.(string)) {
-						return fmt.Errorf("Invalid ARN : %v", v)
+						return fmt.Errorf("Invalid Subscription ID : %v", v)
 					}
 				}
 				return nil

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -71,14 +71,16 @@ func resourcePrivateLinkAzureCreate(d *schema.ResourceData, meta interface{}) er
 		params     = make(map[string][]interface{})
 	)
 
-	if err := api.EnablePrivatelink(instanceID, sleep, timeout); err != nil {
+	err := api.EnablePrivatelink(instanceID, sleep, timeout)
+	if err != nil {
 		return err
 	}
 
 	d.SetId(fmt.Sprintf("%d", instanceID))
 	params["approved_subscriptions"] = d.Get("approved_subscriptions").([]interface{})
 	if len(params) > 0 {
-		if err := api.UpdatePrivatelink(instanceID, params); err != nil {
+		err := api.UpdatePrivatelink(instanceID, params)
+		if err != nil {
 			return err
 		}
 	}
@@ -117,7 +119,8 @@ func resourcePrivateLinkAzureUpdate(d *schema.ResourceData, meta interface{}) er
 	)
 
 	params["approved_subscriptions"] = d.Get("approved_subscriptions").([]interface{})
-	if err := api.UpdatePrivatelink(instanceID, params); err != nil {
+	err := api.UpdatePrivatelink(instanceID, params)
+	if err != nil {
 		return err
 	}
 	return nil
@@ -129,7 +132,8 @@ func resourcePrivateLinkAzureDelete(d *schema.ResourceData, meta interface{}) er
 		instanceID = d.Get("instance_id").(int)
 	)
 
-	if err := api.DisablePrivatelink(instanceID); err != nil {
+	err := api.DisablePrivatelink(instanceID)
+	if err != nil {
 		return err
 	}
 	return nil

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -98,7 +98,7 @@ func resourcePrivateLinkAzureCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	return resourcePrivateLinkAwsRead(d, meta)
+	return resourcePrivateLinkAzureRead(d, meta)
 }
 
 func resourcePrivateLinkAzureRead(d *schema.ResourceData, meta interface{}) error {

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -44,7 +44,7 @@ func resourcePrivateLinkAzure() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Optional:    true,
-				Description: "Approved subscriptions that have access to connect to this endpoint service",
+				Description: "Approved subscriptions to access the endpoint service",
 			},
 			"sleep": {
 				Type:        schema.TypeInt,

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -11,6 +11,8 @@ This resource allows you to create and manage a CloudAMQP instance running Rabbi
 
 Once the instance is created it will be assigned a unique identifier. All other resource and data sources created for this instance needs to reference the instance identifier.
 
+Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html).
+
 ## Example Usage
 
 <details>

--- a/docs/resources/privatelink_aws.md
+++ b/docs/resources/privatelink_aws.md
@@ -1,0 +1,94 @@
+---
+layout: "cloudamqp"
+page_title: "CloudAMQP: cloudamqp_privatelink_aws"
+description: |-
+  Enable PrivateLink for a CloudAMQP instance hosted in AWS.
+---
+
+# cloudamqp_privatelink_aws
+
+Enable PrivateLink for a CloudAMQP instance hosted in AWS. If no existing VPC available when enable PrivateLink, a new VPC will be created with subnet `10.52.72.0/24`.
+
+More information about [CloudAMQP Privatelink](https://www.cloudamqp.com/docs/cloudamqp-privatelink.html#aws-privatelink).
+
+Only available for dedicated subscription plans.
+
+## Example Usage
+
+CloudAMQP instance without existing VPC
+
+```hcl
+resource "cloudamqp_instance" "instance" {
+  name   = "Instance 01"
+  plan   = "squirrel-1"
+  region = "amazon-web-services::us-west-1"
+  tags   = ["test"]
+  rmq_version = "3.10.8"
+}
+
+resource "cloudamqp_privatelink_aws" "privatelink" {
+  instance_id = cloudamqp_instance.instance.id
+  allowed_principals = [
+    "arn:aws:iam::aws-account-id:user/user-name"
+  ]
+}
+```
+
+CloudAMQP instance already in an existing VPC.
+
+```hcl
+resource "cloudamqp_vpc" "vpc" {
+  name = "Standalone VPC"
+  region = "amazon-web-services::us-west-1"
+  subnet = "10.56.72.0/24"
+  tags = ["test"]
+}
+
+resource "cloudamqp_instance" "instance" {
+  name   = "Instance 01"
+  plan   = "squirrel-1"
+  region = "amazon-web-services::us-west-1"
+  tags   = ["test"]
+  rmq_version = "3.10.8"
+  vpc_id = cloudamqp_vpc.vpc.id
+  keep_associated_vpc = true
+}
+
+resource "cloudamqp_privatelink_aws" "privatelink" {
+  instance_id = cloudamqp_instance.instance.id
+  allowed_principals = [
+    "arn:aws:iam::aws-account-id:user/user-name"
+  ]
+}
+```
+
+## Argument Reference
+
+* `instance_id` - (Required) The CloudAMQP instance identifier.
+* `allowed_principals` - (Optional) Allowed principals to access the endpoint service.
+* `sleep` - (Optional) Configurable sleep time (seconds) when enable PrivateLink. Default set to 60 seconds.
+* `timeout` - (Optional) - Configurable timeout time (seconds) when enable PrivateLink. Default set to 3600 seconds.
+
+Allowed principals format: <br>
+`arn:aws:iam::aws-account-id:root` <br>
+`arn:aws:iam::aws-account-id:user/user-name` <br>
+`arn:aws:iam::aws-account-id:role/role-name`
+
+## Attributes Reference
+
+All attributes reference are computed
+
+* `id`  - The identifier for this resource.
+* `status`- PrivateLink status [enable, pending, disable]
+* `service_name` - Service name of the PrivateLink used when creating the endpoint from other VPC.
+* `active_zones` - Covering availability zones used when creating an Endpoint from other VPC.
+
+## Depedency
+
+This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.instance.id`.
+
+## Import
+
+`cloudamqp_privatelink_aws` can be imported using CloudAMQP internal identifier.
+
+`terraform import cloudamqp_privatelink_aws.privatelink <id>`

--- a/docs/resources/privatelink_aws.md
+++ b/docs/resources/privatelink_aws.md
@@ -65,7 +65,7 @@ resource "cloudamqp_privatelink_aws" "privatelink" {
 ## Argument Reference
 
 * `instance_id` - (Required) The CloudAMQP instance identifier.
-* `allowed_principals` - (Optional) Allowed principals to access the endpoint service.
+* `allowed_principals` - (Required) Allowed principals to access the endpoint service.
 * `sleep` - (Optional) Configurable sleep time (seconds) when enable PrivateLink. Default set to 60 seconds.
 * `timeout` - (Optional) - Configurable timeout time (seconds) when enable PrivateLink. Default set to 3600 seconds.
 

--- a/docs/resources/privatelink_aws.md
+++ b/docs/resources/privatelink_aws.md
@@ -13,6 +13,8 @@ More information about [CloudAMQP Privatelink](https://www.cloudamqp.com/docs/cl
 
 Only available for dedicated subscription plans.
 
+Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html).
+
 ## Example Usage
 
 CloudAMQP instance without existing VPC

--- a/docs/resources/privatelink_azure.md
+++ b/docs/resources/privatelink_azure.md
@@ -65,7 +65,7 @@ resource "cloudamqp_privatelink_azure" "privatelink" {
 ## Argument Reference
 
 * `instance_id` - (Required) The CloudAMQP instance identifier.
-* `approved_subscriptions` - (Optional) Approved subscriptions to access the endpoint service. See format below.
+* `approved_subscriptions` - (Required) Approved subscriptions to access the endpoint service. See format below.
 * `sleep` - (Optional) Configurable sleep time (seconds) when enable PrivateLink. Default set to 60 seconds.
 * `timeout` - (Optional) - Configurable timeout time (seconds) when enable PrivateLink. Default set to 3600 seconds.
 

--- a/docs/resources/privatelink_azure.md
+++ b/docs/resources/privatelink_azure.md
@@ -1,0 +1,92 @@
+---
+layout: "cloudamqp"
+page_title: "CloudAMQP: cloudamqp_privatelink_azure"
+description: |-
+  Enable PrivateLink for a CloudAMQP instance hosted in Azure.
+---
+
+# cloudamqp_privatelink_aws
+
+Enable PrivateLink for a CloudAMQP instance hosted in Azure. If no existing VPC available when enable PrivateLink, a new VPC will be created with subnet `10.52.72.0/24`.
+
+More information about [CloudAMQP Privatelink](https://www.cloudamqp.com/docs/cloudamqp-privatelink.html#azure-privatelink).
+
+Only available for dedicated subscription plans.
+
+## Example Usage
+
+CloudAMQP instance without existing VPC
+
+```hcl
+resource "cloudamqp_instance" "instance" {
+  name   = "Instance 01"
+  plan   = "squirrel-1"
+  region = "azure-arm::westus"
+  tags   = ["test"]
+  rmq_version = "3.10.8"
+}
+
+resource "cloudamqp_privatelink_azure" "privatelink" {
+  instance_id = cloudamqp_instance.instance.id
+  approved_subscriptions = [
+    "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+  ]
+}
+```
+
+CloudAMQP instance already in an existing VPC.
+
+```hcl
+resource "cloudamqp_vpc" "vpc" {
+  name = "Standalone VPC"
+  region = "azure-arm::westus"
+  subnet = "10.56.72.0/24"
+  tags = ["test"]
+}
+
+resource "cloudamqp_instance" "instance" {
+  name   = "Instance 01"
+  plan   = "squirrel-1"
+  region = "azure-arm::westus"
+  tags   = ["test"]
+  rmq_version = "3.10.8"
+  vpc_id = cloudamqp_vpc.vpc.id
+  keep_associated_vpc = true
+}
+
+resource "cloudamqp_privatelink_azure" "privatelink" {
+  instance_id = cloudamqp_instance.instance.id
+  approved_subscriptions = [
+    "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+  ]
+}
+```
+
+## Argument Reference
+
+* `instance_id` - (Required) The CloudAMQP instance identifier.
+* `approved_subscriptions` - (Optional) Approved subscriptions to access the endpoint service. See format below.
+* `sleep` - (Optional) Configurable sleep time (seconds) when enable PrivateLink. Default set to 60 seconds.
+* `timeout` - (Optional) - Configurable timeout time (seconds) when enable PrivateLink. Default set to 3600 seconds.
+
+Approved subscriptions format: <br>
+`XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`
+
+## Attributes Reference
+
+All attributes reference are computed
+
+* `id`  - The identifier for this resource.
+* `status`- PrivateLink status [enable, pending, disable]
+* `service_name` - Service name (alias) of the PrivateLink, needed when creating the endpoint.
+* `server_name` - Name of the server having the PrivateLink enabled.
+
+## Depedency
+
+This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.instance.id`.
+
+## Import
+
+`cloudamqp_privatelink_aws` can be imported using CloudAMQP internal identifier.
+
+`terraform import cloudamqp_privatelink_aws.privatelink <id>`

--- a/docs/resources/privatelink_azure.md
+++ b/docs/resources/privatelink_azure.md
@@ -13,6 +13,8 @@ More information about [CloudAMQP Privatelink](https://www.cloudamqp.com/docs/cl
 
 Only available for dedicated subscription plans.
 
+Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html).
+
 ## Example Usage
 
 CloudAMQP instance without existing VPC

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -13,6 +13,8 @@ New Cloudamqp instances can be added to the managed VPC. Set the instance *vpc_i
 
 Only available for dedicated subscription plans.
 
+Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html).
+
 ## Example Usage
 
 

--- a/docs/resources/vpc_gcp_peering.md
+++ b/docs/resources/vpc_gcp_peering.md
@@ -11,6 +11,8 @@ This resouce creates a VPC peering configuration for the CloudAMQP instance. The
 
 Only available for dedicated subscription plans.
 
+Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html).
+
 ## Example Usage
 
 <details>

--- a/docs/resources/vpc_peering.md
+++ b/docs/resources/vpc_peering.md
@@ -11,6 +11,8 @@ This resouce allows you to accepting VPC peering request from an AWS requester. 
 
 Only available for dedicated subscription plans.
 
+Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html).
+
 ## Example Usage
 
 One way to manage the vpc peering is to combine CloudAMQP Terraform provider with AWS Terraform provider and run them at the same time.

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/cloudamqp/terraform-provider-cloudamqp
 
 go 1.17
 
-require github.com/84codes/go-api v1.9.2
+require github.com/84codes/go-api v1.10.0
 
 require github.com/hashicorp/terraform-plugin-sdk v1.17.2
 

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0 h1:STgFzyU5/8miMl0//zKh2aQeTyeaUH3WN9bSUiJ09bA=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/84codes/go-api v1.9.2 h1:OKENiyuP8Rk0TbhfTwsOSahYaFfSGWgUVglPO+kwnF4=
-github.com/84codes/go-api v1.9.2/go.mod h1:tn30UAxVRjmXztEc22AJ/Mc4XAeJuxNb7PlwtDrI3c0=
+github.com/84codes/go-api v1.10.0 h1:qKpHsbBDlpzWUaHlY7iwM2ZK3AClamecMAbCTkWVlrA=
+github.com/84codes/go-api v1.10.0/go.mod h1:tn30UAxVRjmXztEc22AJ/Mc4XAeJuxNb7PlwtDrI3c0=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=


### PR DESCRIPTION
Adds support for PrivateLink for both AWS and Azure.

AWS:
* status
* allowed-principals
* service-name
* active-zones

Azure:
* status
* approved-subscriptions
* server-name
* alias

Make sure instance either have or can enable VPC before creating the PrivateLink.