### PR TITLE
Documentation: Information on how to use HTTP API

### DIFF
--- a/docs/guides/info_http_api.md
+++ b/docs/guides/info_http_api.md
@@ -1,24 +1,24 @@
 ---
 layout: "cloudamqp"
-page_title: "HTTP API"
+page_title: "Message Broker HTTP API"
 subcategory: "info"
 description: |-
-  Example of using HTTP API to create user, vhost etc.
+  Example of using Message Broker HTTP API to create user, vhost etc.
 ---
 
-# HTTP API
+# Message Broker HTTP API
 
-This provider doesn't support using the HTTP API to create user, vhost etc. on the underlying
-RabbitMQ or LavinMQ instance.
+This provider doesn't support using the Message Broker HTTP API to create user, vhost etc. on the
+underlying RabbitMQ or LavinMQ instance.
 
-There are other provider here at the registry that are built for this. Example of the current
+There are other providers here at the registry that are built for this. Example of the current
 unofficial RabbitMQ provider with most downloads:
 https://registry.terraform.io/providers/cyrilgdn/rabbitmq/latest
 
 ## Example Usage
 
-This can be used together with the CloudAMQP provider to access the HTTP API to create
-user, vhost etc.
+This can be used together with the CloudAMQP provider to access the Message Broker HTTP API to
+create user, vhost etc.
 
 ```hcl
 data "cloudamqp_credentials" "credentials" {

--- a/docs/guides/info_http_api.md
+++ b/docs/guides/info_http_api.md
@@ -1,0 +1,33 @@
+---
+layout: "cloudamqp"
+page_title: "HTTP API"
+subcategory: "info"
+description: |-
+  Example of using HTTP API to create user, vhost etc.
+---
+
+# HTTP API
+
+This provider doesn't support using the HTTP API to create user, vhost etc. on the underlying
+RabbitMQ or LavinMQ instance.
+
+There are other provider here at the registry that are built for this. Example of the current
+unofficial RabbitMQ provider with most downloads:
+https://registry.terraform.io/providers/cyrilgdn/rabbitmq/latest
+
+## Example Usage
+
+This can be used together with the CloudAMQP provider to access the HTTP API to create
+user, vhost etc.
+
+```hcl
+data "cloudamqp_credentials" "credentials" {
+  instance_id = cloudamqp_instance.instance.id
+}
+
+provider "rabbitmq" {
+  endpoint = "https://${cloudamqp_instance.instance.host}"
+  username = data.cloudamqp_credentials.credentials.username
+  password = data.cloudamqp_credentials.credentials.password
+}
+```


### PR DESCRIPTION
### WHY are these changes introduced?

This provider don't support the use of Message Broker HTTP API, but can be used together with other providers to do so.

### WHAT is this pull request doing?

Add information and example on how to use other provider to access Message Broker HTTP API.

### HOW can this pull request be tested?

Check new guide.md file.