### PR TITLE
fix: added handling of notice alarm

### DIFF
--- a/cloudamqp/resource_cloudamqp_alarm.go
+++ b/cloudamqp/resource_cloudamqp_alarm.go
@@ -114,8 +114,7 @@ func resourceAlarmCreate(d *schema.ResourceData, meta interface{}) error {
 				d.SetId(alarm["id"].(string))
 				log.Printf("[DEBUG] cloudamqp::resource::alarm::create retrieved existing alarm id: %v", d.Id())
 				log.Printf("[DEBUG] cloudamqp::resource::alarm::create invoking existing alarm update")
-				resourceAlarmUpdate(d, meta)
-				return resourceAlarmRead(d, meta)
+				return resourceAlarmUpdate(d, meta)
 			}
 		}
 

--- a/cloudamqp/resource_cloudamqp_alarm.go
+++ b/cloudamqp/resource_cloudamqp_alarm.go
@@ -100,15 +100,37 @@ func resourceAlarmCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	log.Printf("[DEBUG] cloudamqp::resource::alarm::create params: %v", params)
 
-	data, err := api.CreateAlarm(d.Get("instance_id").(int), params)
-	log.Printf("[DEBUG] cloudamqp::resource::alarm::create data: %v", data)
+	if d.Get("type") == "notice" {
+		log.Printf("[DEBUG] cloudamqp::resource::alarm::create type is 'notice', skipping creation")
+		log.Printf("[DEBUG] cloudamqp::resource::alarm::create type is 'notice', getting existing notice alarm")
+		alarms, err := api.ReadAlarms(d.Get("instance_id").(int))
 
-	if err != nil {
-		return err
-	}
-	if data["id"] != nil {
-		d.SetId(data["id"].(string))
-		log.Printf("[DEBUG] cloudamqp::resource::alarm::create id set: %v", d.Id())
+		if err != nil {
+			return err
+		}
+
+		for _, alarm := range alarms {
+			if alarm["type"] == "notice" {
+				d.SetId(alarm["id"].(string))
+				log.Printf("[DEBUG] cloudamqp::resource::alarm::create retrieved existing alarm id: %v", d.Id())
+				log.Printf("[DEBUG] cloudamqp::resource::alarm::create invoking existing alarm update")
+				resourceAlarmUpdate(d, meta)
+				return resourceAlarmRead(d, meta)
+			}
+		}
+
+		return errors.New(fmt.Sprintf("Couldn't find notice alarm for instance_id %s", d.Get("instance_id")))
+	} else {
+		data, err := api.CreateAlarm(d.Get("instance_id").(int), params)
+		log.Printf("[DEBUG] cloudamqp::resource::alarm::create data: %v", data)
+
+		if err != nil {
+			return err
+		}
+		if data["id"] != nil {
+			d.SetId(data["id"].(string))
+			log.Printf("[DEBUG] cloudamqp::resource::alarm::create id set: %v", d.Id())
+		}
 	}
 
 	return resourceAlarmRead(d, meta)

--- a/cloudamqp/resource_cloudamqp_alarm.go
+++ b/cloudamqp/resource_cloudamqp_alarm.go
@@ -118,7 +118,7 @@ func resourceAlarmCreate(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
-		return errors.New(fmt.Sprintf("Couldn't find notice alarm for instance_id %s", d.Get("instance_id")))
+		return fmt.Errorf("Couldn't find notice alarm for instance_id %s", d.Get("instance_id"))
 	} else {
 		data, err := api.CreateAlarm(d.Get("instance_id").(int), params)
 		log.Printf("[DEBUG] cloudamqp::resource::alarm::create data: %v", data)

--- a/cloudamqp/resource_cloudamqp_alarm.go
+++ b/cloudamqp/resource_cloudamqp_alarm.go
@@ -188,6 +188,10 @@ func resourceAlarmUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAlarmDelete(d *schema.ResourceData, meta interface{}) error {
+	if d.Get("type") == "notice" {
+		log.Printf("[DEBUG] cloudamqp::resource::alarm::delete type is 'notice', skipping deletion, just remove it from state")
+		return nil
+	}
 	api := meta.(*api.API)
 	params := make(map[string]interface{})
 	params["id"] = d.Id()

--- a/cloudamqp/resource_cloudamqp_alarm.go
+++ b/cloudamqp/resource_cloudamqp_alarm.go
@@ -111,7 +111,7 @@ func resourceAlarmCreate(d *schema.ResourceData, meta interface{}) error {
 
 		for _, alarm := range alarms {
 			if alarm["type"] == "notice" {
-				d.SetId(alarm["id"].(string))
+				d.SetId(strconv.FormatFloat(alarm["id"].(float64), 'f', 0, 64))
 				log.Printf("[DEBUG] cloudamqp::resource::alarm::create retrieved existing alarm id: %v", d.Id())
 				log.Printf("[DEBUG] cloudamqp::resource::alarm::create invoking existing alarm update")
 				return resourceAlarmUpdate(d, meta)


### PR DESCRIPTION
Given this issue as context:

https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/219

I'm proposing with this PR that notice alarm "auto-imports" into state on resource "creation", and also apply any changes to the existing notice alarm (that the API allows).