### PR TITLE
Add responders argument for Opsgenie recipient

### DIFF
--- a/cloudamqp/resource_cloudamqp_notification.go
+++ b/cloudamqp/resource_cloudamqp_notification.go
@@ -74,6 +74,11 @@ func resourceNotification() *schema.Resource {
 							Optional:    true,
 							Description: "Responder name",
 						},
+						"username": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Responder username",
+						},
 					},
 				},
 				Description: "Responders for OpsGenie alarms",

--- a/cloudamqp/resource_cloudamqp_notification.go
+++ b/cloudamqp/resource_cloudamqp_notification.go
@@ -2,7 +2,7 @@ package cloudamqp
 
 import (
 	"errors"
-	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
@@ -52,22 +52,59 @@ func resourceNotification() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"responders": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "Responder type, valid options are: team, user, escalation, schedule",
+							ValidateFunc: validateOpsgenieRespondersType(),
+						},
+						"id": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsUUID,
+							Description:  "Responder ID",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Responder name",
+						},
+					},
+				},
+				Description: "Responders for OpsGenie alarms",
+			},
 		},
 	}
 }
 
 func resourceNotificationCreate(d *schema.ResourceData, meta interface{}) error {
-	api := meta.(*api.API)
-	keys := []string{"type", "value", "name", "options"}
-	params := make(map[string]interface{})
+	var (
+		api    = meta.(*api.API)
+		keys   = []string{"type", "value", "name", "options", "responders"}
+		params = make(map[string]interface{})
+	)
+
 	for _, k := range keys {
-		if v := d.Get(k); v != nil {
-			params[k] = v
+		if v := d.Get(k); v != nil && v != "" {
+			switch k {
+			case "responders":
+				if len(v.(*schema.Set).List()) == 0 {
+					continue
+				}
+				params["options"] = opsGenieRespondersParameter(v.(*schema.Set).List())
+			default:
+				params[k] = v
+			}
 		}
 	}
 
+	log.Printf("[DEBUG] resourceNotificationCreate params %v", params)
 	data, err := api.CreateNotification(d.Get("instance_id").(int), params)
-
 	if err != nil {
 		return err
 	}
@@ -75,7 +112,7 @@ func resourceNotificationCreate(d *schema.ResourceData, meta interface{}) error 
 		d.SetId(data["id"].(string))
 	}
 
-	return resourceNotificationRead(d, meta)
+	return nil
 }
 
 func resourceNotificationRead(d *schema.ResourceData, meta interface{}) error {
@@ -96,10 +133,24 @@ func resourceNotificationRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	for k, v := range data {
-		if validateRecipientAttribute(k) {
-			if err = d.Set(k, v); err != nil {
-				return fmt.Errorf("error setting %s for resource %s: %s", k, d.Id(), err)
+		if !validateRecipientAttribute(k) {
+			continue
+		}
+		if v == nil || v == "" {
+			continue
+		}
+
+		switch k {
+		case "options":
+			for key, value := range data[k].(map[string]interface{}) {
+				if key == "responders" {
+					d.Set("responders", value.([]interface{}))
+				} else {
+					d.Set(k, v)
+				}
 			}
+		default:
+			d.Set(k, v)
 		}
 	}
 
@@ -107,29 +158,40 @@ func resourceNotificationRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceNotificationUpdate(d *schema.ResourceData, meta interface{}) error {
-	api := meta.(*api.API)
-	keys := []string{"type", "value", "name", "options"}
-	params := make(map[string]interface{})
-	params["id"] = d.Id()
+	var (
+		api         = meta.(*api.API)
+		keys        = []string{"type", "value", "name", "options", "responders"}
+		params      = make(map[string]interface{})
+		instanceID  = d.Get("instance_id").(int)
+		recipientID = d.Id()
+	)
+
 	for _, k := range keys {
-		if v := d.Get(k); v != nil {
-			params[k] = v
+		if v := d.Get(k); v != nil && v != "" {
+			switch k {
+			case "responders":
+				if len(v.(*schema.Set).List()) == 0 {
+					continue
+				}
+				params["options"] = opsGenieRespondersParameter(v.(*schema.Set).List())
+			default:
+				params[k] = v
+			}
 		}
 	}
 
-	err := api.UpdateNotification(d.Get("instance_id").(int), params)
-	if err != nil {
-		return err
-	}
-
-	return resourceNotificationRead(d, meta)
+	log.Printf("[DEBUG] resourceNotificationUpdate params %v", params)
+	return api.UpdateNotification(instanceID, recipientID, params)
 }
 
 func resourceNotificationDelete(d *schema.ResourceData, meta interface{}) error {
-	api := meta.(*api.API)
-	params := make(map[string]interface{})
-	params["id"] = d.Id()
-	return api.DeleteNotification(d.Get("instance_id").(int), params)
+	var (
+		api         = meta.(*api.API)
+		instanceID  = d.Get("instance_id").(int)
+		recipientID = d.Id()
+	)
+
+	return api.DeleteNotification(instanceID, recipientID)
 }
 
 func validateNotificationType() schema.SchemaValidateFunc {
@@ -151,8 +213,34 @@ func validateRecipientAttribute(key string) bool {
 	case "type",
 		"value",
 		"name",
-		"options":
+		"options",
+		"responders":
 		return true
 	}
 	return false
+}
+
+func validateOpsgenieRespondersType() schema.SchemaValidateFunc {
+	return validation.StringInSlice([]string{
+		"escalation",
+		"schedule",
+		"team",
+		"user",
+	}, true)
+}
+
+func opsGenieRespondersParameter(responders []interface{}) map[string]interface{} {
+	responderParams := make(map[string]interface{})
+	params := make([]map[string]interface{}, len(responders))
+	for index, responder := range responders {
+		param := make(map[string]interface{})
+		for k, v := range responder.(map[string]interface{}) {
+			if v != nil && v != "" {
+				param[k] = v
+			}
+		}
+		params[index] = param
+	}
+	responderParams["responders"] = params
+	return responderParams
 }

--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -48,7 +48,7 @@ resource "cloudamqp_notification" "opsgenie_recipient" {
   }
   responders {
     type = "user"
-    username   = "<user>"
+    username   = "<username>"
   }
 }
 ```

--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -48,7 +48,7 @@ resource "cloudamqp_notification" "opsgenie_recipient" {
   }
   responders {
     type = "user"
-    name   = "<user>"
+    username   = "<user>"
   }
 }
 ```
@@ -157,11 +157,13 @@ ___
 
 The `responders` block consists of:
 
-* `type`  - (Required) Type of responder. [`team`, `user`, `escalation`, `schedule`]
-* `id`    - (Optional) Identifier in UUID format
-* `name`  - (Optional) Name of the responder
+* `type`      - (Required) Type of responder. [`team`, `user`, `escalation`, `schedule`]
+* `id`        - (Optional) Identifier in UUID format
+* `name`      - (Optional) Name of the responder
+* `username`  - (Optional) Username of the responder
 
-When in use, also use id or name together with the required type.
+Responders of type `team`, `escalation` and `schedule` can use either id or name.
+While `user` can use either id or username.
 
 ## Attributes Reference
 

--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -7,7 +7,9 @@ description: |-
 
 # cloudamqp_notification
 
-This resource allows you to create and manage recipients to receive alarm notifications. There will always be a default recipient created upon instance creation. This recipient will use team email and receive notifications from default alarms.
+This resource allows you to create and manage recipients to receive alarm notifications. There will
+always be a default recipient created upon instance creation. This recipient will use team email and
+receive notifications from default alarms.
 
 Available for all subscription plans.
 
@@ -31,7 +33,7 @@ resource "cloudamqp_notification" "email_recipient" {
 
 <details>
   <summary>
-    <b>OpsGenie recipient</b>
+    <b>OpsGenie recipient with optional responders</b>
   </summary>
 
 ```hcl
@@ -40,6 +42,14 @@ resource "cloudamqp_notification" "opsgenie_recipient" {
   type        = "opsgenie" # or "opsgenie-eu"
   value       = "<api-key>"
   name        = "OpsGenie"
+  responders {
+    type = "team"
+    id   = "<team-uuid>"
+  }
+  responders {
+    type = "user"
+    name   = "<user>"
+  }
 }
 ```
 
@@ -47,7 +57,7 @@ resource "cloudamqp_notification" "opsgenie_recipient" {
 
 <details>
   <summary>
-    <b>Pagerduty recipient</b>
+    <b>Pagerduty recipient with optional dedup key</b>
   </summary>
 
 ```hcl
@@ -98,7 +108,7 @@ resource "cloudamqp_notification" "teams_recipient" {
 
 <details>
   <summary>
-    <b>Victorops recipient</b>
+    <b>Victorops recipient with optional routing key (rk)</b>
   </summary>
 
 ```hcl
@@ -140,6 +150,18 @@ The following arguments are supported:
 * `value`       - (Required) Integration/API key or endpoint to send the notification.
 * `name`        - (Optional) Display name of the recipient.
 * `options`     - (Optional) Options argument (e.g. `rk` used for VictorOps routing key).
+* `responders`  - (Optional) An array of reponders (only for OpsGenie). Each `responders` block
+consists of the field documented below.
+
+___
+
+The `responders` block consists of:
+
+* `type`  - (Required) Type of responder. [`team`, `user`, `escalation`, `schedule`]
+* `id`    - (Optional) Identifier in UUID format
+* `name`  - (Optional) Name of the responder
+
+When in use, also use id or name together with the required type.
 
 ## Attributes Reference
 
@@ -174,6 +196,8 @@ This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.inst
 
 ## Import
 
-`cloudamqp_notification` can be imported using CloudAMQP internal identifier of a recipient together (CSV separated) with the instance identifier. To retrieve the identifier of a recipient, use [CloudAMQP API](https://docs.cloudamqp.com/cloudamqp_api.html#list-notification-recipients)
+`cloudamqp_notification` can be imported using CloudAMQP internal identifier of a recipient together
+(CSV separated) with the instance identifier. To retrieve the identifier of a recipient, use
+[CloudAMQP API](https://docs.cloudamqp.com/cloudamqp_api.html#list-notification-recipients)
 
 `terraform import cloudamqp_notification.recipient <id>,<instance_id>`


### PR DESCRIPTION
### WHY are these changes introduced?

Request to add `responders`to OpsGenie recipient and further all alarms created with this recipient(s).
[OpsGenie API-docs](https://docs.opsgenie.com/docs/alert-api#create-alert)

Requires: 
https://github.com/84codes/go-api/pull/45

### WHAT is this pull request doing?

- Add optional responders argument
- Fixes issue when updating recipient
- Updates docs.

### HOW can this pull request be tested?

Manual create recipient, with and without responders. 
(Would benefiet from [go-vcr-test](https://github.com/cloudamqp/terraform-provider-cloudamqp/tree/go-vcr-testing) branch)