### PR TITLE
Extend extra disk resource to support multiple platforms

### DIFF
--- a/cloudamqp/resource_cloudamqp_extra_disk_size.go
+++ b/cloudamqp/resource_cloudamqp_extra_disk_size.go
@@ -12,6 +12,7 @@ func resourceExtraDiskSize() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceExtraDiskSizeUpdate,
 		Read:   resourceExtraDiskSizeRead,
+		Update: resourceExtraDiskSizeUpdate,
 		Delete: resourceExtraDiskSizeDelete,
 		Schema: map[string]*schema.Schema{
 			"instance_id": {
@@ -28,9 +29,21 @@ func resourceExtraDiskSize() *schema.Resource {
 			},
 			"allow_downtime": {
 				Type:        schema.TypeBool,
-				ForceNew:    true,
-				Required:    true,
+				Optional:    true,
+				Default:     false,
 				Description: "When resizing disk, allow cluster downtime to do so",
+			},
+			"sleep": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     30,
+				Description: "Configurable sleep time in seconds between retries for resizing the disk",
+			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     1800,
+				Description: "Configurable timeout time in seconds for resizing the disk",
 			},
 			"nodes": {
 				Type:     schema.TypeList,
@@ -62,8 +75,8 @@ func resourceExtraDiskSizeUpdate(d *schema.ResourceData, meta interface{}) error
 	var (
 		api     = meta.(*api.API)
 		params  = make(map[string]interface{})
-		sleep   = 30   // Seconds between retires when either polling for ready nodes or catching busy backend.
-		timeout = 1800 // Seconds until timeout when either polling for ready nodes or catching busy backend.
+		sleep   = d.Get("sleep").(int)
+		timeout = d.Get("timeout").(int)
 	)
 
 	params["extra_disk_size"] = d.Get("extra_disk_size")

--- a/cloudamqp/resource_cloudamqp_extra_disk_size.go
+++ b/cloudamqp/resource_cloudamqp_extra_disk_size.go
@@ -1,6 +1,7 @@
 package cloudamqp
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/84codes/go-api/api"
@@ -11,44 +12,124 @@ func resourceExtraDiskSize() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceExtraDiskSizeUpdate,
 		Read:   resourceExtraDiskSizeRead,
+		Update: resourceExtraDiskSizeUpdate,
 		Delete: resourceExtraDiskSizeDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
 		Schema: map[string]*schema.Schema{
 			"instance_id": {
 				Type:        schema.TypeInt,
-				ForceNew:    true,
 				Required:    true,
 				Description: "Instance identifier",
 			},
 			"extra_disk_size": {
 				Type:        schema.TypeInt,
-				ForceNew:    true,
 				Required:    true,
 				Description: "Extra disk size in GB",
+			},
+			"allow_downtime": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "When resizing disk, allow downtime to do so",
+			},
+			"sleep": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     30,
+				Description: "Configurable sleep time in seconds between retries for firewall configuration",
+			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     1800,
+				Description: "Configurable timeout time in seconds for firewall configuration",
+			},
+			"nodes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"disk_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"additional_disk_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
 			},
 		},
 	}
 }
 
 func resourceExtraDiskSizeUpdate(d *schema.ResourceData, meta interface{}) error {
-	api := meta.(*api.API)
-	params := make(map[string]interface{})
+	var (
+		api    = meta.(*api.API)
+		params = make(map[string]interface{})
+	)
+
 	params["extra_disk_size"] = d.Get("extra_disk_size")
-	_, err := api.ResizeDisk(d.Get("instance_id").(int), params)
+	params["allow_downtime"] = d.Get("allow_downtime")
+
+	_, err := api.ResizeDisk(d.Get("instance_id").(int), params, 30, 1800)
 	if err != nil {
 		return err
 	}
 	id := strconv.Itoa(d.Get("instance_id").(int))
 	d.SetId(id)
-	return nil
+
+	return resourceExtraDiskSizeRead(d, meta)
 }
 
 func resourceExtraDiskSizeRead(d *schema.ResourceData, meta interface{}) error {
+	var (
+		api        = meta.(*api.API)
+		instanceID = d.Get("instance_id").(int)
+	)
+
+	data, err := api.ReadNodes(instanceID)
+	if err != nil {
+		return err
+	}
+
+	nodes := make([]map[string]interface{}, len(data))
+	for k, v := range data {
+		nodes[k] = readDiskNode(v)
+	}
+
+	if err = d.Set("nodes", nodes); err != nil {
+		return fmt.Errorf("error setting nodes for resource %s, %s", d.Id(), err)
+	}
+
 	return nil
 }
 
 func resourceExtraDiskSizeDelete(d *schema.ResourceData, meta interface{}) error {
+	// Just remove this resource from the state file, no action taken in backend.
 	return nil
+}
+
+func readDiskNode(data map[string]interface{}) map[string]interface{} {
+	node := make(map[string]interface{})
+	for k, v := range data {
+		if validateDiskSchemaAttribute(k) {
+			node[k] = v
+		}
+	}
+	return node
+}
+
+func validateDiskSchemaAttribute(key string) bool {
+	switch key {
+	case "name",
+		"disk_size",
+		"additional_disk_size":
+		return true
+	}
+	return false
 }

