### PR TITLE
Remove default RMQ version request when version left out

### DIFF
--- a/cloudamqp/resource_cloudamqp_instance.go
+++ b/cloudamqp/resource_cloudamqp_instance.go
@@ -178,9 +178,6 @@ func resourceCreate(d *schema.ResourceData, meta interface{}) error {
 	for _, k := range keys {
 		if v := d.Get(k); v != nil && v != "" {
 			params[k] = v
-		} else if k == "rmq_version" {
-			version, _ := api.DefaultRmqVersion()
-			params[k] = version["default_rmq_version"]
 		} else if k == "no_default_alarms" {
 			params[k] = false
 		}


### PR DESCRIPTION
When the version is not included in the configuration to create a new `cloudamqp_instance`. We currently make a request to our API backend to fetch the latest RMQ version. This request is not necessary since our backend use the latest version already when no explicit version is give. Noticed from: https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/236

Remove the default version request and skip adding this version to create instance params.

Note: LavinMQ don't support picking version and will always use the latest.
