### PR TITLE
VictorOps recipient extension

### DIFF
--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -21,6 +21,14 @@ resource "cloudamqp_notification" "recipient_01" {
   value       = "alarm@example.com"
   name        = "alarm"
 }
+
+resource "cloudamqp_notification" "recipient_02" {
+  instance_id = cloudamqp_instance.instance.id
+  type        = "victorops"
+  value       = "<UUID>"
+  name        = "Victorops"
+  routing_key = "ROUTINGKEY"
+}
 ```
 
 ## Argument Reference
@@ -29,8 +37,9 @@ The following arguments are supported:
 
 * `instance_id` - (Required) The CloudAMQP instance ID.
 * `type`        - (Required) Type of the notification. See valid options below.
-* `value`       - (Required) Endpoint to send the notification.
+* `value`       - (Required) Integration/API key or endpoint to send the notification.
 * `name`        - (Optional) Display name of the recipient.
+* `routing_key` - (Optional) Victorops based routing key.
 
 ## Attributes Reference
 

--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -27,7 +27,9 @@ resource "cloudamqp_notification" "recipient_02" {
   type        = "victorops"
   value       = "<UUID>"
   name        = "Victorops"
-  routing_key = "ROUTINGKEY"
+  options     = {
+    "rk" = "ROUTINGKEY"
+  }
 }
 ```
 
@@ -39,7 +41,7 @@ The following arguments are supported:
 * `type`        - (Required) Type of the notification. See valid options below.
 * `value`       - (Required) Integration/API key or endpoint to send the notification.
 * `name`        - (Optional) Display name of the recipient.
-* `routing_key` - (Optional) Victorops based routing key.
+* `options`     - (Optional) Options argument (e.g. rk used for Victorops routing key).
 
 ## Attributes Reference
 

--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -41,7 +41,7 @@ The following arguments are supported:
 * `type`        - (Required) Type of the notification. See valid options below.
 * `value`       - (Required) Integration/API key or endpoint to send the notification.
 * `name`        - (Optional) Display name of the recipient.
-* `options`     - (Optional) Options argument (e.g. rk used for Victorops routing key).
+* `options`     - (Optional) Options argument (e.g. `rk` used for VictorOps routing key).
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds options map[string] as key-value pair to add extra arguments to notification resource.

Can be use for `Victorops` recipients to add routing `rk`- routing key. 

Issue #178 