### PR TITLE
Documentation: Fix link to instance regions guide from the instances guide

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -7,7 +7,7 @@ description: |-
 
 # cloudamqp_instance
 
-This resource allows you to create and manage a CloudAMQP instance running either [**RabbitMQ**](https://www.rabbitmq.com/) or [**LavinMQ**](https://lavinmq.com/) and can be deployed to multiple cloud platforms provider and regions, see [instance regions](../guides/instance_region.md) for more information.
+This resource allows you to create and manage a CloudAMQP instance running either [**RabbitMQ**](https://www.rabbitmq.com/) or [**LavinMQ**](https://lavinmq.com/) and can be deployed to multiple cloud platforms provider and regions, see [instance regions](../guides/info_region.md) for more information.
 
 Once the instance is created it will be assigned a unique identifier. All other resources and data sources created for this instance needs to reference this unique instance identifier.
 


### PR DESCRIPTION
The documentation on https://registry.terraform.io/providers/cloudamqp/cloudamqp/latest/docs/resources/instance incorrectly links to 'instance_regions' instead of info_regions'

_see [instance regions](https://registry.terraform.io/providers/cloudamqp/cloudamqp/latest/docs/guides/instance_region) for more information._

This should be https://registry.terraform.io/providers/cloudamqp/cloudamqp/latest/docs/guides/info_region in the latest version of the documentation.