### PR TITLE
Configurable sleep and timeout for firewall resource

### DIFF
--- a/cloudamqp/resource_cloudamqp_security_firewall.go
+++ b/cloudamqp/resource_cloudamqp_security_firewall.go
@@ -84,6 +84,18 @@ func resourceSecurityFirewall() *schema.Resource {
 					},
 				},
 			},
+			"sleep": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     30,
+				Description: "Configurable sleep time in seconds between retries for firewall configuration",
+			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     1800,
+				Description: "Configurable timeout time in seconds for firewall configuration",
+			},
 		},
 	}
 }
@@ -100,7 +112,7 @@ func resourceSecurityFirewallCreate(d *schema.ResourceData, meta interface{}) er
 
 	instanceID := d.Get("instance_id").(int)
 	log.Printf("[DEBUG] cloudamqp::resource::security_firewall::create instance id: %v", instanceID)
-	data, err := api.CreateFirewallSettings(instanceID, params)
+	data, err := api.CreateFirewallSettings(instanceID, params, d.Get("sleep").(int), d.Get("timeout").(int))
 	if err != nil {
 		return fmt.Errorf("error setting security firewall for resource %s: %s", d.Id(), err)
 	}
@@ -141,7 +153,7 @@ func resourceSecurityFirewallUpdate(d *schema.ResourceData, meta interface{}) er
 		params = append(params, k.(map[string]interface{}))
 	}
 	log.Printf("[DEBUG] cloudamqp::resource::security_firewall::update instance id: %v, params: %v", d.Get("instance_id"), params)
-	data, err := api.UpdateFirewallSettings(d.Get("instance_id").(int), params)
+	data, err := api.UpdateFirewallSettings(d.Get("instance_id").(int), params, d.Get("sleep").(int), d.Get("timeout").(int))
 	if err != nil {
 		return err
 	}
@@ -159,7 +171,7 @@ func resourceSecurityFirewallUpdate(d *schema.ResourceData, meta interface{}) er
 func resourceSecurityFirewallDelete(d *schema.ResourceData, meta interface{}) error {
 	api := meta.(*api.API)
 	log.Printf("[DEBUG] cloudamqp::resource::security_firewall::delete instance id: %v", d.Get("instance_id"))
-	data, err := api.DeleteFirewallSettings(d.Get("instance_id").(int))
+	data, err := api.DeleteFirewallSettings(d.Get("instance_id").(int), d.Get("sleep").(int), d.Get("timeout").(int))
 	d.Set("rules", data)
 	return err
 }

--- a/docs/resources/security_firewall.md
+++ b/docs/resources/security_firewall.md
@@ -44,6 +44,8 @@ Top level argument reference
 
 * `instance_id` - (Required) The CloudAMQP instance ID.
 * `rules`       - (Required) An array of rules, minimum of 1 needs to be configured. Each `rules` block consists of the field documented below.
+* `sleep`       - (Optional) Configurable sleep time in seconds between retries for firewall configuration. Default set to 30 seconds.
+* `timeout`     - (Optional) Configurable timeout time in seconds for firewall configuration. Default set to 1800 seconds.
 
 ___
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/cloudamqp/terraform-provider-cloudamqp
 
 go 1.17
 
-require github.com/84codes/go-api v1.10.1
+require github.com/84codes/go-api v1.10.2
 
 require github.com/hashicorp/terraform-plugin-sdk v1.17.2
 
@@ -21,7 +21,7 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dghubble/sling v1.4.0 // indirect
+	github.com/dghubble/sling v1.4.1 // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0 h1:STgFzyU5/8miMl0//zKh2aQeTyeaUH3WN9bSUiJ09bA=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/84codes/go-api v1.10.1 h1:nAbIVVUmnV2UT3Wi3Qct+Hwou15CgQVXZFoA3/7ROXE=
-github.com/84codes/go-api v1.10.1/go.mod h1:tn30UAxVRjmXztEc22AJ/Mc4XAeJuxNb7PlwtDrI3c0=
+github.com/84codes/go-api v1.10.2 h1:/oIR9LOIQh++VRno7oegYxe6bDilqMlXL0bbT4+5ofc=
+github.com/84codes/go-api v1.10.2/go.mod h1:QbG2CtOMJ6lHWP/9LjTvMZMe3bWAc9ld73H0e16vAPo=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
@@ -87,8 +87,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dghubble/sling v1.4.0 h1:/n8MRosVTthvMbwlNZgLx579OGVjUOy3GNEv5BIqAWY=
-github.com/dghubble/sling v1.4.0/go.mod h1:0r40aNsU9EdDUVBNhfCstAtFgutjgJGYbO1oNzkMoM8=
+github.com/dghubble/sling v1.4.1 h1:AxjTubpVyozMvbBCtXcsWEyGGgUZutC5YGrfxPNVOcQ=
+github.com/dghubble/sling v1.4.1/go.mod h1:QoMB1KL3GAo+7HsD8Itd6S+6tW91who8BGZzuLvpOyc=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
Increase the total time configuring firewall settings before timeout. Amount of time and timeout used can be configurable by setting sleep and timeout. Default set to 30 sec sleep and 30 min timeout. 

Addressing issue when creating new instance, VPC peering and updating firewall settings. Previously updating firewall settings timed out before the automatic VPC peering firewall update had finished. 