### PR TITLE
Add configurable sleep/timeout retries for plugin resources

### DIFF
--- a/cloudamqp/data_source_cloudamqp_plugins.go
+++ b/cloudamqp/data_source_cloudamqp_plugins.go
@@ -39,6 +39,18 @@ func dataSourcePlugins() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						"sleep": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     10,
+							Description: "Configurable sleep time in seconds between retries for plugins",
+						},
+						"timeout": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     1800,
+							Description: "Configurable timeout time in seconds for plugins",
+						},
 					},
 				},
 			},
@@ -47,10 +59,16 @@ func dataSourcePlugins() *schema.Resource {
 }
 
 func dataSourcePluginsRead(d *schema.ResourceData, meta interface{}) error {
-	api := meta.(*api.API)
-	log.Printf("[DEBUG] cloudamqp::data_source::plugins::read instance id: %v", d.Get("instance_id"))
-	data, err := api.ReadPlugins(d.Get("instance_id").(int))
-	d.SetId(fmt.Sprintf("%v.plugins", d.Get("instance_id").(int)))
+	var (
+		api        = meta.(*api.API)
+		instanceID = d.Get("instance_id").(int)
+		sleep      = d.Get("sleep").(int)
+		timeout    = d.Get("timeout").(int)
+	)
+
+	log.Printf("[DEBUG] cloudamqp::data_source::plugins::read instance id: %v", instanceID)
+	data, err := api.ListPlugins(instanceID, sleep, timeout)
+	d.SetId(fmt.Sprintf("%v.plugins", instanceID))
 	if err != nil {
 		return err
 	}

--- a/cloudamqp/data_source_cloudamqp_plugins_community.go
+++ b/cloudamqp/data_source_cloudamqp_plugins_community.go
@@ -35,6 +35,18 @@ func dataSourcePluginsCommunity() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"sleep": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     10,
+							Description: "Configurable sleep time in seconds between retries for plugins",
+						},
+						"timeout": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     1800,
+							Description: "Configurable timeout time in seconds for plugins",
+						},
 					},
 				},
 			},
@@ -43,10 +55,16 @@ func dataSourcePluginsCommunity() *schema.Resource {
 }
 
 func dataSourcePluginsCommunityRead(d *schema.ResourceData, meta interface{}) error {
-	api := meta.(*api.API)
-	log.Printf("[DEBUG] cloudamqp::data_source::plugin_comminity::read instance id: %v", d.Get("instance_id"))
-	data, err := api.ReadPluginsCommunity(d.Get("instance_id").(int))
-	d.SetId(fmt.Sprintf("%v.plugins_community", d.Get("instance_id").(int)))
+	var (
+		api        = meta.(*api.API)
+		instanceID = d.Get("instance_id").(int)
+		sleep      = d.Get("sleep").(int)
+		timeout    = d.Get("timeout").(int)
+	)
+
+	log.Printf("[DEBUG] cloudamqp::data_source::plugin_comminity::read instance id: %v", instanceID)
+	data, err := api.ListPluginsCommunity(instanceID, sleep, timeout)
+	d.SetId(fmt.Sprintf("%v.plugins_community", instanceID))
 	if err != nil {
 		return err
 	}

--- a/cloudamqp/resource_cloudamqp_plugin.go
+++ b/cloudamqp/resource_cloudamqp_plugin.go
@@ -89,7 +89,7 @@ func resourcePluginRead(d *schema.ResourceData, meta interface{}) error {
 		timeout    = d.Get("timeout").(int)
 	)
 
-	// Support for importing resources
+	// Support for importing resource
 	if strings.Contains(d.Id(), ",") {
 		s := strings.Split(d.Id(), ",")
 		d.SetId(s[0])

--- a/cloudamqp/resource_cloudamqp_plugin_community.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community.go
@@ -47,6 +47,18 @@ func resourcePluginCommunity() *schema.Resource {
 				Computed:    true,
 				Description: "Required version of RabbitMQ",
 			},
+			"sleep": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     10,
+				Description: "Configurable sleep time in seconds between retries for plugins",
+			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     1800,
+				Description: "Configurable timeout time in seconds for plugins",
+			},
 		},
 	}
 }

