### PR TITLE
Add configurable retry when reading PrivateLink information

### DIFF
--- a/cloudamqp/resource_cloudamqp_privatelink_aws.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_aws.go
@@ -55,13 +55,13 @@ func resourcePrivateLinkAws() *schema.Resource {
 			"sleep": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     60,
+				Default:     10,
 				Description: "Configurable sleep in seconds between retries when enable PrivateLink",
 			},
 			"timeout": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     3600,
+				Default:     1800,
 				Description: "Configurable timeout in seconds when enable PrivateLink",
 			},
 		},

--- a/cloudamqp/resource_cloudamqp_privatelink_aws.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_aws.go
@@ -102,9 +102,11 @@ func resourcePrivateLinkAwsRead(d *schema.ResourceData, meta interface{}) error 
 	var (
 		api           = meta.(*api.API)
 		instanceID, _ = strconv.Atoi(d.Id()) // Uses d.Id() to allow import
+		sleep         = d.Get("sleep").(int)
+		timeout       = d.Get("timeout").(int)
 	)
 
-	data, err := api.ReadPrivatelink(instanceID)
+	data, err := api.ReadPrivatelink(instanceID, sleep, timeout)
 	if err != nil {
 		return err
 	}

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -99,9 +99,11 @@ func resourcePrivateLinkAzureRead(d *schema.ResourceData, meta interface{}) erro
 	var (
 		api           = meta.(*api.API)
 		instanceID, _ = strconv.Atoi(d.Id()) // Uses d.Id() to allow import
+		sleep         = d.Get("sleep").(int)
+		timeout       = d.Get("timeout").(int)
 	)
 
-	data, err := api.ReadPrivatelink(instanceID)
+	data, err := api.ReadPrivatelink(instanceID, sleep, timeout)
 	if err != nil {
 		return err
 	}

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -52,13 +52,13 @@ func resourcePrivateLinkAzure() *schema.Resource {
 			"sleep": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     60,
+				Default:     10,
 				Description: "Configurable sleep in seconds between retries when enable PrivateLink",
 			},
 			"timeout": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     3600,
+				Default:     1800,
 				Description: "Configurable timeout in seconds when enable PrivateLink",
 			},
 		},

