### PR TITLE
Enable faster instance destroy options in provider configuration

### DIFF
--- a/cloudamqp/provider.go
+++ b/cloudamqp/provider.go
@@ -9,7 +9,7 @@ import (
 )
 
 var version string
-var skipOnDestroy bool
+var enableFasterInstanceDestroy bool
 
 func Provider(v string) *schema.Provider {
 	version = v
@@ -28,11 +28,11 @@ func Provider(v string) *schema.Provider {
 				Optional:    true,
 				Description: "Base URL to CloudAMQP Customer website",
 			},
-			"skip_on_destroy": {
+			"enable_faster_instance_destroy": {
 				Type:        schema.TypeBool,
-				DefaultFunc: schema.EnvDefaultFunc("CLOUDAMQP_SKIP_ON_DESTROY", false),
+				DefaultFunc: schema.EnvDefaultFunc("CLOUDAMQP_ENABLE_FASTER_INSTANCE_DESTROY", false),
 				Optional:    true,
-				Description: "Skip destroying backend resources on 'terraform destroy'",
+				Description: "Skips destroying backend resources on 'terraform destroy'",
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
@@ -76,7 +76,7 @@ func Provider(v string) *schema.Provider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	skipOnDestroy = d.Get("skip_on_destroy").(bool)
+	enableFasterInstanceDestroy = d.Get("enable_faster_instance_destroy").(bool)
 	useragent := fmt.Sprintf("terraform-provider-cloudamqp_v%s", version)
 	log.Printf("[DEBUG] cloudamqp::provider::configure useragent: %v", useragent)
 	return api.New(d.Get("baseurl").(string), d.Get("apikey").(string), useragent), nil

--- a/cloudamqp/provider.go
+++ b/cloudamqp/provider.go
@@ -9,6 +9,7 @@ import (
 )
 
 var version string
+var skipOnDestroy bool
 
 func Provider(v string) *schema.Provider {
 	version = v
@@ -26,6 +27,12 @@ func Provider(v string) *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("CLOUDAMQP_BASEURL", "https://customer.cloudamqp.com"),
 				Optional:    true,
 				Description: "Base URL to CloudAMQP Customer website",
+			},
+			"skip_on_destroy": {
+				Type:        schema.TypeBool,
+				DefaultFunc: schema.EnvDefaultFunc("CLOUDAMQP_SKIP_ON_DESTROY", false),
+				Optional:    true,
+				Description: "Skip destroying backend resources on 'terraform destroy'",
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
@@ -69,6 +76,7 @@ func Provider(v string) *schema.Provider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	skipOnDestroy = d.Get("skip_on_destroy").(bool)
 	useragent := fmt.Sprintf("terraform-provider-cloudamqp_v%s", version)
 	log.Printf("[DEBUG] cloudamqp::provider::configure useragent: %v", useragent)
 	return api.New(d.Get("baseurl").(string), d.Get("apikey").(string), useragent), nil

--- a/cloudamqp/resource_cloudamqp_plugin.go
+++ b/cloudamqp/resource_cloudamqp_plugin.go
@@ -106,6 +106,10 @@ func resourcePluginUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePluginDelete(d *schema.ResourceData, meta interface{}) error {
+	if skipOnDestroy == true {
+		return nil
+	}
+
 	api := meta.(*api.API)
 	return api.DeletePlugin(d.Get("instance_id").(int), d.Get("name").(string))
 }

--- a/cloudamqp/resource_cloudamqp_plugin.go
+++ b/cloudamqp/resource_cloudamqp_plugin.go
@@ -107,7 +107,7 @@ func resourcePluginUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePluginDelete(d *schema.ResourceData, meta interface{}) error {
-	if skipOnDestroy == true {
+	if enableFasterInstanceDestroy == true {
 		log.Printf("[DEBUG] cloudamqp::resource::plugin::delete skip calling backend.")
 		return nil
 	}

--- a/cloudamqp/resource_cloudamqp_plugin.go
+++ b/cloudamqp/resource_cloudamqp_plugin.go
@@ -3,6 +3,7 @@ package cloudamqp
 import (
 	"errors"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
@@ -107,6 +108,7 @@ func resourcePluginUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourcePluginDelete(d *schema.ResourceData, meta interface{}) error {
 	if skipOnDestroy == true {
+		log.Printf("[DEBUG] cloudamqp::resource::plugin::delete skip calling backend.")
 		return nil
 	}
 

--- a/cloudamqp/resource_cloudamqp_plugin_community.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community.go
@@ -119,7 +119,7 @@ func resourcePluginCommunityUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourcePluginCommunityDelete(d *schema.ResourceData, meta interface{}) error {
-	if skipOnDestroy == true {
+	if enableFasterInstanceDestroy == true {
 		log.Printf("[DEBUG] cloudamqp::resource::plugin-community::delete skip calling backend.")
 		return nil
 	}

--- a/cloudamqp/resource_cloudamqp_plugin_community.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community.go
@@ -118,6 +118,10 @@ func resourcePluginCommunityUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourcePluginCommunityDelete(d *schema.ResourceData, meta interface{}) error {
+	if skipOnDestroy == true {
+		return nil
+	}
+
 	api := meta.(*api.API)
 	_, err := api.DisablePluginCommunity(d.Get("instance_id").(int), d.Get("name").(string))
 	return err

--- a/cloudamqp/resource_cloudamqp_plugin_community.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community.go
@@ -3,6 +3,7 @@ package cloudamqp
 import (
 	"errors"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
@@ -119,6 +120,7 @@ func resourcePluginCommunityUpdate(d *schema.ResourceData, meta interface{}) err
 
 func resourcePluginCommunityDelete(d *schema.ResourceData, meta interface{}) error {
 	if skipOnDestroy == true {
+		log.Printf("[DEBUG] cloudamqp::resource::plugin-community::delete skip calling backend.")
 		return nil
 	}
 

--- a/cloudamqp/resource_cloudamqp_security_firewall.go
+++ b/cloudamqp/resource_cloudamqp_security_firewall.go
@@ -170,6 +170,7 @@ func resourceSecurityFirewallUpdate(d *schema.ResourceData, meta interface{}) er
 
 func resourceSecurityFirewallDelete(d *schema.ResourceData, meta interface{}) error {
 	if skipOnDestroy == true {
+		log.Printf("[DEBUG] cloudamqp::resource::security_firewall::delete skip calling backend.")
 		return nil
 	}
 

--- a/cloudamqp/resource_cloudamqp_security_firewall.go
+++ b/cloudamqp/resource_cloudamqp_security_firewall.go
@@ -169,7 +169,7 @@ func resourceSecurityFirewallUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceSecurityFirewallDelete(d *schema.ResourceData, meta interface{}) error {
-	if skipOnDestroy == true {
+	if enableFasterInstanceDestroy == true {
 		log.Printf("[DEBUG] cloudamqp::resource::security_firewall::delete skip calling backend.")
 		return nil
 	}

--- a/cloudamqp/resource_cloudamqp_security_firewall.go
+++ b/cloudamqp/resource_cloudamqp_security_firewall.go
@@ -169,6 +169,10 @@ func resourceSecurityFirewallUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceSecurityFirewallDelete(d *schema.ResourceData, meta interface{}) error {
+	if skipOnDestroy == true {
+		return nil
+	}
+
 	api := meta.(*api.API)
 	log.Printf("[DEBUG] cloudamqp::resource::security_firewall::delete instance id: %v", d.Get("instance_id"))
 	data, err := api.DeleteFirewallSettings(d.Get("instance_id").(int), d.Get("sleep").(int), d.Get("timeout").(int))

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,6 +87,17 @@ The following arguments are supported in the `provider` block:
              The API key can also be read from the environment variable `CLOUDAMQP_APIKEY`.
 
 * `skip_on_destroy` (Optional) This argument can be set to skip delete behaviour for resources on
-                    `terraform destroy`. Each resource supporting this have a section on its respective page.
+                    `terraform destroy`. This will speed up the destroy action and are enabled for
+                    resources that don't need to be cleaned up when destroying `cloudamqp_instance`.
                     The argument can also be read from the environment variable `CLOUDAMQP_SKIP_ON_DESTROY`,
                     default set to false.
+
+___
+
+***List of resources supporting `skip_on_destroy`:***
+
+* cloudamqp_plugin
+* cloudamqp_plugin_community
+* cloudamqp_security_firewall
+
+More information can be found under `Skip on destroy` section on respective resource.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,8 @@ Use the navigation to the left to read about the available resources.
 ```hcl
 # Configure the CloudAMQP Provider
 provider "cloudamqp" {
-  apikey        = var.cloudamqp_customer_api_key
+  apikey          = var.cloudamqp_customer_api_key
+  skip_on_destroy = true // Optional configuration, can be left out.
 }
 
 # Create a new cloudamqp instance
@@ -27,7 +28,6 @@ resource "cloudamqp_instance" "instance" {
   plan          = "bunny-1"
   region        = "amazon-web-services::us-west-1"
   tags          = [ "terraform" ]
-  rmq_version   = "3.8.3"
 }
 
 # New recipient to receieve notifications
@@ -85,3 +85,8 @@ The following arguments are supported in the `provider` block:
              It can be sourced from login in to your CloudAMQP account and go to API access or go
              directly to [API Keys](https://customer.cloudamqp.com/apikeys).
              The API key can also be read from the environment variable `CLOUDAMQP_APIKEY`.
+
+* `skip_on_destroy` (Optional) This argument can be set to skip delete behaviour for resources on
+                    `terraform destroy`. Each resource supporting this have a section on its respective page.
+                    The argument can also be read from the environment variable `CLOUDAMQP_SKIP_ON_DESTROY`,
+                    default set to false.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ Use the navigation to the left to read about the available resources.
 # Configure the CloudAMQP Provider
 provider "cloudamqp" {
   apikey          = var.cloudamqp_customer_api_key
-  skip_on_destroy = true // Optional configuration, can be left out.
+  enable_faster_instance_destroy = true // Optional configuration, can be left out.
 }
 
 # Create a new cloudamqp instance
@@ -86,18 +86,18 @@ The following arguments are supported in the `provider` block:
              directly to [API Keys](https://customer.cloudamqp.com/apikeys).
              The API key can also be read from the environment variable `CLOUDAMQP_APIKEY`.
 
-* `skip_on_destroy` (Optional) This argument can be set to skip delete behaviour for resources on
-                    `terraform destroy`. This will speed up the destroy action and are enabled for
-                    resources that don't need to be cleaned up when destroying `cloudamqp_instance`.
-                    The argument can also be read from the environment variable `CLOUDAMQP_SKIP_ON_DESTROY`,
-                    default set to false.
+* `enable_faster_instance_destroy` - (Optional) This will speed up the destroy action for `cloudamqp_instance`
+                                      when running `terraform destroy`. It's done by skipping delete behaviour
+                                      for resources that don't need to be cleaned up when the servers are deleted.
+                                      The argument can also be read from the environment variable
+                                      `CLOUDAMQP_ENABLE_FASTER_INSTANCE_DESTROY`, default set to false.
 
 ___
 
-***List of resources supporting `skip_on_destroy`:***
+***List of resources affected by `enable_faster_instance_destroy`:***
 
 * cloudamqp_plugin
 * cloudamqp_plugin_community
 * cloudamqp_security_firewall
 
-More information can be found under `Skip on destroy` section on respective resource.
+More information can be found under `Enable faster instance destroy` section on respective resource.

--- a/docs/resources/plugin.md
+++ b/docs/resources/plugin.md
@@ -77,6 +77,36 @@ resource "cloudamqp_plugin" "rabbitmq_amqp1_0" {
 ```
 </details>
 
+<details>
+  <summary>
+    <b>
+      <i>Skip delete behaviour when running `terraform destroy` from v1.27.0
+    </b>
+  </summary>
+
+CloudAMQP Terraform provider [v1.27.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.27.0) support skipping delete behaviour for backend resources when running `terraform destroy`.
+
+```hcl
+# Configure the CloudAMQP Provider
+provider "cloudamqp" {
+  apikey          = var.cloudamqp_customer_api_key
+  skip_on_destroy = true
+}
+
+resource "cloudamqp_plugin" "rabbitmq_top" {
+  instance_id = cloudamqp_instance.instance.id
+  name = "rabbitmq_top"
+  enabled = true
+}
+
+resource "cloudamqp_plugin" "rabbitmq_amqp1_0" {
+  instance_id = cloudamqp_instance.instance.id
+  name = "rabbitmq_amqp1_0"
+  enabled = true
+}
+```
+</details>
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -104,3 +134,10 @@ If multiple plugins should be enable, create dependencies between the plugin res
 `cloudamqp_plugin` can be imported using the name argument of the resource together with CloudAMQP instance identifier. The name and identifier are CSV separated, see example below.
 
 `terraform import cloudamqp_plugin.rabbitmq_management rabbitmq_management,<instance_id>`
+
+## Skip on destroy
+
+When running `terraform destroy` this resource will try disable the managed plugin  before deleting
+`cloudamqp_instance`. This is not necessary since the servers will be deleted.
+
+Set `skip_on_destroy` to ***true*** in the provider configuration to skip this.

--- a/docs/resources/plugin.md
+++ b/docs/resources/plugin.md
@@ -20,8 +20,8 @@ Only available for dedicated subscription plans running ***RabbitMQ***.
 ```hcl
 resource "cloudamqp_plugin" "rabbitmq_top" {
   instance_id = cloudamqp_instance.instance.id
-  name = "rabbitmq_top"
-  enabled = true
+  name        = "rabbitmq_top"
+  enabled     = true
 }
 ```
 
@@ -37,14 +37,14 @@ Rabbit MQ can only change one plugin at a time. It will fail if multiple plugins
 ```hcl
 resource "cloudamqp_plugin" "rabbitmq_top" {
   instance_id = cloudamqp_instance.instance.id
-  name = "rabbitmq_top"
-  enabled = true
+  name        = "rabbitmq_top"
+  enabled     = true
 }
 
 resource "cloudamqp_plugin" "rabbitmq_amqp1_0" {
   instance_id = cloudamqp_instance.instance.id
-  name = "rabbitmq_amqp1_0"
-  enabled = true
+  name        = "rabbitmq_amqp1_0"
+  enabled     = true
 
   depends_on = [
     cloudamqp_plugin.rabbitmq_top
@@ -65,14 +65,14 @@ CloudAMQP Terraform provider [v1.19.2](https://github.com/cloudamqp/terraform-pr
 ```hcl
 resource "cloudamqp_plugin" "rabbitmq_top" {
   instance_id = cloudamqp_instance.instance.id
-  name = "rabbitmq_top"
-  enabled = true
+  name        = "rabbitmq_top"
+  enabled     = true
 }
 
 resource "cloudamqp_plugin" "rabbitmq_amqp1_0" {
   instance_id = cloudamqp_instance.instance.id
-  name = "rabbitmq_amqp1_0"
-  enabled = true
+  name        = "rabbitmq_amqp1_0"
+  enabled     = true
 }
 ```
 </details>
@@ -80,29 +80,36 @@ resource "cloudamqp_plugin" "rabbitmq_amqp1_0" {
 <details>
   <summary>
     <b>
-      <i>Skip delete behaviour when running `terraform destroy` from v1.27.0
+      <i>Faster instance destroy when running `terraform destroy` from v1.27.0
     </b>
   </summary>
 
-CloudAMQP Terraform provider [v1.27.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.27.0) support skipping delete behaviour for backend resources when running `terraform destroy`.
+CloudAMQP Terraform provider [v1.27.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.27.0) enables faster `cloudamqp_instance` destroy when running `terraform destroy`.
 
 ```hcl
 # Configure the CloudAMQP Provider
 provider "cloudamqp" {
-  apikey          = var.cloudamqp_customer_api_key
-  skip_on_destroy = true
+  apikey = var.cloudamqp_customer_api_key
+  enable_faster_instance_destroy = true
+}
+
+resource "cloudamqp_instance" "instance" {
+  name    = "terraform-cloudamqp-instance"
+  plan    = "bunny-1"
+  region  = "amazon-web-services::us-west-1"
+  tags    = ["terraform"]
 }
 
 resource "cloudamqp_plugin" "rabbitmq_top" {
   instance_id = cloudamqp_instance.instance.id
-  name = "rabbitmq_top"
-  enabled = true
+  name        = "rabbitmq_top"
+  enabled     = true
 }
 
 resource "cloudamqp_plugin" "rabbitmq_amqp1_0" {
   instance_id = cloudamqp_instance.instance.id
-  name = "rabbitmq_amqp1_0"
-  enabled = true
+  name        = "rabbitmq_amqp1_0"
+  enabled     = true
 }
 ```
 </details>
@@ -135,9 +142,8 @@ If multiple plugins should be enable, create dependencies between the plugin res
 
 `terraform import cloudamqp_plugin.rabbitmq_management rabbitmq_management,<instance_id>`
 
-## Skip on destroy
+## Enable faster instance destroy
 
-When running `terraform destroy` this resource will try disable the managed plugin  before deleting
-`cloudamqp_instance`. This is not necessary since the servers will be deleted.
+When running `terraform destroy` this resource will try to disable the managed plugin before deleting `cloudamqp_instance`. This is not necessary since the servers will be deleted.
 
-Set `skip_on_destroy` to ***true*** in the provider configuration to skip this.
+Set `enable_faster_instance_destroy` to ***true*** in the provider configuration to skip this.

--- a/docs/resources/plugin_community.md
+++ b/docs/resources/plugin_community.md
@@ -19,32 +19,39 @@ Only available for dedicated subscription plans running ***RabbitMQ***.
 
 ```hcl
 resource "cloudamqp_plugin_community" "rabbitmq_delayed_message_exchange" {
-  instance_id = cloudamqp_instance.instance_01.id
-  name = "rabbitmq_delayed_message_exchange"
-  enabled = true
+  instance_id = cloudamqp_instance.instance.id
+  name        = "rabbitmq_delayed_message_exchange"
+  enabled     = true
 }
 ```
 
 <details>
   <summary>
     <b>
-      <i>Skip delete behaviour when running `terraform destroy` from v1.27.0
+      <i>Faster instance destroy when running `terraform destroy` from v1.27.0
     </b>
   </summary>
 
-CloudAMQP Terraform provider [v1.27.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.27.0) support skipping delete behaviour for backend resources when running `terraform destroy`.
+CloudAMQP Terraform provider [v1.27.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.27.0) enables faster `cloudamqp_instance` destroy when running `terraform destroy`.
 
 ```hcl
 # Configure the CloudAMQP Provider
 provider "cloudamqp" {
-  apikey          = var.cloudamqp_customer_api_key
-  skip_on_destroy = true
+  apikey = var.cloudamqp_customer_api_key
+  enable_faster_instance_destroy = true
+}
+
+resource "cloudamqp_instance" "instance" {
+  name    = "terraform-cloudamqp-instance"
+  plan    = "bunny-1"
+  region  = "amazon-web-services::us-west-1"
+  tags    = ["terraform"]
 }
 
 resource "cloudamqp_plugin_community" "rabbitmq_delayed_message_exchange" {
-  instance_id = cloudamqp_instance.instance_01.id
-  name = "rabbitmq_delayed_message_exchange"
-  enabled = true
+  instance_id = cloudamqp_instance.instance.id
+  name        = "rabbitmq_delayed_message_exchange"
+  enabled     = true
 }
 ```
 </details>
@@ -73,8 +80,8 @@ This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.inst
 
 `terraform import cloudamqp_plugin.<resource_name> <plugin_name>,<instance_id>`
 
-## Skip on destroy
+## Enable faster instance destroy
 
-When running `terraform destroy`, this resource will try to uninstall the managed community plugin before deleting `cloudamqp_instance`. This is not necessary since the servers will be deleted.
+When running `terraform destroy` this resource will try to uninstall the managed community plugin before deleting `cloudamqp_instance`. This is not necessary since the servers will be deleted.
 
-Set `skip_on_destroy` provider configuration to skip this.
+Set `enable_faster_instance_destroy` to ***true***  in the provider configuration to skip this.

--- a/docs/resources/plugin_community.md
+++ b/docs/resources/plugin_community.md
@@ -25,6 +25,30 @@ resource "cloudamqp_plugin_community" "rabbitmq_delayed_message_exchange" {
 }
 ```
 
+<details>
+  <summary>
+    <b>
+      <i>Skip delete behaviour when running `terraform destroy` from v1.27.0
+    </b>
+  </summary>
+
+CloudAMQP Terraform provider [v1.27.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.27.0) support skipping delete behaviour for backend resources when running `terraform destroy`.
+
+```hcl
+# Configure the CloudAMQP Provider
+provider "cloudamqp" {
+  apikey          = var.cloudamqp_customer_api_key
+  skip_on_destroy = true
+}
+
+resource "cloudamqp_plugin_community" "rabbitmq_delayed_message_exchange" {
+  instance_id = cloudamqp_instance.instance_01.id
+  name = "rabbitmq_delayed_message_exchange"
+  enabled = true
+}
+```
+</details>
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -48,3 +72,9 @@ This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.inst
 `cloudamqp_plugin` can be imported using the name argument of the resource together with CloudAMQP instance identifier. The name and identifier are CSV separated, see example below.
 
 `terraform import cloudamqp_plugin.<resource_name> <plugin_name>,<instance_id>`
+
+## Skip on destroy
+
+When running `terraform destroy`, this resource will try to uninstall the managed community plugin before deleting `cloudamqp_instance`. This is not necessary since the servers will be deleted.
+
+Set `skip_on_destroy` provider configuration to skip this.

--- a/docs/resources/security_firewall.md
+++ b/docs/resources/security_firewall.md
@@ -43,17 +43,24 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
 <details>
   <summary>
     <b>
-      <i>Skip delete behaviour when running `terraform destroy` from v1.27.0
+      <i>Faster instance destroy when running `terraform destroy` from v1.27.0
     </b>
   </summary>
 
-CloudAMQP Terraform provider [v1.27.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.27.0) support skipping delete behaviour for backend resources when running `terraform destroy`.
+CloudAMQP Terraform provider [v1.27.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.27.0) enables faster `cloudamqp_instance` destroy when running `terraform destroy`.
 
 ```hcl
 # Configure the CloudAMQP Provider
 provider "cloudamqp" {
-  apikey          = var.cloudamqp_customer_api_key
-  skip_on_destroy = true
+  apikey = var.cloudamqp_customer_api_key
+  enable_faster_instance_destroy = true
+}
+
+resource "cloudamqp_instance" "instance" {
+  name    = "terraform-cloudamqp-instance"
+  plan    = "bunny-1"
+  region  = "amazon-web-services::us-west-1"
+  tags    = ["terraform"]
 }
 
 resource "cloudamqp_security_firewall" "firewall_settings" {
@@ -132,12 +139,12 @@ If used together with [VPC GPC peering](https://registry.terraform.io/providers/
 
 `terraform import cloudamqp_security_firewall.firewall <instance_id>`
 
-## Skip on destroy
+## Enable faster instance destroy
 
 When running `terraform destroy` this resource will try configure the firewall with default rules before deleting
 `cloudamqp_instance`. This is not necessary since the servers will be deleted.
 
-Set `skip_on_destroy` to ***true*** in the provider configuration to skip this.
+Set `enable_faster_instance_destroy` to ***true*** in the provider configuration to skip this.
 
 ## Known issues
 

--- a/docs/resources/security_firewall.md
+++ b/docs/resources/security_firewall.md
@@ -40,6 +40,40 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
 }
 ```
 
+<details>
+  <summary>
+    <b>
+      <i>Skip delete behaviour when running `terraform destroy` from v1.27.0
+    </b>
+  </summary>
+
+CloudAMQP Terraform provider [v1.27.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.27.0) support skipping delete behaviour for backend resources when running `terraform destroy`.
+
+```hcl
+# Configure the CloudAMQP Provider
+provider "cloudamqp" {
+  apikey          = var.cloudamqp_customer_api_key
+  skip_on_destroy = true
+}
+
+resource "cloudamqp_security_firewall" "firewall_settings" {
+  instance_id = cloudamqp_instance.instance.id
+
+  rules {
+    ip          = "192.168.0.0/24"
+    ports       = [4567, 4568]
+    services    = ["AMQP","AMQPS", "HTTPS"]
+  }
+
+  rules {
+    ip          = "10.56.72.0/24"
+    ports       = []
+    services    = ["AMQP","AMQPS", "HTTPS"]
+  }
+}
+```
+</details>
+
 ## Argument Reference
 
 Top level argument reference
@@ -97,6 +131,13 @@ If used together with [VPC GPC peering](https://registry.terraform.io/providers/
 `cloudamqp_security_firewall` can be imported using CloudAMQP instance identifier.
 
 `terraform import cloudamqp_security_firewall.firewall <instance_id>`
+
+## Skip on destroy
+
+When running `terraform destroy` this resource will try configure the firewall with default rules before deleting
+`cloudamqp_instance`. This is not necessary since the servers will be deleted.
+
+Set `skip_on_destroy` to ***true*** in the provider configuration to skip this.
 
 ## Known issues
 


### PR DESCRIPTION
When tearing down the resource block, the `cloudamqp_instance` and underlying servers will be deleted. If resources such as plugins also are present, they will use their delete behaviour (disable plugins in this case). This action is not necessary since the servers are deleted. 

We haven't found any way to determine if the whole resource block should be destroyed or just a single resource. Makes the provider use the delete behaviour for resp. resource to our backend in both cases.

Refrence, part of: [Trello](https://trello.com/c/88gkIFgt)

To speed this up, there is now a configurable global options in the provider configuration called `enable_faster_instance_destroy`. Makes certain resources (see below) skip the delete behaviour against our backend and just remove them from the state. This can default be left out and will be set to false.

Resources affected by this PR are:
- cloudamqp_plugin
- cloudamqp_plugin_community
- cloudamqp_security_firewall