### PR TITLE
Add ForceNew to resources with cloudamqp_instance dependency

### DIFF
--- a/cloudamqp/resource_cloudamqp_alarm.go
+++ b/cloudamqp/resource_cloudamqp_alarm.go
@@ -25,6 +25,7 @@ func resourceAlarm() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeInt,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Instance identifier",
 			},
 			"type": {

--- a/cloudamqp/resource_cloudamqp_custom_domain.go
+++ b/cloudamqp/resource_cloudamqp_custom_domain.go
@@ -22,6 +22,7 @@ func resourceCustomDomain() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeInt,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Instance identifier",
 			},
 			"hostname": {

--- a/cloudamqp/resource_cloudamqp_integration_log.go
+++ b/cloudamqp/resource_cloudamqp_integration_log.go
@@ -26,6 +26,7 @@ func resourceIntegrationLog() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeInt,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Instance identifier used to make proxy calls",
 			},
 			"name": {

--- a/cloudamqp/resource_cloudamqp_integration_metric.go
+++ b/cloudamqp/resource_cloudamqp_integration_metric.go
@@ -26,6 +26,7 @@ func resourceIntegrationMetric() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeInt,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Instance identifier",
 			},
 			"name": {

--- a/cloudamqp/resource_cloudamqp_node_actions.go
+++ b/cloudamqp/resource_cloudamqp_node_actions.go
@@ -16,7 +16,6 @@ func resourceNodeAction() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeInt,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Instance identifier",
 			},
 			"node_name": {

--- a/cloudamqp/resource_cloudamqp_node_actions.go
+++ b/cloudamqp/resource_cloudamqp_node_actions.go
@@ -16,6 +16,7 @@ func resourceNodeAction() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeInt,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Instance identifier",
 			},
 			"node_name": {

--- a/cloudamqp/resource_cloudamqp_notification.go
+++ b/cloudamqp/resource_cloudamqp_notification.go
@@ -24,6 +24,7 @@ func resourceNotification() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeInt,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Instance identifier",
 			},
 			"type": {

--- a/cloudamqp/resource_cloudamqp_plugin.go
+++ b/cloudamqp/resource_cloudamqp_plugin.go
@@ -24,6 +24,7 @@ func resourcePlugin() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeInt,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Instance identifier",
 			},
 			"name": {

--- a/cloudamqp/resource_cloudamqp_plugin_community.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community.go
@@ -24,6 +24,7 @@ func resourcePluginCommunity() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeInt,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Instance identifier",
 			},
 			"name": {

--- a/cloudamqp/resource_cloudamqp_privatelink_aws.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_aws.go
@@ -23,6 +23,7 @@ func resourcePrivateLinkAws() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeInt,
 				Required:    true,
+				ForceNew:    true,
 				Description: "The CloudAMQP instance identifier",
 			},
 			"status": {

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -23,6 +23,7 @@ func resourcePrivateLinkAzure() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeInt,
 				Required:    true,
+				ForceNew:    true,
 				Description: "The CloudAMQP instance identifier",
 			},
 			"status": {

--- a/cloudamqp/resource_cloudamqp_rabbitmq_configuration.go
+++ b/cloudamqp/resource_cloudamqp_rabbitmq_configuration.go
@@ -24,6 +24,7 @@ func resourceRabbitMqConfiguration() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeInt,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Instance identifier",
 			},
 			"heartbeat": {

--- a/cloudamqp/resource_cloudamqp_security_firewall.go
+++ b/cloudamqp/resource_cloudamqp_security_firewall.go
@@ -29,6 +29,7 @@ func resourceSecurityFirewall() *schema.Resource {
 			"instance_id": {
 				Type:        schema.TypeInt,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Instance identifier",
 			},
 			"rules": {


### PR DESCRIPTION
For a resource with dependency to another resource. The dependant resource requires to have ForceNew behaviour added. Otherwise when replacing the top resource, the other will just update the resource with the new dependency attribute and not replace it. 

Add ForceNew behaviour to resources missing these against `cloudamqp_instance`.

This was noticed when `cloudamqp_plugin_community` resource just got updated instead of replaced.