--- a/docs/resources/privatelink_aws.md
+++ b/docs/resources/privatelink_aws.md
@@ -102,9 +102,9 @@ resource "cloudamqp_privatelink_aws" "privatelink" {
 * `instance_id` - (Required) The CloudAMQP instance identifier.
 * `allowed_principals` - (Required) Allowed principals to access the endpoint service.
 * `sleep` - (Optional) Configurable sleep time (seconds) when enable PrivateLink.
-  Default set to 10 seconds.
+  Default set to 10 seconds. *Available from v1.29.0*
 * `timeout` - (Optional) Configurable timeout time (seconds) when enable PrivateLink.
-  Default set to 1800 seconds.
+  Default set to 1800 seconds. *Available from v1.29.0*
 
 Allowed principals format: <br>
 `arn:aws:iam::aws-account-id:root` <br>
@@ -196,10 +196,3 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
 ```
 
 </details>
-
-## Changelog
-
-List of changes made to this resource for different versions.
-
-[v1.29.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.29.0) added
-configurable retries when reading PrivateLink information.

--- a/docs/resources/privatelink_aws.md
+++ b/docs/resources/privatelink_aws.md
@@ -15,6 +15,7 @@ PrivateLink, a new VPC will be created with subnet `10.52.72.0/24`.
  <summary>
     <i>Default PrivateLink firewall rule</i>
   </summary>
+
 ```hcl
 rules {
   Description = "PrivateLink setup"
@@ -23,6 +24,7 @@ rules {
   services    = ["AMQP", "AMQPS", "HTTPS", "STREAM", "STREAM_SSL", "STOMP", "STOMPS", "MQTT", "MQTTS"]
 }
 ```
+
 </details>
 
 Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html)
@@ -58,6 +60,7 @@ resource "cloudamqp_privatelink_aws" "privatelink" {
   ]
 }
 ```
+
 </details>
 
 <details>
@@ -91,6 +94,7 @@ resource "cloudamqp_privatelink_aws" "privatelink" {
   ]
 }
 ```
+
 </details>
 
 ## Argument Reference
@@ -98,9 +102,9 @@ resource "cloudamqp_privatelink_aws" "privatelink" {
 * `instance_id` - (Required) The CloudAMQP instance identifier.
 * `allowed_principals` - (Required) Allowed principals to access the endpoint service.
 * `sleep` - (Optional) Configurable sleep time (seconds) when enable PrivateLink.
-  Default set to 60 seconds.
+  Default set to 10 seconds.
 * `timeout` - (Optional) Configurable timeout time (seconds) when enable PrivateLink.
-  Default set to 3600 seconds.
+  Default set to 1800 seconds.
 
 Allowed principals format: <br>
 `arn:aws:iam::aws-account-id:root` <br>
@@ -190,4 +194,12 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
    ]
 }
 ```
+
 </details>
+
+## Changelog
+
+List of changes made to this resource for different versions.
+
+[v1.29.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.29.0) added
+configurable retries when reading PrivateLink information.

--- a/docs/resources/privatelink_azure.md
+++ b/docs/resources/privatelink_azure.md
@@ -103,9 +103,9 @@ resource "cloudamqp_privatelink_azure" "privatelink" {
 * `approved_subscriptions` - (Required) Approved subscriptions to access the endpoint service.
   See format below.
 * `sleep` - (Optional) Configurable sleep time (seconds) when enable PrivateLink.
-  Default set to 10 seconds.
+  Default set to 10 seconds. *Available from v1.29.0*
 * `timeout` - (Optional) Configurable timeout time (seconds) when enable PrivateLink.
-  Default set to 1800 seconds.
+  Default set to 1800 seconds. *Available from v1.29.0*
 
 Approved subscriptions format (GUID): <br>
 `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`
@@ -195,10 +195,3 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
 ```
 
 </details>
-
-## Changelog
-
-List of changes made to this resource for different versions.
-
-[v1.29.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.29.0) added
-configurable retries when reading PrivateLink information.

--- a/docs/resources/privatelink_azure.md
+++ b/docs/resources/privatelink_azure.md
@@ -11,10 +11,12 @@ Enable PrivateLink for a CloudAMQP instance hosted in Azure. If no existing VPC 
 enable PrivateLink, a new VPC will be created with subnet `10.52.72.0/24`.
 
 -> **Note:** Enabling PrivateLink will automatically add firewall rules for the peered subnet.
+
 <details>
  <summary>
     <i>Default PrivateLink firewall rule</i>
   </summary>
+
 ```hcl
 rules {
   Description = "PrivateLink setup"
@@ -23,6 +25,7 @@ rules {
   services    = ["AMQP", "AMQPS", "HTTPS", "STREAM", "STREAM_SSL", "STOMP", "STOMPS", "MQTT", "MQTTS"]
 }
 ```
+
 </details>
 
 Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html) where you can also
@@ -91,6 +94,7 @@ resource "cloudamqp_privatelink_azure" "privatelink" {
   ]
 }
 ```
+
 </details>
 
 ## Argument Reference
@@ -99,9 +103,9 @@ resource "cloudamqp_privatelink_azure" "privatelink" {
 * `approved_subscriptions` - (Required) Approved subscriptions to access the endpoint service.
   See format below.
 * `sleep` - (Optional) Configurable sleep time (seconds) when enable PrivateLink.
-  Default set to 60 seconds.
+  Default set to 10 seconds.
 * `timeout` - (Optional) Configurable timeout time (seconds) when enable PrivateLink.
-  Default set to 3600 seconds.
+  Default set to 1800 seconds.
 
 Approved subscriptions format (GUID): <br>
 `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`
@@ -189,4 +193,12 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
    ]
 }
 ```
+
 </details>
+
+## Changelog
+
+List of changes made to this resource for different versions.
+
+[v1.29.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.29.0) added
+configurable retries when reading PrivateLink information.


### PR DESCRIPTION
### WHY are these changes introduced?

Reported issues about "Timeout talking to backend" and lack of retries when reading PrivateLink information.

Reference: https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/243
Requires: https://github.com/84codes/go-api/pull/44

### WHAT is this pull request doing?

- Make retries configurable through sleep and timeout
- Add sleep/timeout when reading PrivateLink information

### HOW can this pull request be tested?

Manual enable PrivateLink and read out information. 