### PR TITLE
Fix Stackdriver optional arugments assignments

### DIFF
--- a/cloudamqp/resource_cloudamqp_integration_metric.go
+++ b/cloudamqp/resource_cloudamqp_integration_metric.go
@@ -151,7 +151,8 @@ func resourceIntegrationMetricCreate(d *schema.ResourceData, meta interface{}) e
 		json.Unmarshal([]byte(uDec), &jsonMap)
 		for _, k := range keys {
 			if contains(commonKeys, k) {
-				if v := d.Get(k); v == "" || v == nil {
+				v := d.Get(k)
+				if v == "" || v == nil {
 					delete(params, k)
 					continue
 				} else if k == "queue_allowlist" {
@@ -250,7 +251,8 @@ func resourceIntegrationMetricUpdate(d *schema.ResourceData, meta interface{}) e
 		json.Unmarshal([]byte(uDec), &jsonMap)
 		for _, k := range keys {
 			if contains(commonKeys, k) {
-				if v := d.Get(k); v == "" || v == nil {
+				v := d.Get(k)
+				if v == "" || v == nil {
 					delete(params, k)
 					continue
 				} else if k == "queue_allowlist" {


### PR DESCRIPTION
Previous fix:  https://github.com/cloudamqp/terraform-provider-cloudamqp/commit/4c7b852d97218af5b5d22d73b52641021e818a1f to correct the optional arguments queue/vhost by converting into JSON fileds. Introduced new issues by assigning wrong values during create/update including tags: https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/195

New fix to make sure all allowed optional arguments can be used.
```hcl
resource "cloudamqp_integration_metric" "stackdriver" {
  instance_id = cloudamqp_instance.instance.id
  name = "stackdriver"
  credentials = google_service_account_key.service_account_key.private_key
  queue_allowlist = "<queue-regex>""
  vhost_allowlist = "<vhost-regex>"
  tags = "foo=bar"
}
```