### PR TITLE
Fix PrivateLink/Private Service Connect import

### DIFF
--- a/cloudamqp/resource_cloudamqp_privatelink_aws.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_aws.go
@@ -106,6 +106,17 @@ func resourcePrivateLinkAwsRead(d *schema.ResourceData, meta interface{}) error 
 		timeout       = d.Get("timeout").(int)
 	)
 
+	// Set arguments during import
+	if d.Get("instance_id").(int) == 0 {
+		d.Set("instance_id", instanceID)
+	}
+	if sleep == 0 && timeout == 0 {
+		sleep = 10
+		d.Set("sleep", 10)
+		timeout = 1800
+		d.Set("timeout", 1800)
+	}
+
 	data, err := api.ReadPrivatelink(instanceID, sleep, timeout)
 	if err != nil {
 		return err

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -103,6 +103,17 @@ func resourcePrivateLinkAzureRead(d *schema.ResourceData, meta interface{}) erro
 		timeout       = d.Get("timeout").(int)
 	)
 
+	// Set arguments during import
+	if d.Get("instance_id").(int) == 0 {
+		d.Set("instance_id", instanceID)
+	}
+	if sleep == 0 && timeout == 0 {
+		sleep = 10
+		d.Set("sleep", 10)
+		timeout = 1800
+		d.Set("timeout", 1800)
+	}
+
 	data, err := api.ReadPrivatelink(instanceID, sleep, timeout)
 	if err != nil {
 		return err

--- a/cloudamqp/resource_cloudamqp_vpc_connect.go
+++ b/cloudamqp/resource_cloudamqp_vpc_connect.go
@@ -159,6 +159,15 @@ func resourceVpcConnectRead(d *schema.ResourceData, meta interface{}) error {
 		instanceID, _ = strconv.Atoi(d.Id()) // Uses d.Id() to allow import
 	)
 
+	// Set arguments during import
+	if d.Get("instance_id").(int) == 0 {
+		d.Set("instance_id", instanceID)
+	}
+	if d.Get("sleep").(int) == 0 && d.Get("timeout").(int) == 0 {
+		d.Set("sleep", 10)
+		d.Set("timeout", 3600)
+	}
+
 	data, err := api.ReadVpcConnect(instanceID)
 	if err != nil {
 		return err

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -210,8 +210,7 @@ All attributes reference are computed
 
 `terraform import cloudamqp_instance.instance <id>`
 
-To retrieve the identifier for a VPC, either use [CloudAMQP customer API](https://docs.cloudamqp.com/#list-instances).
-Or use the data source [`cloudamqp_account`](./data-sources/account.md) to list all available instances for an account.
+To retrieve the identifier for an instance, either use [CloudAMQP customer API](https://docs.cloudamqp.com/#list-instances) or use the data source [`cloudamqp_account`](./data-sources/account.md) to list all available instances for an account.
 
 ## Upgrade and downgrade
 

--- a/docs/resources/privatelink_aws.md
+++ b/docs/resources/privatelink_aws.md
@@ -115,7 +115,7 @@ Allowed principals format: <br>
 
 All attributes reference are computed
 
-* `id`  - The identifier for this resource.
+* `id`  - The identifier for this resource. Will be same as `instance_id`
 * `status`- PrivateLink status [enable, pending, disable]
 * `service_name` - Service name of the PrivateLink used when creating the endpoint from other VPC.
 * `active_zones` - Covering availability zones used when creating an Endpoint from other VPC.
@@ -129,6 +129,8 @@ This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.inst
 `cloudamqp_privatelink_aws` can be imported using CloudAMQP internal identifier.
 
 `terraform import cloudamqp_privatelink_aws.privatelink <id>`
+
+The resource uses the same identifier as the CloudAMQP instance. To retrieve the identifier for an instance, either use [CloudAMQP customer API](https://docs.cloudamqp.com/#list-instances) or use the data source [`cloudamqp_account`](./data-sources/account.md).
 
 ## Create PrivateLink with additional firewall rules
 
@@ -176,7 +178,7 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
   instance_id = cloudamqp_instance.instance.id
 
   rules {
-    Description = "Custom PrivateLink setup"
+    description = "Custom PrivateLink setup"
     ip          = cloudamqp_vpc.vpc.subnet
     ports       = []
     services    = ["AMQP", "AMQPS", "HTTPS", "STREAM", "STREAM_SSL"]

--- a/docs/resources/privatelink_azure.md
+++ b/docs/resources/privatelink_azure.md
@@ -114,7 +114,7 @@ Approved subscriptions format (GUID): <br>
 
 All attributes reference are computed
 
-* `id`  - The identifier for this resource.
+* `id`  - The identifier for this resource. Will be same as `instance_id`
 * `status`- PrivateLink status [enable, pending, disable]
 * `service_name` - Service name (alias) of the PrivateLink, needed when creating the endpoint.
 * `server_name` - Name of the server having the PrivateLink enabled.
@@ -128,6 +128,8 @@ This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.inst
 `cloudamqp_privatelink_aws` can be imported using CloudAMQP internal identifier.
 
 `terraform import cloudamqp_privatelink_aws.privatelink <id>`
+
+The resource uses the same identifier as the CloudAMQP instance. To retrieve the identifier for an instance, either use [CloudAMQP customer API](https://docs.cloudamqp.com/#list-instances) or use the data source [`cloudamqp_account`](./data-sources/account.md).
 
 ## Create PrivateLink with additional firewall rules
 
@@ -175,7 +177,7 @@ resource "cloudamqp_security_firewall" "firewall_settings" {
   instance_id = cloudamqp_instance.instance.id
 
   rules {
-    Description = "Custom PrivateLink setup"
+    description = "Custom PrivateLink setup"
     ip          = cloudamqp_vpc.vpc.subnet
     ports       = []
     services    = ["AMQP", "AMQPS", "HTTPS", "STREAM", "STREAM_SSL"]


### PR DESCRIPTION
### WHY are these changes introduced?

When importing PrivateLink or VPC Connect resource, `instance_id` (required) and `sleep/timeout` (optional) arguments are never set. Making Terraform destroy and re-create the resource every time, due to `instance_id` also use ForceNew behaviour.

Reference: https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/249

### WHAT is this pull request doing?

- Set `instance_id` when no value set, just default 0 (null).
- Set `sleep` and `timeout` when no value set, just default 0 (null).
- Update docs with CloudAMQP identifier and PrivateLink identifier information.

### HOW can this pull request be tested?

Import PrivateLink or VPC Connect resource.