### PR TITLE
Update Stackdriver integration to use raw credentials

### DIFF
--- a/cloudamqp/resource_cloudamqp_integration_log.go
+++ b/cloudamqp/resource_cloudamqp_integration_log.go
@@ -1,6 +1,8 @@
 package cloudamqp
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -78,18 +80,18 @@ func resourceIntegrationLog() *schema.Resource {
 			},
 			"project_id": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Computed:    true,
 				Description: "Project ID. (Stackdriver)",
 			},
 			"private_key": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Computed:    true,
 				Sensitive:   true,
 				Description: "The private key. (Stackdriver)",
 			},
 			"client_email": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Computed:    true,
 				Description: "The client email. (Stackdriver)",
 			},
 			"host": {
@@ -103,21 +105,52 @@ func resourceIntegrationLog() *schema.Resource {
 				Optional:    true,
 				Description: "Assign source type to the data exported, eg. generic_single_line. (Splunk)",
 			},
+			"private_key_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "Private key identifier. (Stackdriver)",
+			},
+			"credentials": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Base64Encoded credentials. (Stackdriver)",
+			},
 		},
 	}
 }
 
 func resourceIntegrationLogCreate(d *schema.ResourceData, meta interface{}) error {
-	api := meta.(*api.API)
-	keys := integrationLogKeys(d.Get("name").(string))
-	params := make(map[string]interface{})
-	for _, k := range keys {
-		if v := d.Get(k); v != nil {
-			params[k] = v
+	var (
+		api     = meta.(*api.API)
+		intName = strings.ToLower(d.Get("name").(string))
+		keys    = integrationLogKeys(intName)
+		params  = make(map[string]interface{})
+	)
+
+	if intName == "stackdriver" {
+		if v := d.Get("credentials"); v != nil {
+			uDec, err := base64.URLEncoding.DecodeString(v.(string))
+			if err != nil {
+				return fmt.Errorf("Log integration failed, error decoding private_key: %s ", err.Error())
+			}
+			var jsonMap map[string]interface{}
+			json.Unmarshal([]byte(uDec), &jsonMap)
+			fmt.Printf("jsonMap: %v", jsonMap)
+			for _, k := range keys {
+				params[k] = jsonMap[k]
+			}
+		}
+	} else {
+		for _, k := range keys {
+			if v := d.Get(k); v != nil {
+				params[k] = v
+			}
 		}
 	}
 
-	data, err := api.CreateIntegration(d.Get("instance_id").(int), "logs", d.Get("name").(string), params)
+	data, err := api.CreateIntegration(d.Get("instance_id").(int), "logs", intName, params)
 
 	if err != nil {
 		return err
@@ -161,11 +194,29 @@ func resourceIntegrationLogRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceIntegrationLogUpdate(d *schema.ResourceData, meta interface{}) error {
-	keys := integrationLogKeys(d.Get("name").(string))
-	params := make(map[string]interface{})
-	for _, k := range keys {
-		if v := d.Get(k); v != nil {
-			params[k] = v
+	var (
+		intName = strings.ToLower(d.Get("name").(string))
+		keys    = integrationLogKeys(intName)
+		params  = make(map[string]interface{})
+	)
+
+	if intName == "stackdriver" {
+		if v := d.Get("credentials"); v != nil {
+			uDec, err := base64.URLEncoding.DecodeString(v.(string))
+			if err != nil {
+				return fmt.Errorf("Log integration failed, error decoding private_key: %s ", err.Error())
+			}
+			var jsonMap map[string]interface{}
+			json.Unmarshal([]byte(uDec), &jsonMap)
+			for _, k := range keys {
+				params[k] = jsonMap[k]
+			}
+		}
+	} else {
+		for _, k := range keys {
+			if v := d.Get(k); v != nil {
+				params[k] = v
+			}
 		}
 	}
 
@@ -213,8 +264,9 @@ func validateIntegrationLogsSchemaAttribute(key string) bool {
 		"api_key",
 		"tags",
 		"project_id",
-		"private_key",
 		"client_email",
+		"private_key",
+		"private_key_id",
 		"host",
 		"sourcetype":
 		return true
@@ -237,7 +289,7 @@ func integrationLogKeys(intName string) []string {
 	case "datadog":
 		return []string{"region", "api_key", "tags"}
 	case "stackdriver":
-		return []string{"project_id", "private_key", "client_email"}
+		return []string{"client_email", "private_key_id", "private_key", "project_id"}
 	case "scalyr":
 		return []string{"token", "host"}
 	default:

--- a/cloudamqp/resource_cloudamqp_integration_log.go
+++ b/cloudamqp/resource_cloudamqp_integration_log.go
@@ -80,17 +80,20 @@ func resourceIntegrationLog() *schema.Resource {
 			},
 			"project_id": {
 				Type:        schema.TypeString,
+				Optional:    true,
 				Computed:    true,
 				Description: "Project ID. (Stackdriver)",
 			},
 			"private_key": {
 				Type:        schema.TypeString,
+				Optional:    true,
 				Computed:    true,
 				Sensitive:   true,
 				Description: "The private key. (Stackdriver)",
 			},
 			"client_email": {
 				Type:        schema.TypeString,
+				Optional:    true,
 				Computed:    true,
 				Description: "The client email. (Stackdriver)",
 			},
@@ -107,6 +110,7 @@ func resourceIntegrationLog() *schema.Resource {
 			},
 			"private_key_id": {
 				Type:        schema.TypeString,
+				Optional:    true,
 				Computed:    true,
 				Sensitive:   true,
 				Description: "Private key identifier. (Stackdriver)",
@@ -129,22 +133,24 @@ func resourceIntegrationLogCreate(d *schema.ResourceData, meta interface{}) erro
 		params  = make(map[string]interface{})
 	)
 
-	if intName == "stackdriver" {
-		if v := d.Get("credentials"); v != nil {
-			uDec, err := base64.URLEncoding.DecodeString(v.(string))
-			if err != nil {
-				return fmt.Errorf("Log integration failed, error decoding private_key: %s ", err.Error())
-			}
-			var jsonMap map[string]interface{}
-			json.Unmarshal([]byte(uDec), &jsonMap)
-			fmt.Printf("jsonMap: %v", jsonMap)
-			for _, k := range keys {
-				params[k] = jsonMap[k]
-			}
+	v := d.Get("credentials")
+	if intName == "stackdriver" && v != "" {
+		uDec, err := base64.URLEncoding.DecodeString(v.(string))
+		if err != nil {
+			return fmt.Errorf("Log integration failed, error decoding private_key: %s ", err.Error())
+		}
+		var jsonMap map[string]interface{}
+		json.Unmarshal([]byte(uDec), &jsonMap)
+		fmt.Printf("jsonMap: %v", jsonMap)
+		for _, k := range keys {
+			params[k] = jsonMap[k]
 		}
 	} else {
 		for _, k := range keys {
-			if v := d.Get(k); v != nil {
+			v := d.Get(k)
+			if k == "tags" && v == "" {
+				delete(params, k)
+			} else if v != nil {
 				params[k] = v
 			}
 		}
@@ -200,21 +206,23 @@ func resourceIntegrationLogUpdate(d *schema.ResourceData, meta interface{}) erro
 		params  = make(map[string]interface{})
 	)
 
-	if intName == "stackdriver" {
-		if v := d.Get("credentials"); v != nil {
-			uDec, err := base64.URLEncoding.DecodeString(v.(string))
-			if err != nil {
-				return fmt.Errorf("Log integration failed, error decoding private_key: %s ", err.Error())
-			}
-			var jsonMap map[string]interface{}
-			json.Unmarshal([]byte(uDec), &jsonMap)
-			for _, k := range keys {
-				params[k] = jsonMap[k]
-			}
+	v := d.Get("credentials")
+	if intName == "stackdriver" && v != "" {
+		uDec, err := base64.URLEncoding.DecodeString(v.(string))
+		if err != nil {
+			return fmt.Errorf("Log integration failed, error decoding private_key: %s ", err.Error())
+		}
+		var jsonMap map[string]interface{}
+		json.Unmarshal([]byte(uDec), &jsonMap)
+		for _, k := range keys {
+			params[k] = jsonMap[k]
 		}
 	} else {
 		for _, k := range keys {
-			if v := d.Get(k); v != nil {
+			v := d.Get(k)
+			if k == "tags" && v == "" {
+				delete(params, k)
+			} else if v != nil {
 				params[k] = v
 			}
 		}

--- a/cloudamqp/resource_cloudamqp_integration_metric.go
+++ b/cloudamqp/resource_cloudamqp_integration_metric.go
@@ -98,22 +98,26 @@ func resourceIntegrationMetric() *schema.Resource {
 			},
 			"project_id": {
 				Type:        schema.TypeString,
+				Optional:    true,
 				Computed:    true,
 				Description: "Project ID. (Stackdriver)",
 			},
 			"private_key": {
 				Type:        schema.TypeString,
+				Optional:    true,
 				Computed:    true,
 				Sensitive:   true,
 				Description: "The private key. (Stackdriver)",
 			},
 			"client_email": {
 				Type:        schema.TypeString,
+				Optional:    true,
 				Computed:    true,
 				Description: "The client email. (Stackdriver)",
 			},
 			"private_key_id": {
 				Type:        schema.TypeString,
+				Optional:    true,
 				Computed:    true,
 				Sensitive:   true,
 				Description: "Private key identifier. (Stackdriver)",
@@ -137,24 +141,22 @@ func resourceIntegrationMetricCreate(d *schema.ResourceData, meta interface{}) e
 		params     = make(map[string]interface{})
 	)
 
-	if intName == "stackdriver" {
-		if v := d.Get("credentials"); v != nil {
-			uDec, err := base64.URLEncoding.DecodeString(v.(string))
-			if err != nil {
-				return fmt.Errorf("Log integration failed, error decoding private_key: %s ", err.Error())
-			}
-			var jsonMap map[string]interface{}
-			json.Unmarshal([]byte(uDec), &jsonMap)
-			for _, k := range keys {
-				if contains(commonKeys, k) {
-					if v := d.Get(k); v == "" || v == nil {
-						delete(params, k)
-					} else {
-						params[k] = v
-					}
+	if intName == "stackdriver" && v != "" {
+		uDec, err := base64.URLEncoding.DecodeString(v.(string))
+		if err != nil {
+			return fmt.Errorf("Log integration failed, error decoding private_key: %s ", err.Error())
+		}
+		var jsonMap map[string]interface{}
+		json.Unmarshal([]byte(uDec), &jsonMap)
+		for _, k := range keys {
+			if contains(commonKeys, k) {
+				if v := d.Get(k); v == "" || v == nil {
+					delete(params, k)
 				} else {
-					params[k] = jsonMap[k]
+					params[k] = v
 				}
+			} else {
+				params[k] = jsonMap[k]
 			}
 		}
 	} else {
@@ -168,8 +170,6 @@ func resourceIntegrationMetricCreate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	// log.Printf("[DEBUG] integration-metric::create params: %v", params)
-	// return fmt.Errorf("DUMP")
 	data, err := api.CreateIntegration(d.Get("instance_id").(int), "metrics", intName, params)
 
 	if err != nil {
@@ -222,24 +222,23 @@ func resourceIntegrationMetricUpdate(d *schema.ResourceData, meta interface{}) e
 		params     = make(map[string]interface{})
 	)
 
-	if intName == "stackdriver" {
-		if v := d.Get("credentials"); v != nil {
-			uDec, err := base64.URLEncoding.DecodeString(v.(string))
-			if err != nil {
-				return fmt.Errorf("Log integration failed, error decoding private_key: %s ", err.Error())
-			}
-			var jsonMap map[string]interface{}
-			json.Unmarshal([]byte(uDec), &jsonMap)
-			for _, k := range keys {
-				if contains(commonKeys, k) {
-					if v := d.Get(k); v == "" || v == nil {
-						delete(params, k)
-					} else {
-						params[k] = v
-					}
+	v := d.Get("credentials")
+	if intName == "stackdriver" && v != "" {
+		uDec, err := base64.URLEncoding.DecodeString(v.(string))
+		if err != nil {
+			return fmt.Errorf("Log integration failed, error decoding private_key: %s ", err.Error())
+		}
+		var jsonMap map[string]interface{}
+		json.Unmarshal([]byte(uDec), &jsonMap)
+		for _, k := range keys {
+			if contains(commonKeys, k) {
+				if v := d.Get(k); v == "" || v == nil {
+					delete(params, k)
 				} else {
-					params[k] = jsonMap[k]
+					params[k] = v
 				}
+			} else {
+				params[k] = jsonMap[k]
 			}
 		}
 	} else {

--- a/cloudamqp/resource_cloudamqp_integration_metric.go
+++ b/cloudamqp/resource_cloudamqp_integration_metric.go
@@ -1,6 +1,8 @@
 package cloudamqp
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -96,35 +98,79 @@ func resourceIntegrationMetric() *schema.Resource {
 			},
 			"project_id": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Computed:    true,
 				Description: "Project ID. (Stackdriver)",
 			},
 			"private_key": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Computed:    true,
 				Sensitive:   true,
 				Description: "The private key. (Stackdriver)",
 			},
 			"client_email": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Computed:    true,
 				Description: "The client email. (Stackdriver)",
+			},
+			"private_key_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "Private key identifier. (Stackdriver)",
+			},
+			"credentials": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Base64Encoded credentials. (Stackdriver)",
 			},
 		},
 	}
 }
 
 func resourceIntegrationMetricCreate(d *schema.ResourceData, meta interface{}) error {
-	api := meta.(*api.API)
-	keys := integrationMetricKeys(d.Get("name").(string))
-	params := make(map[string]interface{})
-	for _, k := range keys {
-		if v := d.Get(k); v != nil {
-			params[k] = v
+	var (
+		api        = meta.(*api.API)
+		intName    = strings.ToLower(d.Get("name").(string))
+		commonKeys = []string{"tags", "queue_allowlist", "vhost_allowlist"}
+		keys       = integrationMetricKeys(commonKeys, intName)
+		params     = make(map[string]interface{})
+	)
+
+	if intName == "stackdriver" {
+		if v := d.Get("credentials"); v != nil {
+			uDec, err := base64.URLEncoding.DecodeString(v.(string))
+			if err != nil {
+				return fmt.Errorf("Log integration failed, error decoding private_key: %s ", err.Error())
+			}
+			var jsonMap map[string]interface{}
+			json.Unmarshal([]byte(uDec), &jsonMap)
+			for _, k := range keys {
+				if contains(commonKeys, k) {
+					if v := d.Get(k); v == "" || v == nil {
+						delete(params, k)
+					} else {
+						params[k] = v
+					}
+				} else {
+					params[k] = jsonMap[k]
+				}
+			}
+		}
+	} else {
+		for _, k := range keys {
+			v := d.Get(k)
+			if contains(commonKeys, k) && v == "" {
+				delete(params, k)
+			} else if v != nil {
+				params[k] = v
+			}
 		}
 	}
 
-	data, err := api.CreateIntegration(d.Get("instance_id").(int), "metrics", d.Get("name").(string), params)
+	// log.Printf("[DEBUG] integration-metric::create params: %v", params)
+	// return fmt.Errorf("DUMP")
+	data, err := api.CreateIntegration(d.Get("instance_id").(int), "metrics", intName, params)
 
 	if err != nil {
 		return err
@@ -168,18 +214,50 @@ func resourceIntegrationMetricRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceIntegrationMetricUpdate(d *schema.ResourceData, meta interface{}) error {
-	api := meta.(*api.API)
-	keys := integrationMetricKeys(d.Get("name").(string))
-	params := make(map[string]interface{})
-	for _, k := range keys {
-		if v := d.Get(k); v != nil {
-			params[k] = v
+	var (
+		api        = meta.(*api.API)
+		intName    = strings.ToLower(d.Get("name").(string))
+		commonKeys = []string{"tags", "queue_allowlist", "vhost_allowlist"}
+		keys       = integrationMetricKeys(commonKeys, intName)
+		params     = make(map[string]interface{})
+	)
+
+	if intName == "stackdriver" {
+		if v := d.Get("credentials"); v != nil {
+			uDec, err := base64.URLEncoding.DecodeString(v.(string))
+			if err != nil {
+				return fmt.Errorf("Log integration failed, error decoding private_key: %s ", err.Error())
+			}
+			var jsonMap map[string]interface{}
+			json.Unmarshal([]byte(uDec), &jsonMap)
+			for _, k := range keys {
+				if contains(commonKeys, k) {
+					if v := d.Get(k); v == "" || v == nil {
+						delete(params, k)
+					} else {
+						params[k] = v
+					}
+				} else {
+					params[k] = jsonMap[k]
+				}
+			}
+		}
+	} else {
+		for _, k := range keys {
+			v := d.Get(k)
+			if contains(commonKeys, k) && v == "" {
+				delete(params, k)
+			} else if v != nil {
+				params[k] = v
+			}
 		}
 	}
+
 	err := api.UpdateIntegration(d.Get("instance_id").(int), "metrics", d.Id(), params)
 	if err != nil {
 		return err
 	}
+
 	return resourceIntegrationMetricRead(d, meta)
 }
 
@@ -214,15 +292,16 @@ func validateIntegrationMetricSchemaAttribute(key string) bool {
 		"license_key",
 		"project_id",
 		"private_key",
-		"client_email":
+		"client_email",
+		"private_key_id":
 		return true
 	default:
 		return false
 	}
 }
 
-func integrationMetricKeys(intName string) []string {
-	keys := []string{"tags", "queue_allowlist", "vhost_allowlist"}
+func integrationMetricKeys(commonKeys []string, intName string) []string {
+	keys := commonKeys
 	switch intName {
 	case "cloudwatch":
 		return append(keys, "region", "access_key_id", "secret_access_key")
@@ -239,8 +318,17 @@ func integrationMetricKeys(intName string) []string {
 	case "newrelic_v2":
 		return append(keys, "api_key", "region")
 	case "stackdriver":
-		return append(keys, "project_id", "private_key", "client_email")
+		return append(keys, "client_email", "private_key_id", "private_key", "project_id")
 	default:
 		return append(keys, "region", "access_keys", "secret_access_keys", "email", "api_key", "license_key")
 	}
+}
+
+func contains(s []string, searchString string) bool {
+	for i := range s {
+		if searchString == s[i] {
+			return true
+		}
+	}
+	return false
 }

--- a/cloudamqp/resource_cloudamqp_integration_metric.go
+++ b/cloudamqp/resource_cloudamqp_integration_metric.go
@@ -141,6 +141,7 @@ func resourceIntegrationMetricCreate(d *schema.ResourceData, meta interface{}) e
 		params     = make(map[string]interface{})
 	)
 
+	v := d.Get("credentials")
 	if intName == "stackdriver" && v != "" {
 		uDec, err := base64.URLEncoding.DecodeString(v.(string))
 		if err != nil {

--- a/docs/resources/integration_log.md
+++ b/docs/resources/integration_log.md
@@ -118,9 +118,11 @@ resource "cloudamqp_integration_log" "datadog" {
 <details>
   <summary>
     <b>
-      <i>Stackdriver log integration</i>
+      <i>Stackdriver log integration (v1.20.2 or earlier versions)</i>
     </b>
   </summary>
+
+Use variable file populated with project_id, private_key and client_email
 
 ```hcl
 resource "cloudamqp_integration_log" "stackdriver" {
@@ -129,6 +131,78 @@ resource "cloudamqp_integration_log" "stackdriver" {
   project_id = var.stackdriver_project_id
   private_key = var.stackdriver_private_key
   client_email = var.stackdriver_client_email
+}
+```
+
+or by using google_service_account_key resource from Google provider
+
+```hcl
+resource "google_service_account" "service_account" {
+  account_id = "<account_id>"
+  description = "<description>"
+  display_name = "<display_name>"
+}
+
+resource "google_service_account_key" "service_account_key" {
+  service_account_id = google_service_account.service_account.name
+}
+
+resource "cloudamqp_integration_log" "stackdriver" {
+  instance_id = cloudamqp_instance.instance.id
+  name = "stackdriver"
+  project_id = jsondecode(base64decode(google_service_account_key.service_account_key.private_key)).project_id
+  private_key = jsondecode(base64decode(google_service_account_key.service_account_key.private_key)).private_key
+  client_email = jsondecode(base64decode(google_service_account_key.service_account_key.private_key)).client_email
+}
+```
+</details>
+
+<details>
+  <summary>
+    <b>
+      <i>Stackdriver log integration (v1.30.0 or newer versions)</i>
+    </b>
+  </summary>
+
+Use credentials argument and let the provider do the Base64decode and internally populate, *project_id, client_name, private_key*
+
+```hcl
+resource "google_service_account" "service_account" {
+  account_id = "<account_id>"
+  description = "<description>"
+  display_name = "<display_name>"
+}
+
+resource "google_service_account_key" "service_account_key" {
+  service_account_id = google_service_account.service_account.name
+}
+
+resource "cloudamqp_integration_log" "stackdriver" {
+  instance_id = cloudamqp_instance.instance.id
+  name = "stackdriver"
+  credentials = google_service_account_key.service_account_key.private_key
+}
+```
+
+or use the same as earlier version and decode the google service account key
+
+```hcl
+resource "google_service_account" "service_account" {
+  account_id = "<account_id>"
+  description = "<description>"
+  display_name = "<display_name>"
+}
+
+resource "google_service_account_key" "service_account_key" {
+  service_account_id = google_service_account.service_account.name
+}
+
+resource "cloudamqp_integration_log" "stackdriver" {
+  instance_id = cloudamqp_instance.instance.id
+  name = "stackdriver"
+  project_id = jsondecode(base64decode(google_service_account_key.service_account_key.private_key)).project_id
+  private_key = jsondecode(base64decode(google_service_account_key.service_account_key.private_key)).private_key
+  client_email = jsondecode(base64decode(google_service_account_key.service_account_key.private_key)).client_email
 }
 ```
 </details>
@@ -163,9 +237,10 @@ The following arguments are supported:
 * `secret_access_key` - (Optional) AWS secret access key.
 * `api_key`           - (Optional) The API key.
 * `tags`              - (Optional) Tag the integration, e.g. env=prod, region=europe.
-* `project_id`        - (Optional) The project identifier.
-* `private_key`       - (Optional) The private access key.
-* `client_email`      - (Optional) The client email registered for the integration service.
+* `credentials`       - (Optional) Google Service Account private key credentials.
+* `project_id`        - (Optional/Computed) The project identifier.
+* `private_key`       - (Optional/Computed) The private access key.
+* `client_email`      - (Optional/Computed) The client email registered for the integration service.
 * `host`              - (Optional) The host for Scalyr integration. (app.scalyr.com, app.eu.scalyr.com)
 * `sourcetype`        - (Optional) Assign source type to the data exported, eg. generic_single_line. (Splunk)
 
@@ -193,7 +268,7 @@ Valid names for third party log integration.
 | papertrail | Create a Papertrail endpoint https://papertrailapp.com/systems/setup |
 | splunk     | Create a HTTP Event Collector token at `https://<your-splunk>.cloud.splunk.com/en-US/manager/search/http-eventcollector` |
 | datadog       | Create a Datadog API key at app.datadoghq.com |
-| stackdriver   | Create a service account and add 'monitor metrics writer' role, then download credentials. |
+| stackdriver   | Create a service account and add 'monitor metrics writer' role from your Google Cloud Account |
 | scalyr        | Create a Log write token at https://app.scalyr.com/keys |
 
 ## Integration Type reference
@@ -210,8 +285,10 @@ Required arguments for all integrations: name
 | Papertrail | papertrail | url |
 | Splunk | splunk | token, host_port, sourcetype |
 | Data Dog | datadog | region, api_keys, tags |
-| Stackdriver | stackdriver | project_id, private_key, client_email |
+| Stackdriver | stackdriver | credentials |
 | Scalyr | scalyr | token, host |
+
+***Note:*** Stackdriver (v1.20.2 or earlier versions) required arguments  : project_id, private_key, client_email
 
 ## Attributes Reference
 

--- a/docs/resources/integration_metrics.md
+++ b/docs/resources/integration_metrics.md
@@ -100,9 +100,11 @@ resource "cloudamqp_integration_metric" "newrelic" {
 <details>
   <summary>
     <b>
-      <i>Stackdriver metric integration</i>
+      <i>Stackdriver metric integration (v1.20.2 or earlier versions)</i>
     </b>
   </summary>
+
+Use variable file populated with project_id, private_key and client_email
 
 ```hcl
 resource "cloudamqp_integration_metric" "stackdriver" {
@@ -111,6 +113,78 @@ resource "cloudamqp_integration_metric" "stackdriver" {
   project_id = var.stackdriver_project_id
   private_key = var.stackdriver_private_key
   client_email = var.stackriver_email
+}
+```
+
+or by using google_service_account_key resource from Google provider
+
+```hcl
+resource "google_service_account" "service_account" {
+  account_id = "<account_id>"
+  description = "<description>"
+  display_name = "<display_name>"
+}
+
+resource "google_service_account_key" "service_account_key" {
+  service_account_id = google_service_account.service_account.name
+}
+
+resource "cloudamqp_integration_metric" "stackdriver" {
+  instance_id = cloudamqp_instance.instance.id
+  name = "stackdriver"
+  project_id = jsondecode(base64decode(google_service_account_key.service_account_key.private_key)).project_id
+  private_key = jsondecode(base64decode(google_service_account_key.service_account_key.private_key)).private_key
+  client_email = jsondecode(base64decode(google_service_account_key.service_account_key.private_key)).client_email
+}
+```
+</details>
+
+<details>
+  <summary>
+    <b>
+      <i>Stackdriver metric integration (v1.30.0 or newer versions)</i>
+    </b>
+  </summary>
+
+Use credentials argument and let the provider do the Base64decode and internally populate, *project_id, client_name, private_key*
+
+```hcl
+resource "google_service_account" "service_account" {
+  account_id = "<account_id>"
+  description = "<description>"
+  display_name = "<display_name>"
+}
+
+resource "google_service_account_key" "service_account_key" {
+  service_account_id = google_service_account.service_account.name
+}
+
+resource "cloudamqp_integration_metric" "stackdriver" {
+  instance_id = cloudamqp_instance.instance.id
+  name = "stackdriver"
+  credentials = google_service_account_key.service_account_key.private_key
+}
+```
+
+or use the same as earlier version and decode the google service account key
+
+```hcl
+resource "google_service_account" "service_account" {
+  account_id = "<account_id>"
+  description = "<description>"
+  display_name = "<display_name>"
+}
+
+resource "google_service_account_key" "service_account_key" {
+  service_account_id = google_service_account.service_account.name
+}
+
+resource "cloudamqp_integration_metric" "stackdriver" {
+  instance_id = cloudamqp_instance.instance.id
+  name = "stackdriver"
+  project_id = jsondecode(base64decode(google_service_account_key.service_account_key.private_key)).project_id
+  private_key = jsondecode(base64decode(google_service_account_key.service_account_key.private_key)).private_key
+  client_email = jsondecode(base64decode(google_service_account_key.service_account_key.private_key)).client_email
 }
 ```
 </details>
@@ -125,9 +199,10 @@ The following arguments are supported:
 * `secret_access_key` - (Optional) AWS secret access key.
 * `api_key`           - (Optional) The API key for the integration service.
 * `email`             - (Optional) The email address registred for the integration service.
-* `project_id`        - (Optional) The project identifier.
-* `private_key`       - (Optional) The private access key.
-* `client_email`      - (Optional) The client email registered for the integration service.
+* `credentials`       - (Optional) Google Service Account private key credentials.
+* `project_id`        - (Optional/Computed) The project identifier.
+* `private_key`       - (Optional/Computed) The private access key.
+* `client_email`      - (Optional/Computed) The client email registered for the integration service.
 * `tags`              - (Optional) Tags. e.g. env=prod, region=europe.
 * `queue_allowlist`   - (Optional) Allowlist queues using regular expression. Leave empty to include all queues.
 * `vhost_allowlist`   - (Optional) Allowlist vhost using regular expression. Leave empty to include all vhosts.
@@ -149,13 +224,13 @@ Valid names for third party log integration.
 | librato       | Create a new API token (with record only permissions) here: https://metrics.librato.com/tokens |
 | newrelic      | Deprecated! |
 | newrelic_v2   | Find or register an Insert API key for your account: Go to insights.newrelic.com > Manage data > API keys. |
-| stackdriver   | Create a service account and add 'monitor metrics writer' role, then download credentials. |
+| stackdriver   | Create a service account and add 'monitor metrics writer' role from your Google Cloud Account |
 
 ## Integration type reference
 
 Valid arguments for third party log integrations.
 
-Required arguments for all integrations: *name*
+Required arguments for all integrations: *name*</br>
 Optional arguments for all integrations: *tags*, *queue_allowlist*, *vhost_allowlist*
 
 | Name | Type | Required arguments |
@@ -167,7 +242,9 @@ Optional arguments for all integrations: *tags*, *queue_allowlist*, *vhost_allow
 | Librato                | librato        | email, api_key |
 | New relic (deprecated) | newrelic       | - |
 | New relic v2           | newrelic_v2    | api_key, region |
-| Stackdriver            | stackdriver    | project_id, private_key, client_email |
+| Stackdriver            | stackdriver    | credentials |
+
+***Note:*** Stackdriver (v1.20.2 or earlier versions) required arguments  : project_id, private_key, client_email
 
 ## Attributes Reference
 


### PR DESCRIPTION
Improve use of credentials for Stackdriver, fetched from Google Service Account key when enable log and metric integrations.

_New arguments_
- credentials - (Optional) Google Service Account key credentials
- private_key_id - (Optional/Computed) Private key identifier from Google Service Account key

_Argument updated with Computed_
- project_id
- client_email
- private_key

**Log & metric:**
Use google_service_account_key resource from google provider to populate new argument `credentials`. That will base64decode the data and map it into json, to further set values for `project_id, client_email, private_key, private_key_id`. 

```hcl
resource "google_service_account_key" "service_account_key" {
  service_account_id = google_service_account.service_account.name
}

resource "cloudamqp_integration_log" "stackdriver" {
  instance_id = cloudamqp_instance.instance.id
  name = "stackdriver"
  credentials = google_service_account_key.service_account_key.private_key
}

resource "cloudamqp_integration_metric" "stackdriver" {
  instance_id = cloudamqp_instance.instance.id
  name = "stackdriver"
  credentials = google_service_account_key.service_account_key.private_key
}
```

Make sure to exclude argument `tags` if not used or set to "" in request body.

Old way to add the private_key is still supported. But clarified in documentation on what decoding is needed.
```hcl
resource "cloudamqp_integration_log" "stackdriver" {
  ...
  private_key = jsondecode(base64decode(google_service_account_key.service_account_key.private_key)).private_key
}
```

**Metrics:**
Make sure to exclude arguments `queue_allowlist, vhost_allowlist` if not used or set to "" in request body.