--- a/cloudamqp/resource_cloudamqp_extra_disk_size.go
+++ b/cloudamqp/resource_cloudamqp_extra_disk_size.go
@@ -53,12 +53,14 @@ func resourceExtraDiskSize() *schema.Resource {
 							Computed: true,
 						},
 						"disk_size": {
-							Type:     schema.TypeInt,
-							Computed: true,
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Subscription plan disk size",
 						},
 						"additional_disk_size": {
-							Type:     schema.TypeInt,
-							Computed: true,
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Additional added disk size",
 						},
 					},
 				},
@@ -76,7 +78,7 @@ func resourceExtraDiskSizeUpdate(d *schema.ResourceData, meta interface{}) error
 	params["extra_disk_size"] = d.Get("extra_disk_size")
 	params["allow_downtime"] = d.Get("allow_downtime")
 
-	_, err := api.ResizeDisk(d.Get("instance_id").(int), params, 30, 1800)
+	_, err := api.ResizeDisk(d.Get("instance_id").(int), params, d.Get("sleep").(int), d.Get("timeout").(int))
 	if err != nil {
 		return err
 	}

--- a/cloudamqp/resource_cloudamqp_extra_disk_size.go
+++ b/cloudamqp/resource_cloudamqp_extra_disk_size.go
@@ -12,36 +12,25 @@ func resourceExtraDiskSize() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceExtraDiskSizeUpdate,
 		Read:   resourceExtraDiskSizeRead,
