### PR TITLE
Add support for the Coralogix log integration

### DIFF
--- a/cloudamqp/resource_cloudamqp_integration_log.go
+++ b/cloudamqp/resource_cloudamqp_integration_log.go
@@ -90,7 +90,7 @@ func resourceIntegrationLog() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Sensitive:   true,
-				Description: "The private key. (Stackdriver)",
+				Description: "The private API key used for authentication. (Stackdriver, Coralogix)",
 			},
 			"client_email": {
 				Type:        schema.TypeString,
@@ -121,6 +121,21 @@ func resourceIntegrationLog() *schema.Resource {
 				Optional:    true,
 				Sensitive:   true,
 				Description: "Base64Encoded credentials. (Stackdriver)",
+			},
+			"endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The syslog destination to send the logs to. (Coralogix)",
+			},
+			"application": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The 'Application Name'. (Coralogix)",
+			},
+			"subsystem": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The 'Subsystem Name'. (Coralogix)",
 			},
 		},
 	}
@@ -252,6 +267,7 @@ func validateIntegrationLogName() schema.SchemaValidateFunc {
 		"datadog",
 		"stackdriver",
 		"scalyr",
+		"coralogix",
 	}, true)
 }
 
@@ -277,7 +293,10 @@ func validateIntegrationLogsSchemaAttribute(key string) bool {
 		"private_key",
 		"private_key_id",
 		"host",
-		"sourcetype":
+		"sourcetype",
+		"endpoint",
+		"application",
+		"subsystem":
 		return true
 	}
 	return false
@@ -301,6 +320,8 @@ func integrationLogKeys(intName string) []string {
 		return []string{"client_email", "private_key_id", "private_key", "project_id"}
 	case "scalyr":
 		return []string{"token", "host"}
+	case "coralogix":
+		return []string{"private_key", "endpoint", "application", "subsystem"}
 	default:
 		return []string{"url", "host_port", "token", "region", "access_key_id", "secret_access_key"}
 	}

--- a/docs/resources/integration_log.md
+++ b/docs/resources/integration_log.md
@@ -29,6 +29,7 @@ resource "cloudamqp_integration_log" "cloudwatch" {
   region = var.aws_region
 }
 ```
+
 </details>
 
 <details>
@@ -45,6 +46,7 @@ resource "cloudamqp_integration_log" "logentries" {
   token = var.logentries_token
 }
 ```
+
 </details>
 
 <details>
@@ -77,6 +79,7 @@ resource "cloudamqp_integration_log" "papertrail" {
   url = var.papertrail_url
 }
 ```
+
 </details>
 
 <details>
@@ -95,6 +98,7 @@ resource "cloudamqp_integration_log" "splunk" {
   source_type = "generic_single_line"
 }
 ```
+
 </details>
 
 <details>
@@ -113,6 +117,7 @@ resource "cloudamqp_integration_log" "datadog" {
   tags = var.datadog_tags
 }
 ```
+
 </details>
 
 <details>
@@ -155,6 +160,7 @@ resource "cloudamqp_integration_log" "stackdriver" {
   client_email = jsondecode(base64decode(google_service_account_key.service_account_key.private_key)).client_email
 }
 ```
+
 </details>
 
 <details>
@@ -205,6 +211,7 @@ resource "cloudamqp_integration_log" "stackdriver" {
   client_email = jsondecode(base64decode(google_service_account_key.service_account_key.private_key)).client_email
 }
 ```
+
 </details>
 
 <details>
@@ -222,6 +229,27 @@ resource "cloudamqp_integration_log" "scalyr" {
   host = var.scalyr_host
 }
 ```
+
+</details>
+
+<details>
+  <summary>
+    <b>
+      <i>Coralogix log integration</i>
+    </b>
+  </summary>
+
+```hcl
+resource "cloudamqp_integration_log" "coralogix" {
+  instance_id = cloudamqp_instance.instance.id
+  name        = "coralogix"
+  private_key = var.coralogix_send_data_key
+  endpoint    = var.coralogix_endpoint
+  application = var.coralogix_application
+  subsystem   = cloudamqp_instance.instance.host
+}
+```
+
 </details>
 
 ## Argument Reference
@@ -243,6 +271,9 @@ The following arguments are supported:
 * `client_email`      - (Optional/Computed) The client email registered for the integration service.
 * `host`              - (Optional) The host for Scalyr integration. (app.scalyr.com, app.eu.scalyr.com)
 * `sourcetype`        - (Optional) Assign source type to the data exported, eg. generic_single_line. (Splunk)
+* `endpoint`          - (Optional) The syslog destination to send the logs to for Coralogix. See endpoint [documentations](https://coralogix.com/docs/coralogix-endpoints/).
+* `application`       - (Optional) The application name for Coralogix. See application [documentations](https://coralogix.com/docs/application-and-subsystem-names/)
+* `subsystem`         - (Optional) The subsystem name for Coralogix. See application [documentations](https://coralogix.com/docs/application-and-subsystem-names/)
 
 This is the full list of all arguments. Only a subset of arguments are used based on which type of integration used. See [Integration Type reference](#integration-type-reference) table below for more information.
 
@@ -270,6 +301,7 @@ Valid names for third party log integration.
 | datadog       | Create a Datadog API key at app.datadoghq.com |
 | stackdriver   | Create a service account and add 'monitor metrics writer' role from your Google Cloud Account |
 | scalyr        | Create a Log write token at https://app.scalyr.com/keys |
+| coralogix     | Create Send-Your-Data API key https://coralogix.com/docs/send-your-data-api-key/ |
 
 ## Integration Type reference
 
@@ -287,6 +319,7 @@ Required arguments for all integrations: name
 | Data Dog | datadog | region, api_keys, tags |
 | Stackdriver | stackdriver | credentials |
 | Scalyr | scalyr | token, host |
+| Coralogix | coralogix | private_key, endpoint, application, subsystem |
 
 ***Note:*** Stackdriver (v1.20.2 or earlier versions) required arguments  : project_id, private_key, client_email
 


### PR DESCRIPTION
### WHY are these changes introduced?

Coralogix log integration have been added to our backend and should be added to the provider too.

Reference: https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/252

### WHAT is this pull request doing?

- Adds new arguments and log integration type.

### HOW can this pull request be tested?

- Create cluster and add Coralogix log integration (with necessary info from dev account). 
- Once up and running, trigger error/warning logs depending on log level.
- Check Coralogix dashboard for logs.