### PR TITLE
Add support for signl4 alarms recipient

### DIFF
--- a/cloudamqp/resource_cloudamqp_notification.go
+++ b/cloudamqp/resource_cloudamqp_notification.go
@@ -28,9 +28,10 @@ func resourceNotification() *schema.Resource {
 				Description: "Instance identifier",
 			},
 			"type": {
-				Type:         schema.TypeString,
-				Required:     true,
-				Description:  "Type of the notification, valid options are: email, webhook, pagerduty, victorops, opsgenie, opsgenie-eu, slack, teams",
+				Type:     schema.TypeString,
+				Required: true,
+				Description: "Type of the notification, valid options are: email, opsgenie, opsgenie-eu," +
+					"pagerduty, slack, signl4, teams, victorops, webhook",
 				ValidateFunc: validateNotificationType(),
 			},
 			"value": {
@@ -134,13 +135,14 @@ func resourceNotificationDelete(d *schema.ResourceData, meta interface{}) error 
 func validateNotificationType() schema.SchemaValidateFunc {
 	return validation.StringInSlice([]string{
 		"email",
-		"webhook",
-		"pagerduty",
-		"victorops",
 		"opsgenie",
 		"opsgenie-eu",
+		"pagerduty",
+		"signl4",
 		"slack",
 		"teams",
+		"victorops",
+		"webhook",
 	}, true)
 }
 

--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -21,31 +21,11 @@ Available for all subscription plans.
   </summary>
 
 ```hcl
-# New recipient to receieve notifications
 resource "cloudamqp_notification" "email_recipient" {
   instance_id = cloudamqp_instance.instance.id
   type        = "email"
   value       = "alarm@example.com"
   name        = "alarm"
-}
-```
-
-</details>
-
-<details>
-  <summary>
-    <b>Victorops recipient</b>
-  </summary>
-
-```hcl
-resource "cloudamqp_notification" "victorops_recipient" {
-  instance_id = cloudamqp_instance.instance.id
-  type        = "victorops"
-  value       = "<UUID>"
-  name        = "Victorops"
-  options     = {
-    "rk" = "ROUTINGKEY"
-  }
 }
 ```
 
@@ -76,11 +56,30 @@ resource "cloudamqp_notification" "pagerduty_recipient" {
   </summary>
 
 ```hcl
-resource "cloudamqp_notification" "pagerduty_recipient" {
+resource "cloudamqp_notification" "signl4_recipient" {
   instance_id = cloudamqp_instance.instance.id
   type        = "signl4"
   value       = "<team-secret>"
   name        = "Signl4"
+}
+```
+
+</details>
+
+<details>
+  <summary>
+    <b>Victorops recipient</b>
+  </summary>
+
+```hcl
+resource "cloudamqp_notification" "victorops_recipient" {
+  instance_id = cloudamqp_instance.instance.id
+  type        = "victorops"
+  value       = "<UUID>"
+  name        = "Victorops"
+  options     = {
+    "rk" = "ROUTINGKEY"
+  }
 }
 ```
 

--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -7,9 +7,7 @@ description: |-
 
 # cloudamqp_notification
 
-This resource allows you to create and manage recipients to receive alarm notifications. There will
-always be a default recipient created upon instance creation. This recipient will use team email and
-receive notifications from default alarms.
+This resource allows you to create and manage recipients to receive alarm notifications. There will always be a default recipient created upon instance creation. This recipient will use team email and receive notifications from default alarms.
 
 Available for all subscription plans.
 
@@ -176,8 +174,6 @@ This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.inst
 
 ## Import
 
-`cloudamqp_notification` can be imported using CloudAMQP internal identifier of a recipient together
-(CSV separated) with the instance identifier. To retrieve the identifier of a recipient, use
-[CloudAMQP API](https://docs.cloudamqp.com/cloudamqp_api.html#list-notification-recipients)
+`cloudamqp_notification` can be imported using CloudAMQP internal identifier of a recipient together (CSV separated) with the instance identifier. To retrieve the identifier of a recipient, use [CloudAMQP API](https://docs.cloudamqp.com/cloudamqp_api.html#list-notification-recipients)
 
 `terraform import cloudamqp_notification.recipient <id>,<instance_id>`

--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -121,11 +121,7 @@ Valid options for notification type.
 | Type      | Options  | Description | Note |
 |---|---|---|---|
 | Victorops | rk       | Routing key to route alarm notification | - |
-| PagerDuty | dedupkey | Default the dedup key for PagerDuty is generated depending on what alarm
-has triggered, but here you can set what `dedup` key to use so even if the same alarm is triggered
-for different resources you only get one notification. Leave blank to use the generated dedup key.
-| If multiple alarms are triggered using this recipient, since they all share `dedup` key only the
-first alarm will be shown in PagerDuty |
+| PagerDuty | dedupkey | Default the dedup key for PagerDuty is generated depending on what alarm has triggered, but here you can set what `dedup` key to use so even if the same alarm is triggered for different resources you only get one notification. Leave blank to use the generated dedup key. | If multiple alarms are triggered using this recipient, since they all share `dedup` key only the first alarm will be shown in PagerDuty |
 
 ## Dependency
 

--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -7,11 +7,18 @@ description: |-
 
 # cloudamqp_notification
 
-This resource allows you to create and manage recipients to receive alarm notifications. There will always be a default recipient created upon instance creation. This recipient will use team email and receive notifications from default alarms.
+This resource allows you to create and manage recipients to receive alarm notifications. There will
+always be a default recipient created upon instance creation. This recipient will use team email and
+receive notifications from default alarms.
 
 Available for all subscription plans.
 
 ## Example Usage
+
+<details>
+  <summary>
+    <b>Email recipient</b>
+  </summary>
 
 ```hcl
 # New recipient to receieve notifications
@@ -21,7 +28,16 @@ resource "cloudamqp_notification" "email_recipient" {
   value       = "alarm@example.com"
   name        = "alarm"
 }
+```
 
+</details>
+
+<details>
+  <summary>
+    <b>Victorops recipient</b>
+  </summary>
+
+```hcl
 resource "cloudamqp_notification" "victorops_recipient" {
   instance_id = cloudamqp_instance.instance.id
   type        = "victorops"
@@ -31,7 +47,16 @@ resource "cloudamqp_notification" "victorops_recipient" {
     "rk" = "ROUTINGKEY"
   }
 }
+```
 
+</details>
+
+<details>
+  <summary>
+    <b>Pagerduty recipient</b>
+  </summary>
+
+```hcl
 resource "cloudamqp_notification" "pagerduty_recipient" {
   instance_id = cloudamqp_instance.instance.id
   type        = "pagerduty"
@@ -42,6 +67,24 @@ resource "cloudamqp_notification" "pagerduty_recipient" {
   }
 }
 ```
+
+</details>
+
+<details>
+  <summary>
+    <b>Signl4 recipient</b>
+  </summary>
+
+```hcl
+resource "cloudamqp_notification" "pagerduty_recipient" {
+  instance_id = cloudamqp_instance.instance.id
+  type        = "signl4"
+  value       = "<team-secret>"
+  name        = "Signl4"
+}
+```
+
+</details>
 
 ## Argument Reference
 
@@ -64,20 +107,25 @@ All attributes reference are computed
 Valid options for notification type.
 
 * email
-* webhook
-* pagerduty
-* victorops
 * opsgenie
 * opsgenie-eu
+* pagerduty
+* signl4
 * slack
 * teams
+* victorops
+* webhook
 
 ## Options parameter
 
-| Type      | Options  | Description                                                                                                                                                                                                                                                                      | Note                                                                                                                                    |
-|-----------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| Victorops | rk       | Routing key to route alarm notification                                                                                                                                                                                                                                          | -                                                                                                                                        |
-| PagerDuty | dedupkey | Default the dedup key for PagerDuty is generated depending on what alarm has triggered, but here you can set what `dedup` key to use so even if the same alarm is triggered for different resources you only get one notification. Leave blank to use the generated dedup key. | If multiple alarms are triggered using this recipient, since they all share `dedup` key only the first alarm will be shown in PagerDuty |
+| Type      | Options  | Description | Note |
+|---|---|---|---|
+| Victorops | rk       | Routing key to route alarm notification | - |
+| PagerDuty | dedupkey | Default the dedup key for PagerDuty is generated depending on what alarm
+has triggered, but here you can set what `dedup` key to use so even if the same alarm is triggered
+for different resources you only get one notification. Leave blank to use the generated dedup key.
+| If multiple alarms are triggered using this recipient, since they all share `dedup` key only the
+first alarm will be shown in PagerDuty |
 
 ## Dependency
 
@@ -85,6 +133,8 @@ This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.inst
 
 ## Import
 
-`cloudamqp_notification` can be imported using CloudAMQP internal identifier of a recipient together (CSV separated) with the instance identifier. To retrieve the identifier of a recipient, use [CloudAMQP API](https://docs.cloudamqp.com/cloudamqp_api.html#list-notification-recipients)
+`cloudamqp_notification` can be imported using CloudAMQP internal identifier of a recipient together
+(CSV separated) with the instance identifier. To retrieve the identifier of a recipient, use
+[CloudAMQP API](https://docs.cloudamqp.com/cloudamqp_api.html#list-notification-recipients)
 
 `terraform import cloudamqp_notification.recipient <id>,<instance_id>`

--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -33,6 +33,22 @@ resource "cloudamqp_notification" "email_recipient" {
 
 <details>
   <summary>
+    <b>OpsGenie recipient</b>
+  </summary>
+
+```hcl
+resource "cloudamqp_notification" "opsgenie_recipient" {
+  instance_id = cloudamqp_instance.instance.id
+  type        = "opsgenie" # or "opsgenie-eu"
+  value       = "<api-key>"
+  name        = "OpsGenie"
+}
+```
+
+</details>
+
+<details>
+  <summary>
     <b>Pagerduty recipient</b>
   </summary>
 
@@ -68,6 +84,22 @@ resource "cloudamqp_notification" "signl4_recipient" {
 
 <details>
   <summary>
+    <b>Teams recipient</b>
+  </summary>
+
+```hcl
+resource "cloudamqp_notification" "teams_recipient" {
+  instance_id = cloudamqp_instance.instance.id
+  type        = "teams"
+  value       = "<teams-webhook-url>"
+  name        = "Teams"
+}
+```
+
+</details>
+
+<details>
+  <summary>
     <b>Victorops recipient</b>
   </summary>
 
@@ -75,11 +107,27 @@ resource "cloudamqp_notification" "signl4_recipient" {
 resource "cloudamqp_notification" "victorops_recipient" {
   instance_id = cloudamqp_instance.instance.id
   type        = "victorops"
-  value       = "<UUID>"
+  value       = "<integration-key>"
   name        = "Victorops"
   options     = {
     "rk" = "ROUTINGKEY"
   }
+}
+```
+
+</details>
+
+<details>
+  <summary>
+    <b>Webhook recipient</b>
+  </summary>
+
+```hcl
+resource "cloudamqp_notification" "webhook_recipient" {
+  instance_id = cloudamqp_instance.instance.id
+  type        = "webhook"
+  value       = "<webhook-url>"
+  name        = "Webhook"
 }
 ```
 


### PR DESCRIPTION
### WHY are these changes introduced?

'signl4' alarm recipient have been added to our backend and should be added to the provider too.

### WHAT is this pull request doing?

- Adds new  recipient type.
- Updates to docs (sort recipient by name, examples etc). 