--- a/cloudamqp/resource_cloudamqp_plugin_community.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community.go
@@ -105,10 +105,14 @@ func resourcePluginCommunityRead(d *schema.ResourceData, meta interface{}) error
 	// Support for importing resource
 	if strings.Contains(d.Id(), ",") {
 		s := strings.Split(d.Id(), ",")
-		d.SetId(s[0])
-		d.Set("name", s[0])
+		name = s[0]
+		d.SetId(name)
+		d.Set("name", name)
 		instanceID, _ = strconv.Atoi(s[1])
 		d.Set("instance_id", instanceID)
+		// Set default values for optional arguments
+		d.Set("sleep", 10)
+		d.Set("timeout", 1800)
 	}
 	if instanceID == 0 {
 		return errors.New("missing instance identifier: {resource_id},{instance_id}")
@@ -133,19 +137,14 @@ func resourcePluginCommunityRead(d *schema.ResourceData, meta interface{}) error
 func resourcePluginCommunityUpdate(d *schema.ResourceData, meta interface{}) error {
 	var (
 		api        = meta.(*api.API)
-		keys       = []string{"name", "enabled"}
-		params     map[string]interface{}
 		instanceID = d.Get("instance_id").(int)
+		name       = d.Get("name").(string)
+		enabled    = d.Get("enabled").(bool)
 		sleep      = d.Get("sleep").(int)
 		timeout    = d.Get("timeout").(int)
 	)
 
-	for _, k := range keys {
-		if v := d.Get(k); v != nil {
-			params[k] = v
-		}
-	}
-	_, err := api.UpdatePluginCommunity(instanceID, params, sleep, timeout)
+	_, err := api.UpdatePluginCommunity(instanceID, name, enabled, sleep, timeout)
 	if err != nil {
 		return err
 	}

--- a/cloudamqp/resource_cloudamqp_plugin_test.go
+++ b/cloudamqp/resource_cloudamqp_plugin_test.go
@@ -62,7 +62,7 @@ func testAccCheckPluginEnabled(instanceName, resourceName string) resource.TestC
 		instanceID, _ := strconv.Atoi(rs.Primary.ID)
 
 		api := testAccProvider.Meta().(*api.API)
-		data, err := api.ReadPlugin(instanceID, pluginName)
+		data, err := api.ReadPlugin(instanceID, pluginName, 10, 1800)
 		if err != nil {
 			return fmt.Errorf("Error fetching item with resource %s. %s", resourceName, err)
 		}
@@ -96,7 +96,7 @@ func testAccCheckPluginDisable(instanceName, resourceName string) resource.TestC
 		}
 		instanceID, _ := strconv.Atoi(rs.Primary.ID)
 
-		data, err := api.ReadPlugin(instanceID, pluginName)
+		data, err := api.ReadPlugin(instanceID, pluginName, 10, 1800)
 		if err != nil {
 			return fmt.Errorf("Failed to retrieve plugin %v", err)
 		}

--- a/docs/resources/plugin.md
+++ b/docs/resources/plugin.md
@@ -11,10 +11,6 @@ This resource allows you to enable or disable Rabbit MQ plugins.
 
 Only available for dedicated subscription plans running ***RabbitMQ***.
 
-~> CloudAMQP Terraform provider [v1.10.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.10.0) there is support for multiple retries when requesting information about plugins. This was introduced to avoid `ReadPlugin error 400: Timeout talking to backend`.
-
-~> CloudAMQP Terraform provider [v1.19.2](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.19.2) support asynchronous request for plugin/community actions. Solve issues reported when enable multiple plugins.
-
 ## Example Usage
 
 ```hcl
@@ -121,6 +117,10 @@ The following arguments are supported:
 * `instance_id` - (Required) The CloudAMQP instance ID.
 * `name`        - (Required) The name of the Rabbit MQ plugin.
 * `enabled`     - (Required) Enable or disable the plugins.
+* `sleep` - (Optional) Configurable sleep time (seconds) for retries when requesting information
+about plugins. Default set to 10 seconds.
+* `timeout` - (Optional) - Configurable timeout time (seconds) for retries when requesting
+information about plugins. Default set to 1800 seconds.
 
 ## Attributes Reference
 
@@ -154,6 +154,24 @@ Plugins that is not needed to be managed by the provider since they will always 
 
 ## Enable faster instance destroy
 
-When running `terraform destroy` this resource will try to disable the managed plugin before deleting `cloudamqp_instance`. This is not necessary since the servers will be deleted.
+When running `terraform destroy` this resource will try to disable the managed plugin before
+deleting `cloudamqp_instance`. This is not necessary since the servers will be deleted.
 
 Set `enable_faster_instance_destroy` to ***true*** in the provider configuration to skip this.
+
+## Changelog
+
+List of changes made to this resource for different versions.
+
+[v1.29.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.29.0) configurable
+sleep and timeout for multiple retries when requesting information about plugins.
+
+[v1.27.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.27.0) enables
+faster `cloudamqp_instance` destroy when running `terraform destroy`.
+
+[v1.19.2](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.19.2) support
+asynchronous request for plugin/community actions. Solve issues reported when enable multiple plugins.
+
+[v1.10.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.10.0) support
+for multiple retries when requesting information about plugins.
+This was introduced to avoid `ReadPlugin error 400: Timeout talking to backend`.

--- a/docs/resources/plugin_community.md
+++ b/docs/resources/plugin_community.md
@@ -7,13 +7,10 @@ description: |-
 
 # cloudamqp_plugin_community
 
-This resource allows you to install or uninstall community plugins. Once installed the plugin will be available in `cloudamqp_plugin`.
+This resource allows you to install or uninstall community plugins. Once installed the plugin will
+be available in `cloudamqp_plugin`.
 
 Only available for dedicated subscription plans running ***RabbitMQ***.
-
-~> CloudAMQP Terraform provider [v1.11.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.11.0) there is support for multiple retries when requesting information about community plugins. This was introduced to avoid `ReadPluginCommunity error 400: Timeout talking to backend`.
-
-~> CloudAMQP Terraform provider [v1.19.2](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.19.2) support asynchronous request for plugin/community actions. Solve issues reported when enable multiple plugins.
 
 ## Example Usage
 
@@ -63,6 +60,10 @@ The following arguments are supported:
 * `instance_id` - (Required) The CloudAMQP instance ID.
 * `name`        - (Required) The name of the Rabbit MQ community plugin.
 * `enabled`     - (Required) Enable or disable the plugins.
+* `sleep` - (Optional) Configurable sleep time (seconds) for retries when requesting information
+about community plugins. Default set to 10 seconds.
+* `timeout` - (Optional) - Configurable timeout time (seconds) for retries when requesting
+information about community plugins. Default set to 1800 seconds.
 
 ## Attributes Reference
 
@@ -76,12 +77,32 @@ This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.inst
 
 ## Import
 
-`cloudamqp_plugin` can be imported using the name argument of the resource together with CloudAMQP instance identifier. The name and identifier are CSV separated, see example below.
+`cloudamqp_plugin` can be imported using the name argument of the resource together with CloudAMQP
+instance identifier. The name and identifier are CSV separated, see example below.
 
 `terraform import cloudamqp_plugin.<resource_name> <plugin_name>,<instance_id>`
 
 ## Enable faster instance destroy
 
-When running `terraform destroy` this resource will try to uninstall the managed community plugin before deleting `cloudamqp_instance`. This is not necessary since the servers will be deleted.
+When running `terraform destroy` this resource will try to uninstall the managed community plugin
+before deleting `cloudamqp_instance`. This is not necessary since the servers will be deleted.
 
 Set `enable_faster_instance_destroy` to ***true***  in the provider configuration to skip this.
+
+## Changelog
+
+List of changes made to this resource for different versions.
+
+[v1.29.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.29.0)
+configurable sleep and timeout for multiple retries when requesting information about community plugins.
+
+[v1.27.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.27.0) enables
+faster `cloudamqp_instance` destroy when running `terraform destroy`.
+
+[v1.19.2](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.19.2) support
+asynchronous request for plugin/community actions. Solve issues reported when installing multiple
+community plugins.
+
+[v1.11.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.11.0) there is
+support for multiple retries when requesting information about community plugins.
+This was introduced to avoid `ReadPluginCommunity error 400: Timeout talking to backend`.


### PR DESCRIPTION
### WHY are these changes introduced?

Increased reports about `Error: ReadWithRetry failed, status: 400, message: map[error:Timeout talking to backend]` when reading plugin information. For both official and community based plugins.

[Trello](https://trello.com/c/lzHPFjrj)
Requires: https://github.com/84codes/go-api/pull/40
Latter part of: https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/232

### WHAT is this pull request doing?

- Add sleep/timeout as new arguments with default values
- Make the retires configurable
- Clean up code
- Update documentation

### HOW can this pull request be tested?

Manual tested with new go-api updates. Both official and community plugin resources

- Enable/install plugin
- Disable plugin
- Enable plugin
- rm state plugin
- Import plugin
- Delete/uninstall plugin