### PR TITLE
Add missing plan to the docs

### DIFF
--- a/docs/guides/info_plan.md
+++ b/docs/guides/info_plan.md
@@ -22,6 +22,7 @@ Little lemur    | lemur         | rabbitmq  | shared
 Tough Tiger     | tiger         | rabbitmq  | shared
 Sassy Squirrel  | squirrel-1    | rabbitmq  | dedicated | 1
 Big Bunny       | bunny-1,3     | rabbitmq  | dedicated | 1,3
+Happy Hare      | hare-1,3      | rabbitmq  | dedicated | 1,3
 Roaring Rabbit  | rabbit-1,3,5  | rabbitmq  | dedicated | 1,3,5
 Power Panda     | panda-1,3,5   | rabbitmq  | dedicated | 1,3,5
 Awesome Ape     | ape-1,3,5     | rabbitmq  | dedicated | 1,3,5


### PR DESCRIPTION
Since the
https://github.com/cloudamqp/terraform-provider-cloudamqp/commit/7794f8fb000b918b1a681b87606e771ab2a1708b the provider support more plan but it was not documented