### PR TITLE
Add support to configure cluster_partition_handling

### DIFF
--- a/cloudamqp/resource_cloudamqp_rabbitmq_configuration.go
+++ b/cloudamqp/resource_cloudamqp_rabbitmq_configuration.go
@@ -131,6 +131,13 @@ func resourceRabbitMqConfiguration() *schema.Resource {
 					"Does not affect the file logger. Requires a RabbitMQ restart to be applied.",
 				ValidateFunc: validateLogLevel(),
 			},
+			"cluster_partition_handling": {
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				Description:  "Set how the cluster should handle network partition.",
+				ValidateFunc: validation.StringInSlice([]string{"autoheal", "pause_minority"}, true),
+			},
 			"sleep": {
 				Type:        schema.TypeInt,
 				Optional:    true,
@@ -256,7 +263,8 @@ func validateRabbitMqConfigurationJSONField(key string) bool {
 		"rabbit.vm_memory_high_watermark",
 		"rabbit.queue_index_embed_msgs_below",
 		"rabbit.max_message_size",
-		"rabbit.log.exchange.level":
+		"rabbit.log.exchange.level",
+		"rabbit.cluster_partition_handling":
 		return true
 	}
 	return false
@@ -284,5 +292,6 @@ func rabbitMqConfigurationWriteAttributeKeys() []string {
 		"queue_index_embed_msgs_below",
 		"max_message_size",
 		"log_exchange_level",
+		"cluster_partition_handling",
 	}
 }

--- a/docs/resources/rabbitmq_configuration.md
+++ b/docs/resources/rabbitmq_configuration.md
@@ -31,6 +31,7 @@ resource "cloudamqp_rabbitmq_configuration" "rabbitmq_config" {
   max_message_size = 134217728
   queue_index_embed_msgs_below = 4096
   vm_memory_high_watermark = 0.81
+  cluster_partition_handling = "autoheal"
 }
 ```
 </details>
@@ -54,6 +55,7 @@ resource "cloudamqp_rabbitmq_configuration" "rabbitmq_config" {
   max_message_size = 134217728
   queue_index_embed_msgs_below = 4096
   vm_memory_high_watermark = 0.81
+  cluster_partition_handling = "autoheal"
 }
 
 data "cloudamqp_nodes" "list_nodes" {
@@ -103,6 +105,7 @@ The following arguments are supported:
 * `log_exchange_level`            - (Computed/Optional) Log level for the logger used for log integrations and the CloudAMQP Console log view.
 
   ***Note: Requires a restart of RabbitMQ to be applied.***
+* `cluster_partition_handling`    - (Computed/Optional) Set how the cluster should handle network partition.
 * `sleep` - (Optional) Configurable sleep time in seconds between retries for RabbitMQ configuration. Default set to 60 seconds.
 * `timeout` - (Optional) - Configurable timeout time in seconds for RabbitMQ configuration. Default set to 3600 seconds.
 
@@ -124,6 +127,9 @@ All attributes reference are computed
 | queue_index_embed_msgs_below | int | 4096 | 1 | 10485760 | bytes | Applied immediately for new queues, requires restart for existing queues |  |
 | max_message_size | int | 134217728 | 1 | 536870912 | bytes | Only effects new channels |  |
 | log_exchange_level | string | error | - | - |  | RabbitMQ restart required | debug, info, warning, error, critical |
+| cluster_partition_handling | string | see below | - | - |  | Applied immediately | autoheal, pause_minority |
+
+  *Note: Recommended settings for cluster_partition_handling: `pause_minority` on multi node cluster (3 or more nodes), otherwise `autoheal`*
 
 ## Dependency
 


### PR DESCRIPTION
Extend the configurable arguments for rabbitmq_configuration to also configure cluster_partition_handling. How the cluster should behave during network partition. Limited used of valid values to `autoheal` or `pause_minority`.

Depends on changes made in:
https://github.com/84codes/cloudamqp-api/pull/396