### PR TITLE
Configurable wait on GCP Peering status

### DIFF
--- a/cloudamqp/resource_cloudamqp_vpc_gcp_peering.go
+++ b/cloudamqp/resource_cloudamqp_vpc_gcp_peering.go
@@ -57,10 +57,14 @@ func resourceVpcGcpPeering() *schema.Resource {
 
 func resourceCreateVpcGcpPeering(d *schema.ResourceData, meta interface{}) error {
 	var (
-		waitOnStatus = d.Get("wait_on_peering_status").(bool)
 		api          = meta.(*api.API)
 		keys         = []string{"peer_network_uri"}
 		params       = make(map[string]interface{})
+		instanceID   = d.Get("instance_id").(int)
+		vpcID        = d.Get("vpc_id").(string)
+		waitOnStatus = d.Get("wait_on_peering_status").(bool)
+		data         map[string]interface{}
+		err          = errors.New("")
 	)
 
 	for _, k := range keys {
@@ -69,16 +73,14 @@ func resourceCreateVpcGcpPeering(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	log.Printf("[DEBUG] cloudamqp::vpc_gcp_peering::create instance_id: %v, vpc_id: %v",
-		d.Get("instance_id"), d.Get("vpc_id"))
-	data := make(map[string]interface{})
-	err := errors.New("")
-	if d.Get("instance_id") == 0 && d.Get("vpc_id") == nil {
+	log.Printf("[DEBUG] cloudamqp::vpc_gcp_peering::create instance_id: %d, vpc_id: %s, "+
+		"waitOnStatus: %v", instanceID, vpcID, waitOnStatus)
+	if instanceID == 0 && vpcID == "" {
 		return errors.New("you need to specify either instance_id or vpc_id")
-	} else if d.Get("instance_id") != 0 {
-		data, err = api.RequestVpcGcpPeering(d.Get("instance_id").(int), params, waitOnStatus)
-	} else if d.Get("vpc_id") != nil {
-		data, err = api.RequestVpcGcpPeeringWithVpcId(d.Get("vpc_id").(string), params, waitOnStatus)
+	} else if instanceID != 0 {
+		data, err = api.RequestVpcGcpPeering(instanceID, params, waitOnStatus)
+	} else if vpcID != "" {
+		data, err = api.RequestVpcGcpPeeringWithVpcId(vpcID, params, waitOnStatus)
 	}
 
 	if err != nil {
@@ -95,10 +97,12 @@ func resourceCreateVpcGcpPeering(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceReadVpcGcpPeering(d *schema.ResourceData, meta interface{}) error {
-	api := meta.(*api.API)
+	var (
+		api  = meta.(*api.API)
+		data map[string]interface{}
+		err  = errors.New("")
+	)
 
-	data := make(map[string]interface{})
-	err := errors.New("")
 	if d.Get("instance_id") == 0 && d.Get("vpc_id") == nil {
 		return errors.New("you need to specify either instance_id or vpc_id")
 	} else if d.Get("instance_id") != 0 {

--- a/docs/resources/vpc_gcp_peering.md
+++ b/docs/resources/vpc_gcp_peering.md
@@ -18,8 +18,8 @@ This resouce creates a VPC peering configuration for the CloudAMQP instance. The
 rules {
   Description = "VPC peer request"
   ip          = "<VPC peered subnet>"
-  ports       = []
-  services    = ["AMQP", "AMQPS", "HTTPS", "STREAM", "STREAM_SSL", "STOMP", "STOMPS", "MQTT", "MQTTS"]
+  ports       = [15672]
+  services    = ["AMQP", "AMQPS", "HTTPS", "STREAM", "STREAM_SSL"]
 }
 ```
 </details>
@@ -112,6 +112,32 @@ resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
 ```
 </details>
 
+<details>
+  <summary>
+    <b>
+      <i>VPC peering post v1.28.0, wait_on_peering_status </i>
+    </b>
+  </summary>
+
+Default peering request, no need to set `wait_on_peering_status`. It's default set to false and will not wait on peering status.
+```hcl
+resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
+  vpc_id = cloudamqp_vpc.vpc.id
+  peer_network_uri = "https://www.googleapis.com/compute/v1/projects/<PROJECT-NAME>/global/networks/<NETWORK-NAME>"
+}
+```
+
+Peering request and waiting for peering status.
+```hcl
+resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
+  vpc_id = cloudamqp_vpc.vpc.id
+  wait_on_peering_status = true
+  peer_network_uri = "https://www.googleapis.com/compute/v1/projects/<PROJECT-NAME>/global/networks/<NETWORK-NAME>"
+}
+```
+
+</details>
+
 ## Argument Reference
 
  *Note: this resource require either `instance_id` or `vpc_id` from v1.16.0*
@@ -125,6 +151,10 @@ resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
  ***Note: Added as optional in version v1.16.0, will be required in next major version (v2.0)***
 
 * `peer_network_uri`- (Required) Network uri of the VPC network to which you will peer with.
+
+* `wait_on_peering_status` - (Optional) Should the resource wait until the peering is connected.
+
+ ***Note: Added as optional in version v1.28.0. Default set to false and will not wait until the peering is done from both VPCs***
 
 ## Attributes Reference
 

--- a/docs/resources/vpc_gcp_peering.md
+++ b/docs/resources/vpc_gcp_peering.md
@@ -152,7 +152,7 @@ resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
 
 * `peer_network_uri`- (Required) Network uri of the VPC network to which you will peer with.
 
-* `wait_on_peering_status` - (Optional) Should the resource wait until the peering is connected.
+* `wait_on_peering_status` - (Optional) Makes the resource wait until the peering is connected.
 
  ***Note: Added as optional in version v1.28.0. Default set to false and will not wait until the peering is done from both VPCs***
 


### PR DESCRIPTION
Feature request: #226 to be able to configure if the GCP peering resource should wait on the status or not. Adds a new argument `wait_on_peering_status`, default set to false and will not wait until status has changed.

Requires: https://github.com/84codes/go-api/pull/38

Can be tested with two CloudAMQP instances i hosted in GCE. Need network uri from one of them to be able to run peering from the other.

```hcl
locals {
  peer_network_uri = "<uri>"
}

resource "cloudamqp_vpc" "vpc" {
  name = "terraform-vpc-peering"
  region = "google-compute-engine::europe-north1"
  subnet = "10.56.72.0/24"
  tags = []
}

resource "cloudamqp_instance" "instance" {
  name   = "terraform-vpc-peering"
  plan   = "bunny-1"
  region = "google-compute-engine::europe-north1"
  tags   = ["google"]
  vpc_id = cloudamqp_vpc.vpc.id
}

data "cloudamqp_vpc_gcp_info" "vpc_info" {
  vpc_id = cloudamqp_vpc.vpc.id
}

resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
  vpc_id = cloudamqp_vpc.vpc.id
  peer_network_uri = local.peer_network_uri
}
``` 

