### PR TITLE
Update firewall rules, PrivateLink and VPC Peering documentation

### DIFF
--- a/docs/resources/privatelink_aws.md
+++ b/docs/resources/privatelink_aws.md
@@ -9,7 +9,7 @@ description: |-
 
 Enable PrivateLink for a CloudAMQP instance hosted in AWS. If no existing VPC available when enable PrivateLink, a new VPC will be created with subnet `10.52.72.0/24`.
 
-~> **Note:** Enable PrivateLink will trigger a firewall change that automatically add rule for the peered subnet.
+~> **Note:** Enabling PrivateLink will automatically add firewall rules for the peered subnet.
 <details>
  <summary>
     <i>Default PrivateLink firewall rule</i>
@@ -24,7 +24,7 @@ rules {
 ```
 </details>
 
-Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html) and more information about [CloudAMQP Privatelink](https://www.cloudamqp.com/docs/cloudamqp-privatelink.html#aws-privatelink).
+Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html) where you can also find more information about [CloudAMQP PrivateLink](https://www.cloudamqp.com/docs/cloudamqp-privatelink.html#aws-privatelink).
 
 Only available for dedicated subscription plans.
 
@@ -121,7 +121,7 @@ This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.inst
 ## Create PrivateLink with additional firewall rules
 
 To create a PrivateLink configuration with additional firewall rules, it's required to chain the [cloudamqp_security_firewall](https://registry.terraform.io/providers/cloudamqp/cloudamqp/latest/docs/resources/security_firewall)
-resource to avoid parallel conflicting resource calls. This is done by adding dependency in the firewall resource to the PrivateLink resource, `cloudamqp_privatelink_aws.privatelink`.
+resource to avoid parallel conflicting resource calls. You can do this by making the firewall resource depend on the PrivateLink resource, `cloudamqp_privatelink_aws.privatelink`.
 
 Furthermore, since all firewall rules are overwritten, the otherwise automatically added rules for the PrivateLink also needs to be added.
 

--- a/docs/resources/privatelink_aws.md
+++ b/docs/resources/privatelink_aws.md
@@ -9,23 +9,40 @@ description: |-
 
 Enable PrivateLink for a CloudAMQP instance hosted in AWS. If no existing VPC available when enable PrivateLink, a new VPC will be created with subnet `10.52.72.0/24`.
 
-More information about [CloudAMQP Privatelink](https://www.cloudamqp.com/docs/cloudamqp-privatelink.html#aws-privatelink).
+~> **NOTE:** Once the PrivateLink is enabled our backend will automatically create a firewall rule for this.
+<details>
+ <summary>
+    <i>Default PrivateLink firewall rule</i>
+  </summary>
+```hcl
+rules {
+  Description = "PrivateLink setup"
+  ip          = "10.56.72.0/24"
+  ports       = []
+  services    = ["AMQP", "AMQPS", "HTTPS", "STREAM", "STREAM_SSL", "STOMP", "STOMPS", "MQTT", "MQTTS"]
+}
+```
+</details>
+
+Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html) and more information about [CloudAMQP Privatelink](https://www.cloudamqp.com/docs/cloudamqp-privatelink.html#aws-privatelink).
 
 Only available for dedicated subscription plans.
 
-Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html).
-
 ## Example Usage
 
-CloudAMQP instance without existing VPC
+<details>
+  <summary>
+    <b>
+      <i>CloudAMQP instance without existing VPC</i>
+    </b>
+  </summary>
 
 ```hcl
 resource "cloudamqp_instance" "instance" {
   name   = "Instance 01"
-  plan   = "squirrel-1"
+  plan   = "bunny-1"
   region = "amazon-web-services::us-west-1"
-  tags   = ["test"]
-  rmq_version = "3.10.8"
+  tags   = []
 }
 
 resource "cloudamqp_privatelink_aws" "privatelink" {
@@ -35,23 +52,28 @@ resource "cloudamqp_privatelink_aws" "privatelink" {
   ]
 }
 ```
+</details>
 
-CloudAMQP instance already in an existing VPC.
+<details>
+  <summary>
+    <b>
+      <i>CloudAMQP instance in an existing VPC</i>
+    </b>
+  </summary>
 
 ```hcl
 resource "cloudamqp_vpc" "vpc" {
   name = "Standalone VPC"
   region = "amazon-web-services::us-west-1"
   subnet = "10.56.72.0/24"
-  tags = ["test"]
+  tags = []
 }
 
 resource "cloudamqp_instance" "instance" {
   name   = "Instance 01"
-  plan   = "squirrel-1"
+  plan   = "bunny-1"
   region = "amazon-web-services::us-west-1"
-  tags   = ["test"]
-  rmq_version = "3.10.8"
+  tags   = []
   vpc_id = cloudamqp_vpc.vpc.id
   keep_associated_vpc = true
 }
@@ -63,6 +85,64 @@ resource "cloudamqp_privatelink_aws" "privatelink" {
   ]
 }
 ```
+</details>
+
+<details>
+  <summary>
+    <b>
+      <i>CloudAMQP instance in an existing VPC with managed firewall rules</i>
+    </b>
+  </summary>
+
+Chain firewall to privatelink resources to make sure the firewall rules are applied after privatelink have been enabled.
+
+```hcl
+resource "cloudamqp_vpc" "vpc" {
+  name = "Standalone VPC"
+  region = "amazon-web-services::us-west-1"
+  subnet = "10.56.72.0/24"
+  tags = []
+}
+
+resource "cloudamqp_instance" "instance" {
+  name   = "Instance 01"
+  plan   = "bunny-1"
+  region = "amazon-web-services::us-west-1"
+  tags   = []
+  vpc_id = cloudamqp_vpc.vpc.id
+  keep_associated_vpc = true
+}
+
+resource "cloudamqp_privatelink_aws" "privatelink" {
+  instance_id = cloudamqp_instance.instance.id
+  allowed_principals = [
+    "arn:aws:iam::aws-account-id:user/user-name"
+  ]
+}
+
+resource "cloudamqp_security_firewall" "firewall_settings" {
+  instance_id = cloudamqp_instance.instance.id
+
+  rules {
+    Description = "PrivateLink setup"
+    ip          = cloudamqp_vpc.vpc.subnet
+    ports       = []
+    services    = ["AMQP", "AMQPS", "HTTPS", "STREAM", "STREAM_SSL"]
+  }
+
+  rules {
+    description = "MGMT interface"
+    ip = "0.0.0.0/0"
+    ports = []
+    services = ["HTTPS"]
+  }
+
+  depends_on = [
+    cloudamqp_privatelink_aws.privatelink
+   ]
+}
+```
+</details>
 
 ## Argument Reference
 

--- a/docs/resources/privatelink_azure.md
+++ b/docs/resources/privatelink_azure.md
@@ -9,7 +9,7 @@ description: |-
 
 Enable PrivateLink for a CloudAMQP instance hosted in Azure. If no existing VPC available when enable PrivateLink, a new VPC will be created with subnet `10.52.72.0/24`.
 
-~> **Note:** Enable PrivateLink will trigger a firewall change that automatically add rule for the peered subnet.
+~> **Note:** Enabling PrivateLink will automatically add firewall rules for the peered subnet.
 <details>
  <summary>
     <i>Default PrivateLink firewall rule</i>
@@ -24,7 +24,7 @@ rules {
 ```
 </details>
 
-Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html) and more information about [CloudAMQP Privatelink](https://www.cloudamqp.com/docs/cloudamqp-privatelink.html#azure-privatelink).
+Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html) where you can also find more information about [CloudAMQP PrivateLink](https://www.cloudamqp.com/docs/cloudamqp-privatelink.html#azure-privatelink).
 
 Only available for dedicated subscription plans.
 
@@ -119,7 +119,7 @@ This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.inst
 ## Create PrivateLink with additional firewall rules
 
 To create a PrivateLink configuration with additional firewall rules, it's required to chain the [cloudamqp_security_firewall](https://registry.terraform.io/providers/cloudamqp/cloudamqp/latest/docs/resources/security_firewall)
-resource to avoid parallel conflicting resource calls. This is done by adding dependency in the firewall resource to the PrivateLink resource, `cloudamqp_privatelink_azure.privatelink`.
+resource to avoid parallel conflicting resource calls. You can do this by making the firewall resource depend on the PrivateLink resource, `cloudamqp_privatelink_azure.privatelink`.
 
 Furthermore, since all firewall rules are overwritten, the otherwise automatically added rules for the PrivateLink also needs to be added.
 

--- a/docs/resources/privatelink_azure.md
+++ b/docs/resources/privatelink_azure.md
@@ -9,7 +9,7 @@ description: |-
 
 Enable PrivateLink for a CloudAMQP instance hosted in Azure. If no existing VPC available when enable PrivateLink, a new VPC will be created with subnet `10.52.72.0/24`.
 
-~> **NOTE:** Once the PrivateLink is enabled our backend will automatically create a firewall rule for this.
+~> **Note:** Enable PrivateLink will trigger a firewall change that automatically add rule for the peered subnet.
 <details>
  <summary>
     <i>Default PrivateLink firewall rule</i>
@@ -17,7 +17,7 @@ Enable PrivateLink for a CloudAMQP instance hosted in Azure. If no existing VPC 
 ```hcl
 rules {
   Description = "PrivateLink setup"
-  ip          = "10.56.72.0/24"
+  ip          = "<VPC Subnet>"
   ports       = []
   services    = ["AMQP", "AMQPS", "HTTPS", "STREAM", "STREAM_SSL", "STOMP", "STOMPS", "MQTT", "MQTTS"]
 }
@@ -87,6 +87,43 @@ resource "cloudamqp_privatelink_azure" "privatelink" {
 ```
 </details>
 
+## Argument Reference
+
+* `instance_id` - (Required) The CloudAMQP instance identifier.
+* `approved_subscriptions` - (Required) Approved subscriptions to access the endpoint service. See format below.
+* `sleep` - (Optional) Configurable sleep time (seconds) when enable PrivateLink. Default set to 60 seconds.
+* `timeout` - (Optional) - Configurable timeout time (seconds) when enable PrivateLink. Default set to 3600 seconds.
+
+Approved subscriptions format: <br>
+`XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`
+
+## Attributes Reference
+
+All attributes reference are computed
+
+* `id`  - The identifier for this resource.
+* `status`- PrivateLink status [enable, pending, disable]
+* `service_name` - Service name (alias) of the PrivateLink, needed when creating the endpoint.
+* `server_name` - Name of the server having the PrivateLink enabled.
+
+## Depedency
+
+This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.instance.id`.
+
+## Import
+
+`cloudamqp_privatelink_aws` can be imported using CloudAMQP internal identifier.
+
+`terraform import cloudamqp_privatelink_aws.privatelink <id>`
+
+## Create PrivateLink with additional firewall rules
+
+To create a PrivateLink configuration with additional firewall rules, it's required to chain the [cloudamqp_security_firewall](https://registry.terraform.io/providers/cloudamqp/cloudamqp/latest/docs/resources/security_firewall)
+resource to avoid parallel conflicting resource calls. This is done by adding dependency in the firewall resource to the PrivateLink resource, `cloudamqp_privatelink_azure.privatelink`.
+
+Furthermore, since all firewall rules are overwritten, the otherwise automatically added rules for the PrivateLink also needs to be added.
+
+## Example usage with additional firewall rules
 
 <details>
   <summary>
@@ -94,8 +131,6 @@ resource "cloudamqp_privatelink_azure" "privatelink" {
       <i>CloudAMQP instance in an existing VPC with managed firewall rules</i>
     </b>
   </summary>
-
-Chain firewall to privatelink resources to make sure the firewall rules are applied after privatelink have been enabled.
 
 ```hcl
 resource "cloudamqp_vpc" "vpc" {
@@ -125,7 +160,7 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
   instance_id = cloudamqp_instance.instance.id
 
   rules {
-    Description = "PrivateLink setup"
+    Description = "Custom PrivateLink setup"
     ip          = cloudamqp_vpc.vpc.subnet
     ports       = []
     services    = ["AMQP", "AMQPS", "HTTPS", "STREAM", "STREAM_SSL"]
@@ -144,32 +179,3 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
 }
 ```
 </details>
-
-## Argument Reference
-
-* `instance_id` - (Required) The CloudAMQP instance identifier.
-* `approved_subscriptions` - (Required) Approved subscriptions to access the endpoint service. See format below.
-* `sleep` - (Optional) Configurable sleep time (seconds) when enable PrivateLink. Default set to 60 seconds.
-* `timeout` - (Optional) - Configurable timeout time (seconds) when enable PrivateLink. Default set to 3600 seconds.
-
-Approved subscriptions format: <br>
-`XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`
-
-## Attributes Reference
-
-All attributes reference are computed
-
-* `id`  - The identifier for this resource.
-* `status`- PrivateLink status [enable, pending, disable]
-* `service_name` - Service name (alias) of the PrivateLink, needed when creating the endpoint.
-* `server_name` - Name of the server having the PrivateLink enabled.
-
-## Depedency
-
-This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.instance.id`.
-
-## Import
-
-`cloudamqp_privatelink_aws` can be imported using CloudAMQP internal identifier.
-
-`terraform import cloudamqp_privatelink_aws.privatelink <id>`

--- a/docs/resources/security_firewall.md
+++ b/docs/resources/security_firewall.md
@@ -9,7 +9,7 @@ description: |-
 
 This resource allows you to configure and manage firewall rules for the CloudAMQP instance.
 
-~> **WARNING:** All firewall rules applied with this resource will overwrite current firewall configuration. Make sure all wanted rules are present to not lose them.
+~> **WARNING:** Firewall rules applied with this resource will replace any existing firewall rules. Make sure all wanted rules are present to not lose them.
 
 Only available for dedicated subscription plans.
 

--- a/docs/resources/security_firewall.md
+++ b/docs/resources/security_firewall.md
@@ -7,7 +7,9 @@ description: |-
 
 # cloudamqp_security_firewall
 
-This resource allows you to configure and manage firewall rules for the CloudAMQP instance. Beware that all rules need to be present, since all older configurations will be overwritten.
+This resource allows you to configure and manage firewall rules for the CloudAMQP instance.
+
+~> **WARNING:** All firewall rules applied with this resource will overwrite current firewall configuration. Make sure all wanted rules are present to not lose them.
 
 Only available for dedicated subscription plans.
 

--- a/docs/resources/vpc_gcp_peering.md
+++ b/docs/resources/vpc_gcp_peering.md
@@ -9,7 +9,7 @@ description: |-
 
 This resouce creates a VPC peering configuration for the CloudAMQP instance. The configuration will connect to another VPC network hosted on Google Cloud Platform (GCP). See the [GCP documentation](https://cloud.google.com/vpc/docs/using-vpc-peering) for more information on how to create the VPC peering configuration.
 
-~> **Note:** Creating a VPC peering will trigger a firewall change that automatically add rule for the peered subnet.
+~> **Note:** Creating a VPC peering will automatically add firewall rules for the peered subnet.
 <details>
  <summary>
     <i>Default VPC peering firewall rule</i>

--- a/docs/resources/vpc_gcp_peering.md
+++ b/docs/resources/vpc_gcp_peering.md
@@ -9,9 +9,24 @@ description: |-
 
 This resouce creates a VPC peering configuration for the CloudAMQP instance. The configuration will connect to another VPC network hosted on Google Cloud Platform (GCP). See the [GCP documentation](https://cloud.google.com/vpc/docs/using-vpc-peering) for more information on how to create the VPC peering configuration.
 
-Only available for dedicated subscription plans.
+~> **Note:** Creating a VPC peering will trigger a firewall change that automatically add rule for the peered subnet.
+<details>
+ <summary>
+    <i>Default VPC peering firewall rule</i>
+  </summary>
+```hcl
+rules {
+  Description = "VPC peer request"
+  ip          = "<VPC peered subnet>"
+  ports       = []
+  services    = ["AMQP", "AMQPS", "HTTPS", "STREAM", "STREAM_SSL", "STOMP", "STOMPS", "MQTT", "MQTTS"]
+}
+```
+</details>
 
 Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html).
+
+Only available for dedicated subscription plans.
 
 ## Example Usage
 
@@ -34,12 +49,11 @@ resource "cloudamqp_instance" "instance" {
   plan   = "bunny-1"
   region = "google-compute-engine::europe-north1"
   tags   = ["terraform"]
-  rmq_version = "3.9.14"
   vpc_subnet = "10.40.72.0/24"
 }
 
 # VPC information
-data "cloudamqp_vpc_gcp info" "vpc_info" {
+data "cloudamqp_vpc_gcp_info" "vpc_info" {
   instance_id = cloudamqp_instance.instance.id
 }
 
@@ -78,28 +92,25 @@ resource "cloudamqp_instance" "instance" {
   plan   = "bunny-1"
   region = "google-compute-engine::europe-north1"
   tags   = ["terraform"]
-  rmq_version = "3.9.14"
   vpc_id = cloudamqp_vpc.vpc.id
 }
 
 # VPC information
-data "cloudamqp_vpc_gcp info" "vpc_info" {
+data "cloudamqp_vpc_gcp_info" "vpc_info" {
   vpc_id = cloudamqp_vpc.vpc.info
-  # vpc_id prefered over instance_id
+  # or
   # instance_id = cloudamqp_instance.instance.id
 }
 
 # VPC peering configuration
 resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
   vpc_id = cloudamqp_vpc.vpc.id
-  # vpc_id prefered over instance_id
+  # or
   # instance_id = cloudamqp_instance.instance.id
   peer_network_uri = "https://www.googleapis.com/compute/v1/projects/<PROJECT-NAME>/global/networks/<NETWORK-NAME>"
 }
 ```
 </details>
-
-*Note: Creating a VPC peering configuration will trigger a firewall change to automatically add rules for the peered subnet.*
 
 ## Argument Reference
 
@@ -166,6 +177,7 @@ resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
 resource "cloudamqp_security_firewall" "firewall_settings" {
   instance_id = cloudamqp_instance.instance.id
 
+  # Default VPC peering rule
   rules {
     ip          =  var.peer_subnet
     ports       = [15672]
@@ -206,6 +218,7 @@ resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
 resource "cloudamqp_security_firewall" "firewall_settings" {
   instance_id = cloudamqp_instance.instance.id
 
+  # Default VPC peering rule
   rules {
     ip          =  var.peer_subnet
     ports       = [15672]

--- a/docs/resources/vpc_gcp_peering.md
+++ b/docs/resources/vpc_gcp_peering.md
@@ -173,7 +173,6 @@ resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
 }
 
 # Firewall rules
-
 resource "cloudamqp_security_firewall" "firewall_settings" {
   instance_id = cloudamqp_instance.instance.id
 
@@ -227,9 +226,10 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
   }
 
   rules {
-    ip          = "192.168.0.0/24"
-    ports       = [4567, 4568]
-    services    = ["AMQP","AMQPS", "HTTPS"]
+    ip          = "0.0.0.0/0"
+    ports       = []
+    services    = ["HTTPS"]
+    description = "MGMT interface"
   }
 
   depends_on = [

--- a/docs/resources/vpc_peering.md
+++ b/docs/resources/vpc_peering.md
@@ -330,22 +330,28 @@ resource "cloudamqp_vpc_peering" "vpc_accept_peering" {
   timeout = 600
 }
 
-# Firewall rules
+# AWS - VPC subnet for peering requester
+data "aws_vpc" "requester_vpc" {
+  id = data.aws_subnet.subnet.vpc_id
+}
+
+# CloudAMQP - Managed firewall rules
 resource "cloudamqp_security_firewall" "firewall_settings" {
   instance_id = cloudamqp_instance.instance.id
 
   # Default VPC peering rule
   rules {
-    ip          =  data.aws_instance.aws_instance.subnet_id
+    ip          =  data.aws_vpc.requester_vpc.cidr_block
     ports       = [15672]
     services    = ["AMQP","AMQPS", "STREAM", "STREAM_SSL"]
     description = "VPC peering for <NETWORK>"
   }
 
   rules {
-    ip          = "192.168.0.0/24"
-    ports       = [4567, 4568]
-    services    = ["AMQP","AMQPS", "HTTPS"]
+    ip          = "0.0.0.0/0"
+    ports       = []
+    services    = ["HTTPS"]
+    description = "MGMT interface"
   }
 
   depends_on = [

--- a/docs/resources/vpc_peering.md
+++ b/docs/resources/vpc_peering.md
@@ -9,7 +9,7 @@ description: |-
 
 This resouce allows you to accepting VPC peering request from an AWS requester. This is only available for CloudAMQP instance hosted in AWS.
 
-~> **Note:** Creating a VPC peering will trigger a firewall change that automatically add rule for the peered subnet.
+~> **Note:** Creating a VPC peering will automatically add firewall rules for the peered subnet.
 <details>
  <summary>
     <i>Default VPC peering firewall rule</i>
@@ -253,7 +253,7 @@ Not possible to import this resource.
 ## Create VPC Peering with additional firewall rules
 
 To create a VPC peering configuration with additional firewall rules, it's required to chain the [cloudamqp_security_firewall](https://registry.terraform.io/providers/cloudamqp/cloudamqp/latest/docs/resources/security_firewall)
-resource to avoid parallel conflicting resource calls. This is done by adding dependency in the firewall resource to the VPC peering resource (`cloudamqp_vpc_peering.vpc_accept_peering`).
+resource to avoid parallel conflicting resource calls. You can do this by making the firewall resource depend on the VPC peering resource (`cloudamqp_vpc_peering.vpc_accept_peering`).
 
 Furthermore, since all firewall rules are overwritten, the otherwise automatically added rules for the VPC peering also needs to be added.
 


### PR DESCRIPTION
Clarify in the documentation when and how firewall rules are automatically set by our backend for PrivateLink and VPC Peering. Also add new examples on how to make `cloudamqp_security_firewall` resource manageable.

Resources that adds its own rules:
- PrivateLink (AWS, Azure)
- VPC Peering (AWS, Google)
