### PR TITLE
Add configurable sleep/timeout for GCP VPC peering

### DIFF
--- a/cloudamqp/data_source_cloudamqp_vpc_gcp_info.go
+++ b/cloudamqp/data_source_cloudamqp_vpc_gcp_info.go
@@ -39,21 +39,41 @@ func dataSourceVpcGcpInfo() *schema.Resource {
 				Computed:    true,
 				Description: "VPC network uri",
 			},
+			"sleep": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     10,
+				Description: "Configurable sleep in seconds between retries when reading peering",
+			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     1800,
+				Description: "Configurable timeout time (seconds) before retries times out",
+			},
 		},
 	}
 }
 
 func dataSourceVpcGcpInfoRead(d *schema.ResourceData, meta interface{}) error {
-	api := meta.(*api.API)
-	data := make(map[string]interface{})
-	err := errors.New("")
-	log.Printf("[DEBUG] cloudamqp::data::vpc_gcp_info::request instance_id: %v, vpc_id: %v", d.Get("instance_id"), d.Get("vpc_id"))
-	if d.Get("instance_id") == 0 && d.Get("vpc_id") == nil {
+	var (
+		api         = meta.(*api.API)
+		data        = make(map[string]interface{})
+		err         = errors.New("")
+		instance_id = d.Get("instance_id").(int)
+		vpc_id      = d.Get("vpc_id").(string)
+		sleep       = d.Get("sleep").(int)
+		timeout     = d.Get("timeout").(int)
+	)
+
+	log.Printf("[DEBUG] cloudamqp::data::vpc_gcp_info::request instance_id: %v, vpc_id: %v",
+		instance_id, vpc_id)
+	if instance_id == 0 && vpc_id == "" {
 		return errors.New("you need to specify either instance_id or vpc_id")
-	} else if d.Get("instance_id") != 0 {
-		data, err = api.ReadVpcGcpInfo(d.Get("instance_id").(int))
+	} else if instance_id != 0 {
+		data, err = api.ReadVpcGcpInfo(instance_id, sleep, timeout)
 	} else if d.Get("vpc_id") != nil {
-		data, err = api.ReadVpcGcpInfoWithVpcId(d.Get("vpc_id").(string))
+		data, err = api.ReadVpcGcpInfoWithVpcId(vpc_id, sleep, timeout)
 	}
 
 	if err != nil {

--- a/docs/data-sources/vpc_gcp_info.md
+++ b/docs/data-sources/vpc_gcp_info.md
@@ -23,6 +23,7 @@ data "cloudamqp_vpc_gcp_info" "vpc_info" {
   instance_id = cloudamqp_instance.instance.id
 }
 ```
+
 </details>
 
 <details>
@@ -39,6 +40,7 @@ data "cloudamqp_vpc_gcp_info" "vpc_info" {
   # instance_id = cloudamqp_instance.instance.id
 }
 ```
+
 </details>
 
 ## Argument reference
@@ -52,6 +54,9 @@ data "cloudamqp_vpc_gcp_info" "vpc_info" {
 * `vpc_id` - (Optional) The managed VPC identifier.
 
  ***Note: Added as optional in version v1.16.0 and will be required in next major version (v2.0)***
+
+* `sleep` - (Optional) Configurable sleep time (seconds) between retries when reading peering. Default set to 10 seconds.
+* `timeout` - (Optional) - Configurable timeout time (seconds) before retries times out. Default set to 1800 seconds.
 
 ## Attributes reference
 

--- a/docs/resources/vpc_gcp_peering.md
+++ b/docs/resources/vpc_gcp_peering.md
@@ -278,17 +278,3 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
 ```
 
 </details>
-
-## Changelog
-
-List of changes made to this resource for different versions.
-
-[v1.29.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.29.0)
-Configurable sleep and timeout for retries when requesting and reading peering.
-
-[v1.28.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.18.0)
-Added `wait_on_peering_status` argument if the resource should wait until both VPCs have done its peering.
-
-[v1.16.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.16.0)
-Deprecated intance_id, set from required to optional. Will be removed in next major version (v2.0).
-Added vpc_id, set to optional. Will be required in next major version (v2.0).

--- a/docs/resources/vpc_gcp_peering.md
+++ b/docs/resources/vpc_gcp_peering.md
@@ -23,6 +23,7 @@ rules {
   services    = ["AMQP", "AMQPS", "HTTPS", "STREAM", "STREAM_SSL"]
 }
 ```
+
 </details>
 
 Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/plans.html).
@@ -64,6 +65,7 @@ resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
   peer_network_uri = "https://www.googleapis.com/compute/v1/projects/<PROJECT-NAME>/global/networks/<NETWORK-NAME>"
 }
 ```
+
 </details>
 
 <details>
@@ -111,6 +113,7 @@ resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
   peer_network_uri = "https://www.googleapis.com/compute/v1/projects/<PROJECT-NAME>/global/networks/<NETWORK-NAME>"
 }
 ```
+
 </details>
 
 <details>
@@ -121,6 +124,7 @@ resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
   </summary>
 
 Default peering request, no need to set `wait_on_peering_status`. It's default set to false and will not wait on peering status.
+
 ```hcl
 resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
   vpc_id = cloudamqp_vpc.vpc.id
@@ -129,6 +133,7 @@ resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
 ```
 
 Peering request and waiting for peering status.
+
 ```hcl
 resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
   vpc_id = cloudamqp_vpc.vpc.id
@@ -156,6 +161,9 @@ resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
 * `wait_on_peering_status` - (Optional) Makes the resource wait until the peering is connected.
 
  ***Note: Added as optional in version v1.28.0. Default set to false and will not wait until the peering is done from both VPCs***
+
+* `sleep` - (Optional) Configurable sleep time (seconds) between retries when requesting or reading peering. Default set to 10 seconds.
+* `timeout` - (Optional) - Configurable timeout time (seconds) before retries times out. Default set to 1800 seconds.
 
 ## Attributes Reference
 
@@ -226,6 +234,7 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
   ]
 }
 ```
+
 </details>
 
 <details>
@@ -268,4 +277,18 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
   ]
 }
 ```
+
 </details>
+
+## Changelog
+
+List of changes made to this resource for different versions.
+
+[v1.29.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.29.0) configurable
+sleep and timeout for retries when requesting and reading peering.
+
+[v1.28.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.18.0)
+Added `wait_on_peering_status` as optional, set to wait until peering is finished.
+
+[v1.16.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.16.0)
+deprecated intance_id and use vpc_id instead

--- a/docs/resources/vpc_gcp_peering.md
+++ b/docs/resources/vpc_gcp_peering.md
@@ -10,6 +10,7 @@ description: |-
 This resouce creates a VPC peering configuration for the CloudAMQP instance. The configuration will connect to another VPC network hosted on Google Cloud Platform (GCP). See the [GCP documentation](https://cloud.google.com/vpc/docs/using-vpc-peering) for more information on how to create the VPC peering configuration.
 
 ~> **Note:** Creating a VPC peering will automatically add firewall rules for the peered subnet.
+
 <details>
  <summary>
     <i>Default VPC peering firewall rule</i>
@@ -148,22 +149,20 @@ resource "cloudamqp_vpc_gcp_peering" "vpc_peering_request" {
 
  *Note: this resource require either `instance_id` or `vpc_id` from v1.16.0*
 
-* `instance_id` - (Optional) The CloudAMQP instance identifier.
+* `instance_id` - (Optional) The CloudAMQP instance identifier. *Deprecated from v1.16.0*
 
- ***Depreacted: Changed from required to optional in v1.16.0, will be removed in next major version (v2.0)***
-
-* `vpc_id` - (Optional) The managed VPC identifier.
-
- ***Note: Added as optional in version v1.16.0, will be required in next major version (v2.0)***
+* `vpc_id` - (Optional) The managed VPC identifier. *Available from v1.16.0*
 
 * `peer_network_uri`- (Required) Network uri of the VPC network to which you will peer with.
 
 * `wait_on_peering_status` - (Optional) Makes the resource wait until the peering is connected.
+Default set to false. *Available from v1.28.0*
 
- ***Note: Added as optional in version v1.28.0. Default set to false and will not wait until the peering is done from both VPCs***
+* `sleep` - (Optional) Configurable sleep time (seconds) between retries when requesting or reading
+peering. Default set to 10 seconds. *Available from v1.29.0*
 
-* `sleep` - (Optional) Configurable sleep time (seconds) between retries when requesting or reading peering. Default set to 10 seconds.
-* `timeout` - (Optional) - Configurable timeout time (seconds) before retries times out. Default set to 1800 seconds.
+* `timeout` - (Optional) - Configurable timeout time (seconds) before retries times out. Default set
+to 1800 seconds. *Available from v1.29.0*
 
 ## Attributes Reference
 
@@ -284,11 +283,12 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
 
 List of changes made to this resource for different versions.
 
-[v1.29.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.29.0) configurable
-sleep and timeout for retries when requesting and reading peering.
+[v1.29.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.29.0)
+Configurable sleep and timeout for retries when requesting and reading peering.
 
 [v1.28.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.18.0)
-Added `wait_on_peering_status` as optional, set to wait until peering is finished.
+Added `wait_on_peering_status` argument if the resource should wait until both VPCs have done its peering.
 
 [v1.16.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.16.0)
-deprecated intance_id and use vpc_id instead
+Deprecated intance_id, set from required to optional. Will be removed in next major version (v2.0).
+Added vpc_id, set to optional. Will be required in next major version (v2.0).


### PR DESCRIPTION
### WHY are these changes introduced?

Reported issues about "Timeout talking to backend" and lack of retries when requesting VPC peering.

Part of: https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/242
Requires: https://github.com/84codes/go-api/pull/43

### WHAT is this pull request doing?

- Make retries configurable through sleep and timeout
- Add sleep/timeout when requesting VPC Peering

### HOW can this pull request be tested?

Manual run a workflow with VPC peering to another VPC hosted in GCP.