-		Update: resourceExtraDiskSizeUpdate,
 		Delete: resourceExtraDiskSizeDelete,
 		Schema: map[string]*schema.Schema{
 			"instance_id": {
 				Type:        schema.TypeInt,
+				ForceNew:    true,
 				Required:    true,
 				Description: "Instance identifier",
 			},
 			"extra_disk_size": {
 				Type:        schema.TypeInt,
+				ForceNew:    true,
 				Required:    true,
 				Description: "Extra disk size in GB",
 			},
 			"allow_downtime": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
+				ForceNew:    true,
+				Required:    true,
 				Description: "When resizing disk, allow downtime to do so",
-			},
-			"sleep": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     30,
-				Description: "Configurable sleep time in seconds between retries for firewall configuration",
-			},
-			"timeout": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     1800,
-				Description: "Configurable timeout time in seconds for firewall configuration",
 			},
 			"nodes": {
 				Type:     schema.TypeList,
@@ -71,14 +60,16 @@ func resourceExtraDiskSize() *schema.Resource {
 
 func resourceExtraDiskSizeUpdate(d *schema.ResourceData, meta interface{}) error {
 	var (
-		api    = meta.(*api.API)
-		params = make(map[string]interface{})
+		api     = meta.(*api.API)
+		params  = make(map[string]interface{})
+		sleep   = 30   // 30 seconds between retires when polling if extra disk size been succesfull.
+		timeout = 1800 // seconds between polling will timeout.
 	)
 
 	params["extra_disk_size"] = d.Get("extra_disk_size")
 	params["allow_downtime"] = d.Get("allow_downtime")
 
-	_, err := api.ResizeDisk(d.Get("instance_id").(int), params, d.Get("sleep").(int), d.Get("timeout").(int))
+	_, err := api.ResizeDisk(d.Get("instance_id").(int), params, sleep, timeout)
 	if err != nil {
 		return err
 	}

--- a/cloudamqp/resource_cloudamqp_extra_disk_size.go
+++ b/cloudamqp/resource_cloudamqp_extra_disk_size.go
@@ -30,7 +30,7 @@ func resourceExtraDiskSize() *schema.Resource {
 				Type:        schema.TypeBool,
 				ForceNew:    true,
 				Required:    true,
-				Description: "When resizing disk, allow downtime to do so",
+				Description: "When resizing disk, allow cluster downtime to do so",
 			},
 			"nodes": {
 				Type:     schema.TypeList,
@@ -103,7 +103,8 @@ func resourceExtraDiskSizeRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceExtraDiskSizeDelete(d *schema.ResourceData, meta interface{}) error {
-	// Just remove this resource from the state file, no action taken in backend.
+	// Just remove this resource from the state file, as the delete route does not exist in the backend
+	// but we need to allow delete to happen, e.g. when you destroy your instance
 	return nil
 }
 

--- a/cloudamqp/resource_cloudamqp_extra_disk_size.go
+++ b/cloudamqp/resource_cloudamqp_extra_disk_size.go
@@ -62,8 +62,8 @@ func resourceExtraDiskSizeUpdate(d *schema.ResourceData, meta interface{}) error
 	var (
 		api     = meta.(*api.API)
 		params  = make(map[string]interface{})
-		sleep   = 30   // 30 seconds between retires when polling if extra disk size been succesfull.
-		timeout = 1800 // seconds between polling will timeout.
+		sleep   = 30   // Seconds between retires when either polling for ready nodes or catching busy backend.
+		timeout = 1800 // Seconds until timeout when either polling for ready nodes or catching busy backend.
 	)
 
 	params["extra_disk_size"] = d.Get("extra_disk_size")

--- a/docs/data-sources/nodes.md
+++ b/docs/data-sources/nodes.md
@@ -32,13 +32,17 @@ ___
 
 The `nodes` block consist of
 
-* `hostname`          - External hostname assigned to the node.
-* `name`              - Name of the node.
-* `running`           - Is the node running?
-* `rabbitmq_version`  - Currently configured Rabbit MQ version on the node.
-* `erlang_version`    - Currently used Erlanbg version on the node.
-* `hipe`              - Enable or disable High-performance Erlang.
-* `configured`        - Is the node configured?
+* `hostname`              - External hostname assigned to the node.
+* `name`                  - Name of the node.
+* `running`               - Is the node running?
+* `rabbitmq_version`      - Currently configured Rabbit MQ version on the node.
+* `erlang_version`        - Currently used Erlanbg version on the node.
+* `hipe`                  - Enable or disable High-performance Erlang.
+* `configured`            - Is the node configured?
+* `disk_size`             - Subscription plan disk size
+* `additional_disk_size`  - Additional added disk size
+
+***Note:*** *Total disk size = disk_size + additional_disk_size*
 
 ## Dependency
 

--- a/docs/resources/extra_disk_size.md
+++ b/docs/resources/extra_disk_size.md
@@ -7,15 +7,36 @@ description: |-
 
 # cloudamqp_extra_disk_size
 
-This resource allows you to expand the disk with additional storage capacity. There is no downtime when expanding the disk.
+This resource allows you to resize the disk with additional storage capacity.
 
-Only available for dedicated subscription plans hosted at Amazon Web Services (AWS) at this time.
+***Pre v1.25.0***: Only available for Amazon Web Services (AWS) and it done without downtime
 
-~> **WARNING:** Due to restrictions from cloud providers, it's only possible to resize the disk every 8 hours.
+***Post v1.25.0***: Now also available for Google-Compute-Engine (GCE) and Azure.
+
+Introducing an additional optional argument called `allow_downtime`, default set to *false*. This will resize the disk without downtime for *AWS* and *GCE*. While Azure only support swapping the disk, and this argument needs to be set to *true*.
+
+Allow downtime also makes it possible to circumvent the time rate limit or shrinking the disk.
+
+| Cloud Platform        | allow_downtime=false | allow_downtime=true           |
+|-----------------------|----------------------|-------------------------------|
+| amazon-web-services   | Expand current disk  | Try to expand, otherwise swap |
+| google-compute-engine | Expand current disk  | Try to expand, otherwise swap |
+| azure-arm             | Not supported        | Swap disk to new size         |
+
+~> **WARNING:** Due to restrictions from cloud providers, it's only possible to resize the disk every 8 hours. Unless the `allow_downtime=true` is set. Then the disk will be swapped for a new.
 
 Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/).
 
+Only available for dedicated subscription plans.
+
 ## Example Usage
+
+<details>
+  <summary>
+    <b>
+      <i>AWS extra disk size (pre v1.25.0)</i>
+    </b>
+  </summary>
 
 ```hcl
 # Configure CloudAMQP provider
@@ -26,7 +47,7 @@ provider "cloudamqp" {
 # Instance
 resource "cloudamqp_instance" "instance" {
   name   = "Instance"
-  plan   = "squirrel-1"
+  plan   = "bunny-1"
   region = "amazon-web-services::us-west-2"
   rmq_version = "3.10.1"
 }
@@ -46,10 +67,153 @@ data "cloudamqp_nodes" "nodes" {
 }
 ```
 
+</details>
+
+<details>
+  <summary>
+    <b>
+      <i>AWS extra disk size without downtime</i>
+    </b>
+  </summary>
+
+```hcl
+# Configure CloudAMQP provider
+provider "cloudamqp" {
+  apikey = var.cloudamqp_customer_api_key
+}
+
+# Instance
+resource "cloudamqp_instance" "instance" {
+  name   = "Instance"
+  plan   = "bunny-1"
+  region = "amazon-web-services::us-west-2"
+  rmq_version = "3.10.1"
+}
+
+# Resize disk with 25 extra GB, without downtime
+resource "cloudamqp_extra_disk_size" "resize_disk" {
+  instance_id = cloudamqp_instance.instance.id
+  extra_disk_size = 25
+  allow_downtime = false
+}
+
+# Refresh nodes info after disk resize
+data "cloudamqp_nodes" "nodes" {
+  instance_id = cloudamqp_instance.instance.id
+  depends_on = [
+    cloudamqp_extra_disk_size.resize_disk,
+  ]
+}
+```
+
+</details>
+
+<details>
+  <summary>
+    <b>
+      <i>GCE extra disk size without downtime</i>
+    </b>
+  </summary>
+
+```hcl
+# Configure CloudAMQP provider
+provider "cloudamqp" {
+  apikey = var.cloudamqp_customer_api_key
+}
+
+# Instance
+resource "cloudamqp_instance" "instance" {
+  name   = "Instance"
+  plan   = "bunny-1"
+  region = "google-compute-engine::us-central1"
+  rmq_version = "3.10.1"
+}
+
+# Resize disk with 25 extra GB, without downtime
+resource "cloudamqp_extra_disk_size" "resize_disk" {
+  instance_id = cloudamqp_instance.instance.id
+  extra_disk_size = 25
+  allow_downtime = false
+}
+
+# Refresh nodes info after disk resize
+data "cloudamqp_nodes" "nodes" {
+  instance_id = cloudamqp_instance.instance.id
+  depends_on = [
+    cloudamqp_extra_disk_size.resize_disk,
+  ]
+}
+```
+
+</details>
+
+<details>
+  <summary>
+    <b>
+      <i>Azure extra disk size with downtime</i>
+    </b>
+  </summary>
+
+```hcl
+# Configure CloudAMQP provider
+provider "cloudamqp" {
+  apikey = var.cloudamqp_customer_api_key
+}
+
+# Instance
+resource "cloudamqp_instance" "instance" {
+  name   = "Instance"
+  plan   = "bunny-1"
+  region = "azure-arm::centralus"
+  rmq_version = "3.10.1"
+}
+
+# Resize disk with 25 extra GB, with downtime
+resource "cloudamqp_extra_disk_size" "resize_disk" {
+  instance_id = cloudamqp_instance.instance.id
+  extra_disk_size = 25
+  allow_downtime = true
+}
+
+# Refresh nodes info after disk resize
+data "cloudamqp_nodes" "nodes" {
+  instance_id = cloudamqp_instance.instance.id
+  depends_on = [
+    cloudamqp_extra_disk_size.resize_disk,
+  ]
+}
+```
+
+</details>
+
 ## Argument Reference
 
-* `instance_id`       - (Required/ForceNew) The CloudAMQP instance ID.
-* `extra_disk_size`   - (Required/ForceNew) Extra disk size in GB. Supported values: 25, 50, 100, 250, 500, 1000, 2000
+* `instance_id`       - (Required) The CloudAMQP instance ID.
+* `extra_disk_size`   - (Required) Extra disk size in GB. Supported values: 25, 50, 100, 250, 500, 1000, 2000
+* `allow_downtime`    - (Optional) When resizing the disk, allow downtime to do so. Default set to false. (Only Available from v1.25.0).
+* `sleep`             - (Optional) Configurable sleep time in seconds between retries for firewall configuration. Default set to 30 seconds.
+* `timeout`           - (Optional) Configurable timeout time in seconds for firewall configuration. Default set to 1800 seconds.
+
+## Attributes reference
+
+All attributes reference are computed
+
+* `id`    - The identifier for this resource.
+* `nodes` - An array of node information. Each `nodes` block consists of the fields documented below.
+
+___
+
+The `nodes` block consist of
+
+* `name`                  - Name of the node.
+* `disk_size`             - Subscription plan disk size
+* `additional_disk_size`  - Additional added disk size
+
+***Note:*** *Total disk size = disk_size + additional_disk_size*
+
+## Dependency
+
+This data source depends on CloudAMQP instance identifier, `cloudamqp_instance.instance.id`.
 
 ## Import
 

--- a/docs/resources/extra_disk_size.md
+++ b/docs/resources/extra_disk_size.md
@@ -13,7 +13,7 @@ This resource allows you to resize the disk with additional storage capacity.
 
 ***Post v1.25.0***: Now also available for Google-Compute-Engine (GCE) and Azure.
 
-Introducing an additional optional argument called `allow_downtime`, default set to *false*. This will resize the disk without downtime for *AWS* and *GCE*. While Azure only support swapping the disk, and this argument needs to be set to *true*.
+Introducing a new required argument called `allow_downtime`. This will resize the disk without downtime for *AWS* and *GCE*. While Azure only support swapping the disk, and this argument needs to be set to *true*.
 
 Allow downtime also makes it possible to circumvent the time rate limit or shrinking the disk.
 
@@ -23,7 +23,9 @@ Allow downtime also makes it possible to circumvent the time rate limit or shrin
 | google-compute-engine | Expand current disk  | Try to expand, otherwise swap |
 | azure-arm             | Not supported        | Swap disk to new size         |
 
-~> **WARNING:** Due to restrictions from cloud providers, it's only possible to resize the disk every 8 hours. Unless the `allow_downtime=true` is set. Then the disk will be swapped for a new.
+<br>
+
+~> **WARNING:** Due to restrictions from cloud providers, it's only possible to resize the disk every 8 hours. Unless the `allow_downtime=true` is set, then the disk will be swapped for a new.
 
 Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/).
 
@@ -58,7 +60,8 @@ resource "cloudamqp_extra_disk_size" "resize_disk" {
   extra_disk_size = 25
 }
 
-# Refresh nodes info after disk resize
+# Optional, refresh nodes info after disk resize by adding dependency
+# to cloudamqp_extra_disk_size.resize_disk resource
 data "cloudamqp_nodes" "nodes" {
   instance_id = cloudamqp_instance.instance.id
   depends_on = [
@@ -97,7 +100,8 @@ resource "cloudamqp_extra_disk_size" "resize_disk" {
   allow_downtime = false
 }
 
-# Refresh nodes info after disk resize
+# Optional, refresh nodes info after disk resize by adding dependency
+# to cloudamqp_extra_disk_size.resize_disk resource
 data "cloudamqp_nodes" "nodes" {
   instance_id = cloudamqp_instance.instance.id
   depends_on = [
@@ -136,7 +140,8 @@ resource "cloudamqp_extra_disk_size" "resize_disk" {
   allow_downtime = false
 }
 
-# Refresh nodes info after disk resize
+# Optional, refresh nodes info after disk resize by adding dependency
+# to cloudamqp_extra_disk_size.resize_disk resource
 data "cloudamqp_nodes" "nodes" {
   instance_id = cloudamqp_instance.instance.id
   depends_on = [
@@ -175,7 +180,8 @@ resource "cloudamqp_extra_disk_size" "resize_disk" {
   allow_downtime = true
 }
 
-# Refresh nodes info after disk resize
+# Optional, refresh nodes info after disk resize by adding dependency
+# to cloudamqp_extra_disk_size.resize_disk resource
 data "cloudamqp_nodes" "nodes" {
   instance_id = cloudamqp_instance.instance.id
   depends_on = [

--- a/docs/resources/extra_disk_size.md
+++ b/docs/resources/extra_disk_size.md
@@ -11,11 +11,12 @@ This resource allows you to resize the disk with additional storage capacity.
 
 ***Pre v1.25.0***: Only available for Amazon Web Services (AWS) and it done without downtime
 
-***Post v1.25.0***: Now also available for Google-Compute-Engine (GCE) and Azure.
+***Post v1.25.0***: Now also available for Google Compute Engine (GCE) and Azure.
 
-Introducing a new required argument called `allow_downtime`. This will resize the disk without downtime for *AWS* and *GCE*. While Azure only support swapping the disk, and this argument needs to be set to *true*.
+Introducing a new optional argument called `allow_downtime`.  Leaving it out or set it to false will proceed to try and resize the disk without downtime, available for *AWS* and *GCE*.
+While *Azure* only support swapping the disk, and this argument needs to be set to *true*.
 
-Allow downtime also makes it possible to circumvent the time rate limit or shrinking the disk.
+`allow_downtime` also makes it possible to circumvent the time rate limit or shrinking the disk.
 
 | Cloud Platform        | allow_downtime=false | allow_downtime=true           |
 |-----------------------|----------------------|-------------------------------|
@@ -27,11 +28,7 @@ Allow downtime also makes it possible to circumvent the time rate limit or shrin
 
 ~> **WARNING:** Due to restrictions from cloud providers, it's only possible to resize the disk every 8 hours. Unless the `allow_downtime=true` is set, then the disk will be swapped for a new.
 
-<br>
-
-Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/).
-
-Only available for dedicated subscription plans.
+Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/) and only available for dedicated subscription plans.
 
 ## Example Usage
 
@@ -53,7 +50,6 @@ resource "cloudamqp_instance" "instance" {
   name   = "Instance"
   plan   = "bunny-1"
   region = "amazon-web-services::us-west-2"
-  rmq_version = "3.10.1"
 }
 
 # Resize disk with 25 extra GB
@@ -92,14 +88,12 @@ resource "cloudamqp_instance" "instance" {
   name   = "Instance"
   plan   = "bunny-1"
   region = "amazon-web-services::us-west-2"
-  rmq_version = "3.10.1"
 }
 
 # Resize disk with 25 extra GB, without downtime
 resource "cloudamqp_extra_disk_size" "resize_disk" {
   instance_id = cloudamqp_instance.instance.id
   extra_disk_size = 25
-  allow_downtime = false
 }
 
 # Optional, refresh nodes info after disk resize by adding dependency
@@ -132,14 +126,12 @@ resource "cloudamqp_instance" "instance" {
   name   = "Instance"
   plan   = "bunny-1"
   region = "google-compute-engine::us-central1"
-  rmq_version = "3.10.1"
 }
 
 # Resize disk with 25 extra GB, without downtime
 resource "cloudamqp_extra_disk_size" "resize_disk" {
   instance_id = cloudamqp_instance.instance.id
   extra_disk_size = 25
-  allow_downtime = false
 }
 
 # Optional, refresh nodes info after disk resize by adding dependency
@@ -172,7 +164,6 @@ resource "cloudamqp_instance" "instance" {
   name   = "Instance"
   plan   = "bunny-1"
   region = "azure-arm::centralus"
-  rmq_version = "3.10.1"
 }
 
 # Resize disk with 25 extra GB, with downtime
@@ -199,8 +190,12 @@ data "cloudamqp_nodes" "nodes" {
 Any changes to the arguments will destroy and recreate this resource.
 
 * `instance_id`       - (ForceNew/Required) The CloudAMQP instance ID.
-* `extra_disk_size`   - (ForceNew/Required) Extra disk size in GB. Supported values: 25, 50, 100, 250, 500, 1000, 2000
-* `allow_downtime`    - (ForceNew/Required) When resizing the disk, allow downtime to do so. (Only Available from v1.25.0).
+* `extra_disk_size`   - (ForceNew/Required) Extra disk size in GB. Supported values: 0, 25, 50, 100, 250, 500, 1000, 2000
+* `allow_downtime`    - (Optional) When resizing the disk, allow cluster downtime if necessary. Default set to false.
+* `sleep`       - (Optional) Configurable sleep time in seconds between retries for resizing the disk. Default set to 30 seconds.
+* `timeout`     - (Optional) Configurable timeout time in seconds for resizing the disk. Default set to 1800 seconds.
+
+***Note:*** `allow_downtime` Only available from v1.25.0 and required when hosting in *Azure*.
 
 ## Attributes reference
 

--- a/docs/resources/extra_disk_size.md
+++ b/docs/resources/extra_disk_size.md
@@ -19,13 +19,15 @@ Allow downtime also makes it possible to circumvent the time rate limit or shrin
 
 | Cloud Platform        | allow_downtime=false | allow_downtime=true           |
 |-----------------------|----------------------|-------------------------------|
-| amazon-web-services   | Expand current disk  | Try to expand, otherwise swap |
-| google-compute-engine | Expand current disk  | Try to expand, otherwise swap |
+| amazon-web-services   | Expand current disk* | Try to expand, otherwise swap |
+| google-compute-engine | Expand current disk* | Try to expand, otherwise swap |
 | azure-arm             | Not supported        | Swap disk to new size         |
 
-<br>
+*Preferable method to use.
 
 ~> **WARNING:** Due to restrictions from cloud providers, it's only possible to resize the disk every 8 hours. Unless the `allow_downtime=true` is set, then the disk will be swapped for a new.
+
+<br>
 
 Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/).
 
@@ -198,7 +200,7 @@ Any changes to the arguments will destroy and recreate this resource.
 
 * `instance_id`       - (ForceNew/Required) The CloudAMQP instance ID.
 * `extra_disk_size`   - (ForceNew/Required) Extra disk size in GB. Supported values: 25, 50, 100, 250, 500, 1000, 2000
-* `allow_downtime`    - (ForceNew/Required) When resizing the disk, allow downtime to do so. Default set to false. (Only Available from v1.25.0).
+* `allow_downtime`    - (ForceNew/Required) When resizing the disk, allow downtime to do so. (Only Available from v1.25.0).
 
 ## Attributes reference
 

--- a/docs/resources/extra_disk_size.md
+++ b/docs/resources/extra_disk_size.md
@@ -188,11 +188,11 @@ data "cloudamqp_nodes" "nodes" {
 
 ## Argument Reference
 
-* `instance_id`       - (Required) The CloudAMQP instance ID.
-* `extra_disk_size`   - (Required) Extra disk size in GB. Supported values: 25, 50, 100, 250, 500, 1000, 2000
-* `allow_downtime`    - (Optional) When resizing the disk, allow downtime to do so. Default set to false. (Only Available from v1.25.0).
-* `sleep`             - (Optional) Configurable sleep time in seconds between retries for firewall configuration. Default set to 30 seconds.
-* `timeout`           - (Optional) Configurable timeout time in seconds for firewall configuration. Default set to 1800 seconds.
+Any changes to the arguments will destroy and recreate this resource.
+
+* `instance_id`       - (ForceNew/Required) The CloudAMQP instance ID.
+* `extra_disk_size`   - (ForceNew/Required) Extra disk size in GB. Supported values: 25, 50, 100, 250, 500, 1000, 2000
+* `allow_downtime`    - (ForceNew/Required) When resizing the disk, allow downtime to do so. Default set to false. (Only Available from v1.25.0).
 
 ## Attributes reference
 

--- a/docs/resources/extra_disk_size.md
+++ b/docs/resources/extra_disk_size.md
@@ -191,11 +191,11 @@ Any changes to the arguments will destroy and recreate this resource.
 
 * `instance_id`       - (ForceNew/Required) The CloudAMQP instance ID.
 * `extra_disk_size`   - (ForceNew/Required) Extra disk size in GB. Supported values: 0, 25, 50, 100, 250, 500, 1000, 2000
-* `allow_downtime`    - (Optional) When resizing the disk, allow cluster downtime if necessary. Default set to false.
+* `allow_downtime`    - (Optional) When resizing the disk, allow cluster downtime if necessary. Default set to false. Required when hosting in *Azure*.
 * `sleep`       - (Optional) Configurable sleep time in seconds between retries for resizing the disk. Default set to 30 seconds.
 * `timeout`     - (Optional) Configurable timeout time in seconds for resizing the disk. Default set to 1800 seconds.
 
-***Note:*** `allow_downtime` Only available from v1.25.0 and required when hosting in *Azure*.
+***Note:*** `allow_downtime`, `sleep`, `timeout` only available from v1.25.0.
 
 ## Attributes reference
 


### PR DESCRIPTION
Introducing new optional argument `allow_downtime` to notify API backend. This will allow actions to be taken, that could require cluster downtime while resizing the disk. I.e. `azure-arm`, needs to swap disk instead of just expand the disk, which require downtime. 

| Cloud Platform        | allow_downtime=false | allow_downtime=true           |
|-----------------------|----------------------|-------------------------------|
| amazon-web-services   | Expand current disk  | Try to expand, otherwise swap |
| google-compute-engine | Expand current disk  | Try to expand, otherwise swap |
| azure-arm             | Not supported        | Swap disk to new size         |

Old arguments kept as ForceNew/Required. Any changes made to any of them, will destroy and recreate the resource. 

Require dependency update to wait for disk resize action to finish: https://github.com/84codes/go-api/pull/31

Further update, computed `nodes` section, to display similar disk information as in the [nodes data source ](https://github.com/cloudamqp/terraform-provider-cloudamqp/blob/main/cloudamqp/data_source_cloudamqp_nodes.go)