### PR TITLE
Use the backend for online validation

### DIFF
--- a/cloudamqp/resource_cloudamqp_instance.go
+++ b/cloudamqp/resource_cloudamqp_instance.go
@@ -27,10 +27,9 @@ func resourceInstance() *schema.Resource {
 				Description: "Name of the instance",
 			},
 			"plan": {
-				Type:         schema.TypeString,
-				Required:     true,
-				Description:  "Name of the plan, see documentation for valid plans",
-				ValidateFunc: validatePlanName(),
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the plan, see documentation for valid plans",
 			},
 			"region": {
 				Type:        schema.TypeString,
@@ -128,6 +127,20 @@ func resourceInstance() *schema.Resource {
 				oldPlanType, _ := getPlanType(old.(string))
 				newPlanType, _ := getPlanType(new.(string))
 				return !(oldPlanType == newPlanType)
+			}),
+			customdiff.ValidateChange("plan", func(old, new, meta interface{}) error {
+				if old == new {
+					return nil
+				}
+				api := meta.(*api.API)
+				return api.ValidatePlan(new.(string))
+			}),
+			customdiff.ValidateChange("region", func(old, new, meta interface{}) error {
+				if old == new {
+					return nil
+				}
+				api := meta.(*api.API)
+				return api.ValidateRegion(new.(string))
 			}),
 		),
 	}


### PR DESCRIPTION
Ongoing test implementation to move away from hardcoded validations in the provider and instead use our backend. Will also take into account team based feature flags set. 

Investigating question: Will this transfer well for Terraform plugin SDKv1 -> SDKv2 -> Framework migration.

Requires: https://github.com/84codes/go-api/pull/34