### PR TITLE
Post Go-API import modifications

### DIFF
--- a/api/account.go
+++ b/api/account.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 )
 
-func (api *API) ListInstances() ([]map[string]interface{}, error) {
+func (api *API) ListInstances() ([]map[string]any, error) {
 	var (
-		data   []map[string]interface{}
-		failed map[string]interface{}
+		data   []map[string]any
+		failed map[string]any
 	)
 
 	response, err := api.sling.New().Path("api/instances").Receive(&data, &failed)
@@ -30,10 +30,10 @@ func (api *API) ListInstances() ([]map[string]interface{}, error) {
 	}
 }
 
-func (api *API) ListVpcs() ([]map[string]interface{}, error) {
+func (api *API) ListVpcs() ([]map[string]any, error) {
 	var (
-		data   []map[string]interface{}
-		failed map[string]interface{}
+		data   []map[string]any
+		failed map[string]any
 		path   = "/api/vpcs"
 	)
 
@@ -58,7 +58,7 @@ func (api *API) ListVpcs() ([]map[string]interface{}, error) {
 
 func (api *API) RotatePassword(instanceID int) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("api/instances/%d/account/rotate-password", instanceID)
 	)
 
@@ -80,7 +80,7 @@ func (api *API) RotatePassword(instanceID int) error {
 
 func (api *API) RotateApiKey(instanceID int) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("api/instances/%d/account/rotate-apikey", instanceID)
 	)
 

--- a/api/account.go
+++ b/api/account.go
@@ -10,18 +10,24 @@ func (api *API) ListInstances() ([]map[string]interface{}, error) {
 	var (
 		data   []map[string]interface{}
 		failed map[string]interface{}
-		path   = "api/instances"
 	)
 
-	response, err := api.sling.New().Path(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::account::list_instances data: %v", data)
+	response, err := api.sling.New().Path("api/instances").Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("ListInstances failed, status: %v, message: %s", response.StatusCode, failed)
+
+	switch response.StatusCode {
+	case 200:
+		log.Printf("[DEBUG] api::account#list_instances data: %v", data)
+		return data, nil
+	case 410:
+		log.Printf("[WARN] api::instance#list status: 410, message: The instance has been deleted")
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("list instances failed, status: %d, message: %s",
+			response.StatusCode, failed)
 	}
-	return data, nil
 }
 
 func (api *API) ListVpcs() ([]map[string]interface{}, error) {
@@ -32,22 +38,22 @@ func (api *API) ListVpcs() ([]map[string]interface{}, error) {
 	)
 
 	response, err := api.sling.New().Path(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::vpc::list data: %v", data)
-
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("ListVpcs failed, status: %v, message: %v", response.StatusCode, failed)
-	}
 
-	for k := range data {
-		vpcID := strconv.FormatFloat(data[k]["id"].(float64), 'f', 0, 64)
-		data_temp, _ := api.readVpcName(vpcID)
-		data[k]["vpc_name"] = data_temp["name"]
+	switch response.StatusCode {
+	case 200:
+		log.Printf("[DEBUG] api::account#list_vpcs data: %v", data)
+		for k := range data {
+			vpcID := strconv.FormatFloat(data[k]["id"].(float64), 'f', 0, 64)
+			data_temp, _ := api.readVpcName(vpcID)
+			data[k]["vpc_name"] = data_temp["name"]
+		}
+		return data, nil
+	default:
+		return nil, fmt.Errorf("list VPCs failed, status: %d, message: %s", response.StatusCode, failed)
 	}
-
-	return data, nil
 }
 
 func (api *API) RotatePassword(instanceID int) error {
@@ -67,7 +73,7 @@ func (api *API) RotatePassword(instanceID int) error {
 	case 204:
 		return nil
 	default:
-		return fmt.Errorf("failed to rotate api key, statusCode: %v, failed: %v",
+		return fmt.Errorf("failed to rotate api key, statusCode: %d, failed: %v",
 			response.StatusCode, failed)
 	}
 }

--- a/api/alarms.go
+++ b/api/alarms.go
@@ -7,12 +7,10 @@ import (
 	"time"
 )
 
-func (api *API) CreateAlarm(instanceID int, params map[string]interface{}) (
-	map[string]interface{}, error) {
-
+func (api *API) CreateAlarm(instanceID int, params map[string]any) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/alarms", instanceID)
 	)
 
@@ -37,10 +35,10 @@ func (api *API) CreateAlarm(instanceID int, params map[string]interface{}) (
 	}
 }
 
-func (api *API) ReadAlarm(instanceID int, alarmID string) (map[string]interface{}, error) {
+func (api *API) ReadAlarm(instanceID int, alarmID string) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/alarms/%s", instanceID, alarmID)
 	)
 
@@ -60,10 +58,10 @@ func (api *API) ReadAlarm(instanceID int, alarmID string) (map[string]interface{
 	}
 }
 
-func (api *API) ListAlarms(instanceID int) ([]map[string]interface{}, error) {
+func (api *API) ListAlarms(instanceID int) ([]map[string]any, error) {
 	var (
-		data   []map[string]interface{}
-		failed map[string]interface{}
+		data   []map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/alarms", instanceID)
 	)
 
@@ -83,9 +81,9 @@ func (api *API) ListAlarms(instanceID int) ([]map[string]interface{}, error) {
 	}
 }
 
-func (api *API) UpdateAlarm(instanceID int, params map[string]interface{}) error {
+func (api *API) UpdateAlarm(instanceID int, params map[string]any) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/alarms/%s", instanceID, params["id"].(string))
 	)
 
@@ -105,7 +103,7 @@ func (api *API) UpdateAlarm(instanceID int, params map[string]interface{}) error
 
 func (api *API) DeleteAlarm(instanceID int, alarmID string) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/alarms/%s", instanceID, alarmID)
 	)
 
@@ -125,8 +123,8 @@ func (api *API) DeleteAlarm(instanceID int, alarmID string) error {
 
 func (api *API) waitUntilAlarmDeletion(instanceID int, alarmID string) error {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 	)
 
 	log.Printf("[DEBUG] api::alarms#waitUntilAlarmDeletion waiting")

--- a/api/alarms.go
+++ b/api/alarms.go
@@ -1,119 +1,146 @@
 package api
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strconv"
 	"time"
 )
 
-func (api *API) CreateAlarm(instanceID int, params map[string]interface{}) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::alarm::create instance ID: %v, params: %v", instanceID, params)
-	path := fmt.Sprintf("/api/instances/%d/alarms", instanceID)
-	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::alarm::create data: %v", data)
+func (api *API) CreateAlarm(instanceID int, params map[string]interface{}) (
+	map[string]interface{}, error) {
 
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/alarms", instanceID)
+	)
+
+	log.Printf("[DEBUG] api::alarms#create path: %s", path)
+	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 201 {
-		return nil, fmt.Errorf("CreateAlarm failed, status: %v, message: %s", response.StatusCode, failed)
-	}
 
-	if id, ok := data["id"]; ok {
-		data["id"] = strconv.FormatFloat(id.(float64), 'f', 0, 64)
-		log.Printf("[DEBUG] go-api::alarm::create id set: %v", data["id"])
-	} else {
-		msg := fmt.Sprintf("go-api::instance::create Invalid alarm identifier: %v", data["id"])
-		log.Printf("[ERROR] %s", msg)
-		return nil, errors.New(msg)
+	switch response.StatusCode {
+	case 201:
+		log.Printf("[DEBUG] api::alarms#create data: %v", data)
+		if id, ok := data["id"]; ok {
+			data["id"] = strconv.FormatFloat(id.(float64), 'f', 0, 64)
+		} else {
+			return nil, fmt.Errorf("create alarm failed, invalid alarm identifier: %v", data["id"])
+		}
+		return data, err
+	default:
+		return nil,
+			fmt.Errorf("create alarm failed, status: %d, message: %s", response.StatusCode, failed)
 	}
-
-	return data, err
 }
 
 func (api *API) ReadAlarm(instanceID int, alarmID string) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::alarm::read instance ID: %v, alarm ID: %v", instanceID, alarmID)
-	path := fmt.Sprintf("/api/instances/%v/alarms/%v", instanceID, alarmID)
-	response, err := api.sling.New().Get(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::alarm::read data : %v", data)
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/alarms/%s", instanceID, alarmID)
+	)
 
+	log.Printf("[DEBUG] api::alarms#read path: %s", path)
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("ReadAlarm failed, status: %v, message: %s", response.StatusCode, failed)
-	}
 
-	return data, err
+	switch response.StatusCode {
+	case 200:
+		log.Printf("[DEBUG] api::alarms#read data : %v", data)
+		return data, err
+	default:
+		return nil,
+			fmt.Errorf("read alarm failed, status: %d, message: %s", response.StatusCode, failed)
+	}
 }
 
-func (api *API) ReadAlarms(instanceID int) ([]map[string]interface{}, error) {
-	var data []map[string]interface{}
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::alarm::read instance ID: %v", instanceID)
-	path := fmt.Sprintf("/api/instances/%d/alarms", instanceID)
-	response, err := api.sling.New().Get(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::alarm::read data: %v", data)
+func (api *API) ListAlarms(instanceID int) ([]map[string]interface{}, error) {
+	var (
+		data   []map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/alarms", instanceID)
+	)
 
+	log.Printf("[DEBUG] api::alarms#list path: %s", path)
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("Alarms::ReadAlarms failed, status: %v, message: %s", response.StatusCode, failed)
-	}
 
-	return data, err
+	switch response.StatusCode {
+	case 200:
+		log.Printf("[DEBUG] api::alarms#list data: %v", data)
+		return data, err
+	default:
+		return nil,
+			fmt.Errorf("list alarms failed, status: %d, message: %s", response.StatusCode, failed)
+	}
 }
 
 func (api *API) UpdateAlarm(instanceID int, params map[string]interface{}) error {
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::alarm::update instance ID: %v, params: %v", instanceID, params)
-	path := fmt.Sprintf("/api/instances/%v/alarms/%v", instanceID, params["id"])
-	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
+	var (
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/alarms/%s", instanceID, params["id"].(string))
+	)
 
+	log.Printf("[DEBUG] api::alarms#update path: %s", path)
+	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
 	if err != nil {
 		return err
 	}
-	if response.StatusCode != 201 {
-		return fmt.Errorf("Alarms::UpdateAlarm failed, status: %v, message: %s", response.StatusCode, failed)
-	}
 
-	return err
+	switch response.StatusCode {
+	case 201:
+		return nil
+	default:
+		return fmt.Errorf("update alarm failed, status: %d, message: %s", response.StatusCode, failed)
+	}
 }
 
-func (api *API) DeleteAlarm(instanceID int, params map[string]interface{}) error {
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::alarm::delete instance id: %v, params: %v", instanceID, params)
-	path := fmt.Sprintf("/api/instances/%v/alarms/%v", instanceID, params["id"])
-	response, _ := api.sling.New().Delete(path).BodyJSON(params).Receive(nil, &failed)
+func (api *API) DeleteAlarm(instanceID int, alarmID string) error {
+	var (
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/alarms/%s", instanceID, alarmID)
+	)
 
-	if response.StatusCode != 204 {
-		return fmt.Errorf("Alarm::DeleteAlarm failed, status: %v, message: %s", response.StatusCode, failed)
+	log.Printf("[DEBUG] api::alarms::delete path: %s", path)
+	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
+	if err != nil {
+		return err
 	}
 
-	return api.waitUntilAlarmDeletion(instanceID, params["id"].(string))
+	switch response.StatusCode {
+	case 204:
+		return api.waitUntilAlarmDeletion(instanceID, alarmID)
+	default:
+		return fmt.Errorf("delete alarm failed, status: %d, message: %s", response.StatusCode, failed)
+	}
 }
 
-func (api *API) waitUntilAlarmDeletion(instanceID int, id string) error {
-	log.Printf("[DEBUG] go-api::alarm::waitUntilAlarmDeletion waiting")
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
+func (api *API) waitUntilAlarmDeletion(instanceID int, alarmID string) error {
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+	)
+
+	log.Printf("[DEBUG] api::alarms#waitUntilAlarmDeletion waiting")
 	for {
-		path := fmt.Sprintf("/api/instances/%v/alarms/%v", instanceID, id)
+		path := fmt.Sprintf("/api/instances/%d/alarms/%s", instanceID, alarmID)
 		response, err := api.sling.New().Path(path).Receive(&data, &failed)
-
 		if err != nil {
-			log.Printf("[DEBUG] go-api::alarm::waitUntilAlarmDeletion error: %v", err)
+			log.Printf("[DEBUG] api::alarms#waitUntilAlarmDeletion error: %v", err)
 			return err
 		}
-		if response.StatusCode == 404 {
-			log.Print("[DEBUG] go-api::alarm::waitUntilAlarmDeletion deleted")
+
+		switch response.StatusCode {
+		case 404:
+			log.Print("[DEBUG] api::alarms#waitUntilAlarmDeletion deleted")
 			return nil
 		}
 

--- a/api/api.go
+++ b/api/api.go
@@ -12,8 +12,11 @@ type API struct {
 }
 
 func (api *API) DefaultRmqVersion() (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+	)
+
 	_, err := api.sling.New().Get("/api/default_rabbitmq_version").Receive(&data, &failed)
 	if err != nil {
 		return nil, err

--- a/api/api.go
+++ b/api/api.go
@@ -11,10 +11,10 @@ type API struct {
 	client *http.Client
 }
 
-func (api *API) DefaultRmqVersion() (map[string]interface{}, error) {
+func (api *API) DefaultRmqVersion() (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 	)
 
 	_, err := api.sling.New().Get("/api/default_rabbitmq_version").Receive(&data, &failed)

--- a/api/aws_eventbridge.go
+++ b/api/aws_eventbridge.go
@@ -6,12 +6,10 @@ import (
 	"strconv"
 )
 
-func (api *API) CreateAwsEventBridge(instanceID int, params map[string]interface{}) (
-	map[string]interface{}, error) {
-
+func (api *API) CreateAwsEventBridge(instanceID int, params map[string]any) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/eventbridges", instanceID)
 	)
 
@@ -36,12 +34,10 @@ func (api *API) CreateAwsEventBridge(instanceID int, params map[string]interface
 	}
 }
 
-func (api *API) ReadAwsEventBridge(instanceID int, eventbridgeID string) (
-	map[string]interface{}, error) {
-
+func (api *API) ReadAwsEventBridge(instanceID int, eventbridgeID string) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/eventbridges/%s", instanceID, eventbridgeID)
 	)
 
@@ -59,10 +55,10 @@ func (api *API) ReadAwsEventBridge(instanceID int, eventbridgeID string) (
 	}
 }
 
-func (api *API) ReadAwsEventBridges(instanceID int) (map[string]interface{}, error) {
+func (api *API) ReadAwsEventBridges(instanceID int) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/eventbridges", instanceID)
 	)
 
@@ -82,7 +78,7 @@ func (api *API) ReadAwsEventBridges(instanceID int) (map[string]interface{}, err
 
 func (api *API) DeleteAwsEventBridge(instanceID int, eventbridgeID string) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/eventbridges/%s", instanceID, eventbridgeID)
 	)
 

--- a/api/aws_eventbridge.go
+++ b/api/aws_eventbridge.go
@@ -6,33 +6,39 @@ import (
 	"strconv"
 )
 
-func (api *API) CreateAwsEventBridge(instanceID int, params map[string]interface{}) (map[string]interface{}, error) {
+func (api *API) CreateAwsEventBridge(instanceID int, params map[string]interface{}) (
+	map[string]interface{}, error) {
+
 	var (
 		data   map[string]interface{}
 		failed map[string]interface{}
 		path   = fmt.Sprintf("/api/instances/%d/eventbridges", instanceID)
 	)
 
-	log.Printf("[DEBUG] go-api::aws-eventbridge::create instance ID: %d, params: %v", instanceID, params)
+	log.Printf("[DEBUG] api::aws-eventbridge#create path: %s", path)
 	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 201 {
-		return nil, fmt.Errorf("failed to create AWS EventBridge, status: %v, message: %s",
+
+	switch response.StatusCode {
+	case 201:
+		if id, ok := data["id"]; ok {
+			data["id"] = strconv.FormatFloat(id.(float64), 'f', 0, 64)
+			log.Printf("[DEBUG] api::aws-eventbridge#create AWS EventBridge identifier: %v", data["id"])
+		} else {
+			return nil, fmt.Errorf("failed to create AWS EventBridge, invalid identifier: %v", data["id"])
+		}
+		return data, nil
+	default:
+		return nil, fmt.Errorf("failed to create AWS EventBridge, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
-	if id, ok := data["id"]; ok {
-		data["id"] = strconv.FormatFloat(id.(float64), 'f', 0, 64)
-		log.Printf("[DEBUG] go-api::aws-eventbridge::create EventBridge identifier: %v", data["id"])
-	} else {
-		return nil, fmt.Errorf("go-api::aws-eventbridge::create Invalid identifier: %v", data["id"])
-	}
-
-	return data, nil
 }
 
-func (api *API) ReadAwsEventBridge(instanceID int, eventbridgeID string) (map[string]interface{}, error) {
+func (api *API) ReadAwsEventBridge(instanceID int, eventbridgeID string) (
+	map[string]interface{}, error) {
+
 	var (
 		data   map[string]interface{}
 		failed map[string]interface{}
@@ -43,12 +49,14 @@ func (api *API) ReadAwsEventBridge(instanceID int, eventbridgeID string) (map[st
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("failed to read AWS EventBridge, status: %v, message: %s",
+
+	switch response.StatusCode {
+	case 200:
+		return data, nil
+	default:
+		return nil, fmt.Errorf("failed to read AWS EventBridge, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
-
-	return data, nil
 }
 
 func (api *API) ReadAwsEventBridges(instanceID int) (map[string]interface{}, error) {
@@ -62,12 +70,14 @@ func (api *API) ReadAwsEventBridges(instanceID int) (map[string]interface{}, err
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("failed to read AWS EventBridges, status: %v, message: %s",
+
+	switch response.StatusCode {
+	case 200:
+		return data, nil
+	default:
+		return nil, fmt.Errorf("failed to read AWS EventBridges, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
-
-	return data, nil
 }
 
 func (api *API) DeleteAwsEventBridge(instanceID int, eventbridgeID string) error {
@@ -76,7 +86,7 @@ func (api *API) DeleteAwsEventBridge(instanceID int, eventbridgeID string) error
 		path   = fmt.Sprintf("/api/instances/%d/eventbridges/%s", instanceID, eventbridgeID)
 	)
 
-	log.Printf("[DEBUG] go-api::aws-eventbridge::delete instance id: %d, eventbridge id: %s", instanceID, eventbridgeID)
+	log.Printf("[DEBUG] api::aws-eventbridge#delete path: %s", path)
 	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
 	if err != nil {
 		return err
@@ -88,7 +98,8 @@ func (api *API) DeleteAwsEventBridge(instanceID int, eventbridgeID string) error
 	case 404:
 		// AWS EventBridge not found in the backend. Silent let the resource be deleted.
 		return nil
+	default:
+		return fmt.Errorf("failed to delete AWS EventBridge, status: %d, message: %s",
+			response.StatusCode, failed)
 	}
-
-	return fmt.Errorf("failed to delete AWS EventBridge, status: %v, message: %s", response.StatusCode, failed)
 }

--- a/api/credentials.go
+++ b/api/credentials.go
@@ -2,25 +2,29 @@ package api
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"strconv"
 )
 
 func (api *API) ReadCredentials(id int) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	instanceID := strconv.Itoa(id)
-	log.Printf("[DEBUG] go-api::credentials::read instance ID: %v", instanceID)
+	var (
+		data       map[string]interface{}
+		failed     map[string]interface{}
+		instanceID = strconv.Itoa(id)
+	)
+
 	response, err := api.sling.New().Path("/api/instances/").Get(instanceID).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("ReadCredentials failed, status: %v, message: %s", response.StatusCode, failed)
-	}
 
-	return extractInfo(data["url"].(string)), nil
+	switch response.StatusCode {
+	case 200:
+		return extractInfo(data["url"].(string)), nil
+	default:
+		return nil, fmt.Errorf("read credentials failed, status: %d, message: %s",
+			response.StatusCode, failed)
+	}
 }
 
 func extractInfo(url string) map[string]interface{} {

--- a/api/credentials.go
+++ b/api/credentials.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 )
 
-func (api *API) ReadCredentials(id int) (map[string]interface{}, error) {
+func (api *API) ReadCredentials(id int) (map[string]any, error) {
 	var (
-		data       map[string]interface{}
-		failed     map[string]interface{}
+		data       map[string]any
+		failed     map[string]any
 		instanceID = strconv.Itoa(id)
 	)
 
@@ -27,8 +27,8 @@ func (api *API) ReadCredentials(id int) (map[string]interface{}, error) {
 	}
 }
 
-func extractInfo(url string) map[string]interface{} {
-	paramsMap := make(map[string]interface{})
+func extractInfo(url string) map[string]any {
+	paramsMap := make(map[string]any)
 	r := regexp.MustCompile(`^.*:\/\/(?P<username>(.*)):(?P<password>(.*))@`)
 	match := r.FindStringSubmatch(url)
 

--- a/api/custom_domain.go
+++ b/api/custom_domain.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (api *API) waitUntilCustomDomainConfigured(instanceID int, configured bool) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	for {
 		response, err := api.ReadCustomDomain(instanceID)
@@ -26,11 +26,9 @@ func (api *API) waitUntilCustomDomainConfigured(instanceID int, configured bool)
 	}
 }
 
-func (api *API) CreateCustomDomain(instanceID int, hostname string) (
-	map[string]interface{}, error) {
-
+func (api *API) CreateCustomDomain(instanceID int, hostname string) (map[string]any, error) {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		params = make(map[string]string)
 		path   = fmt.Sprintf("/api/instances/%d/custom-domain", instanceID)
 	)
@@ -52,10 +50,10 @@ func (api *API) CreateCustomDomain(instanceID int, hostname string) (
 	}
 }
 
-func (api *API) ReadCustomDomain(instanceID int) (map[string]interface{}, error) {
+func (api *API) ReadCustomDomain(instanceID int) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/custom-domain", instanceID)
 	)
 
@@ -75,9 +73,7 @@ func (api *API) ReadCustomDomain(instanceID int) (map[string]interface{}, error)
 	}
 }
 
-func (api *API) UpdateCustomDomain(instanceID int, hostname string) (
-	map[string]interface{}, error) {
-
+func (api *API) UpdateCustomDomain(instanceID int, hostname string) (map[string]any, error) {
 	log.Printf("[DEBUG] go-api::custom_domain#update instanceID: %d, hostname: %s",
 		instanceID, hostname)
 
@@ -99,9 +95,9 @@ func (api *API) UpdateCustomDomain(instanceID int, hostname string) (
 	return api.waitUntilCustomDomainConfigured(instanceID, true)
 }
 
-func (api *API) DeleteCustomDomain(instanceID int) (map[string]interface{}, error) {
+func (api *API) DeleteCustomDomain(instanceID int) (map[string]any, error) {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/custom-domain", instanceID)
 	)
 

--- a/api/disk.go
+++ b/api/disk.go
@@ -7,8 +7,8 @@ import (
 	"time"
 )
 
-func (api *API) ResizeDisk(instanceID int, params map[string]interface{}, sleep, timeout int) (
-	map[string]interface{}, error) {
+func (api *API) ResizeDisk(instanceID int, params map[string]any, sleep, timeout int) (
+	map[string]any, error) {
 
 	var (
 		id   = strconv.Itoa(instanceID)
@@ -19,12 +19,12 @@ func (api *API) ResizeDisk(instanceID int, params map[string]interface{}, sleep,
 	return api.resizeDiskWithRetry(id, params, 1, sleep, timeout)
 }
 
-func (api *API) resizeDiskWithRetry(id string, params map[string]interface{}, attempt, sleep,
-	timeout int) (map[string]interface{}, error) {
+func (api *API) resizeDiskWithRetry(id string, params map[string]any, attempt, sleep,
+	timeout int) (map[string]any, error) {
 
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("api/instances/%s/disk", id)
 	)
 

--- a/api/disk.go
+++ b/api/disk.go
@@ -7,20 +7,24 @@ import (
 	"time"
 )
 
-func (api *API) ResizeDisk(instanceID int, params map[string]interface{}, sleep, timeout int) (map[string]interface{}, error) {
+func (api *API) ResizeDisk(instanceID int, params map[string]interface{}, sleep, timeout int) (
+	map[string]interface{}, error) {
+
 	var (
 		id   = strconv.Itoa(instanceID)
 		path = fmt.Sprintf("api/instances/%s/disk", id)
 	)
-	log.Printf("[DEBUG] go-api::resizeDisk::resizeDiskWithRetry path: %s, "+
+	log.Printf("[DEBUG] api::resizeDisk#resizeDiskWithRetry path: %s, "+
 		"attempt: %d, sleep: %d, timeout: %d", path, 1, sleep, timeout)
 	return api.resizeDiskWithRetry(id, params, 1, sleep, timeout)
 }
 
-func (api *API) resizeDiskWithRetry(id string, params map[string]interface{}, attempt, sleep, timeout int) (map[string]interface{}, error) {
+func (api *API) resizeDiskWithRetry(id string, params map[string]interface{}, attempt, sleep,
+	timeout int) (map[string]interface{}, error) {
+
 	var (
-		data   = make(map[string]interface{})
-		failed = make(map[string]interface{})
+		data   map[string]interface{}
+		failed map[string]interface{}
 		path   = fmt.Sprintf("api/instances/%s/disk", id)
 	)
 
@@ -38,13 +42,13 @@ func (api *API) resizeDiskWithRetry(id string, params map[string]interface{}, at
 		}
 		return data, nil
 	case 400:
-		log.Printf("[DEBUG] go-api::resizeDisk::resizeDiskWithRetry failed: %v", failed)
+		log.Printf("[DEBUG] api::resizeDisk#resizeDiskWithRetry failed: %v", failed)
 		switch {
 		case failed["error_code"] == nil:
 			break
 		case failed["error_code"].(float64) == 40099:
-			log.Printf("[DEBUG] go-api::resizeDisk::resizeDiskWithRetry %s, will try again, attempt: %d, until "+
-				"timeout: %d", failed["error"].(string), attempt, (timeout - (attempt * sleep)))
+			log.Printf("[DEBUG] api::resizeDisk#resizeDiskWithRetry %s, will try again, attempt: %d, "+
+				"until timeout: %d", failed["error"].(string), attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.resizeDiskWithRetry(id, params, attempt, sleep, timeout)
@@ -52,6 +56,6 @@ func (api *API) resizeDiskWithRetry(id string, params map[string]interface{}, at
 			return nil, fmt.Errorf("resize disk failed: %s", failed["error"].(string))
 		}
 	}
-	return nil, fmt.Errorf("resize disk failed, status: %v, message: %s",
+	return nil, fmt.Errorf("resize disk failed, status: %d, message: %s",
 		response.StatusCode, failed["error"].(string))
 }

--- a/api/instance.go
+++ b/api/instance.go
@@ -8,10 +8,10 @@ import (
 	"time"
 )
 
-func (api *API) waitUntilReady(instanceID string) (map[string]interface{}, error) {
+func (api *API) waitUntilReady(instanceID string) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%s", instanceID)
 	)
 
@@ -38,8 +38,8 @@ func (api *API) waitUntilReady(instanceID string) (map[string]interface{}, error
 
 func (api *API) waitUntilAllNodesReady(instanceID string) error {
 	var (
-		data   []map[string]interface{}
-		failed map[string]interface{}
+		data   []map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("api/instances/%v/nodes", instanceID)
 	)
 
@@ -67,13 +67,13 @@ func (api *API) waitWithTimeoutUntilAllNodesConfigured(instanceID string, attemp
 	timeout int) error {
 
 	var (
-		data   []map[string]interface{}
-		failed map[string]interface{}
+		data   []map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("api/instances/%v/nodes", instanceID)
 	)
+
 	log.Printf("[DEBUG] api::instance#waitWithTimeoutUntilAllNodesConfigured not yet ready, "+
 		"will try again, attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
-
 	_, err := api.sling.New().Path(path).Receive(&data, &failed)
 	if err != nil {
 		return err
@@ -98,8 +98,8 @@ func (api *API) waitWithTimeoutUntilAllNodesConfigured(instanceID string, attemp
 
 func (api *API) waitUntilDeletion(instanceID string) error {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%s", instanceID)
 	)
 
@@ -123,10 +123,10 @@ func (api *API) waitUntilDeletion(instanceID string) error {
 	}
 }
 
-func (api *API) CreateInstance(params map[string]interface{}) (map[string]interface{}, error) {
+func (api *API) CreateInstance(params map[string]any) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 	)
 
 	log.Printf("[DEBUG] api::instance#create params: %v", params)
@@ -151,10 +151,10 @@ func (api *API) CreateInstance(params map[string]interface{}) (map[string]interf
 	}
 }
 
-func (api *API) ReadInstance(instanceID string) (map[string]interface{}, error) {
+func (api *API) ReadInstance(instanceID string) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%s", instanceID)
 	)
 
@@ -177,9 +177,9 @@ func (api *API) ReadInstance(instanceID string) (map[string]interface{}, error) 
 	}
 }
 
-func (api *API) UpdateInstance(instanceID string, params map[string]interface{}) error {
+func (api *API) UpdateInstance(instanceID string, params map[string]any) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("api/instances/%v", instanceID)
 	)
 
@@ -203,7 +203,7 @@ func (api *API) UpdateInstance(instanceID string, params map[string]interface{})
 
 func (api *API) DeleteInstance(instanceID string, keep_vpc bool) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("api/instances/%s?keep_vpc=%v", instanceID, keep_vpc)
 	)
 
@@ -225,8 +225,8 @@ func (api *API) DeleteInstance(instanceID string, keep_vpc bool) error {
 	}
 }
 
-func (api *API) UrlInformation(url string) map[string]interface{} {
-	paramsMap := make(map[string]interface{})
+func (api *API) UrlInformation(url string) map[string]any {
+	paramsMap := make(map[string]any)
 	r := regexp.MustCompile(`^.*:\/\/(?P<username>(.*)):(?P<password>(.*))@(?P<host>(.*))\/(?P<vhost>(.*))`)
 	match := r.FindStringSubmatch(url)
 

--- a/api/instance.go
+++ b/api/instance.go
@@ -15,8 +15,7 @@ func (api *API) waitUntilReady(instanceID string) (map[string]interface{}, error
 		path   = fmt.Sprintf("/api/instances/%s", instanceID)
 	)
 
-	log.Printf("[DEBUG] go-api::instance::waitUntilReady waiting")
-
+	log.Printf("[DEBUG] api::instance#waitUntilReady waiting")
 	for {
 		response, err := api.sling.New().Path(path).Receive(&data, &failed)
 		if err != nil {
@@ -30,7 +29,7 @@ func (api *API) waitUntilReady(instanceID string) (map[string]interface{}, error
 				return data, nil
 			}
 		default:
-			return nil, fmt.Errorf("waitUntilReady failed, status: %v, message: %s",
+			return nil, fmt.Errorf("waitUntilReady failed, status: %d, message: %s",
 				response.StatusCode, failed)
 		}
 		time.Sleep(10 * time.Second)
@@ -50,10 +49,10 @@ func (api *API) waitUntilAllNodesReady(instanceID string) error {
 			return err
 		}
 
-		log.Printf("[DEBUG] go-api::instance::waitUntilAllNodesReady numberOfNodes: %v", len(data))
+		log.Printf("[DEBUG] api::instance#waitUntilAllNodesReady numberOfNodes: %v", len(data))
 		ready := true
 		for _, node := range data {
-			log.Printf("[DEBUG] go-api::instance::waitUntilAllNodesReady ready: %v, configured: %v",
+			log.Printf("[DEBUG] api::instance#waitUntilAllNodesReady ready: %v, configured: %v",
 				ready, node["configured"])
 			ready = ready && node["configured"].(bool)
 		}
@@ -72,8 +71,8 @@ func (api *API) waitWithTimeoutUntilAllNodesConfigured(instanceID string, attemp
 		failed map[string]interface{}
 		path   = fmt.Sprintf("api/instances/%v/nodes", instanceID)
 	)
-	log.Printf("[DEBUG] go-api::instance::waitWithTimeoutUntilAllNodesConfigured not yet ready, "+
-		" will try again, attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
+	log.Printf("[DEBUG] api::instance#waitWithTimeoutUntilAllNodesConfigured not yet ready, "+
+		"will try again, attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
 
 	_, err := api.sling.New().Path(path).Receive(&data, &failed)
 	if err != nil {
@@ -84,11 +83,11 @@ func (api *API) waitWithTimeoutUntilAllNodesConfigured(instanceID string, attemp
 
 	ready := true
 	for _, node := range data {
-		log.Printf("[DEBUG] go-api::instance::waitWithTimeoutUntilAllNodesConfigured ready: %v, configured: %v",
-			ready, node["configured"])
+		log.Printf("[DEBUG] api::instance#waitWithTimeoutUntilAllNodesConfigured ready: %v, "+
+			"configured: %v", ready, node["configured"])
 		ready = ready && node["configured"].(bool)
 	}
-	log.Printf("[DEBUG] go-api::instance::waitWithTimeoutUntilAllNodesConfigured ready: %v", ready)
+	log.Printf("[DEBUG] api::instance#waitWithTimeoutUntilAllNodesConfigured ready: %v", ready)
 	if ready {
 		return nil
 	}
@@ -104,20 +103,20 @@ func (api *API) waitUntilDeletion(instanceID string) error {
 		path   = fmt.Sprintf("/api/instances/%s", instanceID)
 	)
 
-	log.Printf("[DEBUG] go-api::instance::waitUntilDeletion waiting")
+	log.Printf("[DEBUG] api::instance#waitUntilDeletion waiting")
 	for {
 		response, err := api.sling.New().Path(path).Receive(&data, &failed)
 		if err != nil {
-			log.Printf("[DEBUG] go-api::instance::waitUntilDeletion error: %v", err)
+			log.Printf("[DEBUG] api::instance#waitUntilDeletion error: %v", err)
 			return err
 		}
 
 		switch response.StatusCode {
 		case 404:
-			log.Print("[DEBUG] go-api::instance::waitUntilDeletion deleted")
+			log.Print("[DEBUG] api::instance#waitUntilDeletion deleted")
 			return nil
 		case 410:
-			log.Print("[DEBUG] go-api::instance::waitUntilDeletion deleted")
+			log.Print("[DEBUG] api::instance#waitUntilDeletion deleted")
 			return nil
 		}
 		time.Sleep(10 * time.Second)
@@ -130,20 +129,20 @@ func (api *API) CreateInstance(params map[string]interface{}) (map[string]interf
 		failed map[string]interface{}
 	)
 
-	log.Printf("[DEBUG] go-api::instance::create params: %v", params)
+	log.Printf("[DEBUG] api::instance#create params: %v", params)
 	response, err := api.sling.New().Post("/api/instances").BodyJSON(params).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::instance::waitUntilReady data: %v", data)
 	if err != nil {
 		return nil, err
 	}
 
 	switch response.StatusCode {
 	case 200:
+		log.Printf("[DEBUG] api::instance#waitUntilReady data: %v", data)
 		if id, ok := data["id"]; ok {
 			data["id"] = strconv.FormatFloat(id.(float64), 'f', 0, 64)
-			log.Printf("[DEBUG] go-api::instance::create id set: %v", data["id"])
+			log.Printf("[DEBUG] api::instance#create id set: %v", data["id"])
 		} else {
-			return nil, fmt.Errorf("go-api::instance::create Invalid instance identifier: %v", data["id"])
+			return nil, fmt.Errorf("api::instance#create invalid instance identifier: %v", data["id"])
 		}
 		return api.waitUntilReady(data["id"].(string))
 	default:
@@ -159,46 +158,21 @@ func (api *API) ReadInstance(instanceID string) (map[string]interface{}, error) 
 		path   = fmt.Sprintf("/api/instances/%s", instanceID)
 	)
 
-	log.Printf("[DEBUG] go-api::instance::read instance ID: %v", instanceID)
+	log.Printf("[DEBUG] api::instance#read instance ID: %s", instanceID)
 	response, err := api.sling.New().Path(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::instance::read data: %v", data)
 	if err != nil {
 		return nil, err
 	}
 
 	switch response.StatusCode {
 	case 200:
+		log.Printf("[DEBUG] api::instance#read data: %v", data)
 		return data, nil
 	case 410:
-		log.Printf("[WARN] go-api::instance::read status: 410, message: The instance has been deleted")
+		log.Printf("[WARN] api::instance#read status: 410, message: The instance has been deleted")
 		return nil, nil
 	default:
 		return nil, fmt.Errorf("read instance failed, status: %v, message: %s",
-			response.StatusCode, failed)
-	}
-}
-
-// TODO: Rename to ListInstances
-func (api *API) ReadInstances() ([]map[string]interface{}, error) {
-	var (
-		data   []map[string]interface{}
-		failed map[string]interface{}
-	)
-
-	response, err := api.sling.New().Get("/api/instances").Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::instance::list data: %v", data)
-	if err != nil {
-		return nil, err
-	}
-
-	switch response.StatusCode {
-	case 200:
-		return data, nil
-	case 410:
-		log.Printf("[WARN] go-api::instance::list status: 410, message: The instance has been deleted")
-		return nil, nil
-	default:
-		return nil, fmt.Errorf("list instances failed, status: %v, message: %s",
 			response.StatusCode, failed)
 	}
 }
@@ -209,7 +183,7 @@ func (api *API) UpdateInstance(instanceID string, params map[string]interface{})
 		path   = fmt.Sprintf("api/instances/%v", instanceID)
 	)
 
-	log.Printf("[DEBUG] go-api::instance::update instance ID: %v, params: %v", instanceID, params)
+	log.Printf("[DEBUG] api::instance#update path: %s", path)
 	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
 	if err != nil {
 		return err
@@ -219,7 +193,7 @@ func (api *API) UpdateInstance(instanceID string, params map[string]interface{})
 	case 200:
 		return api.waitUntilAllNodesReady(instanceID)
 	case 410:
-		log.Printf("[WARN] go-api::instance::update status: 410, message: The instance has been deleted")
+		log.Printf("[WARN] api::instance#update status: 410, message: The instance has been deleted")
 		return nil
 	default:
 		return fmt.Errorf("update instance failed, status: %v, message: %s",
@@ -233,7 +207,7 @@ func (api *API) DeleteInstance(instanceID string, keep_vpc bool) error {
 		path   = fmt.Sprintf("api/instances/%s?keep_vpc=%v", instanceID, keep_vpc)
 	)
 
-	log.Printf("[DEBUG] go-api::instance::delete instance ID: %v", instanceID)
+	log.Printf("[DEBUG] api::instance#delete path: %s", path)
 	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
 	if err != nil {
 		return err
@@ -243,7 +217,7 @@ func (api *API) DeleteInstance(instanceID string, keep_vpc bool) error {
 	case 204:
 		return api.waitUntilDeletion(instanceID)
 	case 410:
-		log.Printf("[WARN] go-api::instance::delete status: 410, message: The instance has been deleted")
+		log.Printf("[WARN] api::instance#delete status: 410, message: The instance has been deleted")
 		return nil
 	default:
 		return fmt.Errorf("delete instance failed, status: %v, message: %s",

--- a/api/integration.go
+++ b/api/integration.go
@@ -8,11 +8,11 @@ import (
 
 // CreateIntegration enables integration communication, either for logs or metrics.
 func (api *API) CreateIntegration(instanceID int, intType string, intName string,
-	params map[string]interface{}) (map[string]interface{}, error) {
+	params map[string]any) (map[string]any, error) {
 
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/integrations/%s/%s", instanceID, intType, intName)
 	)
 
@@ -40,12 +40,10 @@ func (api *API) CreateIntegration(instanceID int, intType string, intName string
 }
 
 // ReadIntegration retrieves a specific logs or metrics integration
-func (api *API) ReadIntegration(instanceID int, intType, intID string) (
-	map[string]interface{}, error) {
-
+func (api *API) ReadIntegration(instanceID int, intType, intID string) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/integrations/%s/%s", instanceID, intType, intID)
 	)
 
@@ -59,14 +57,14 @@ func (api *API) ReadIntegration(instanceID int, intType, intID string) (
 	case 200:
 		log.Printf("[DEBUG] api::integration#read data: %v", data)
 		// Convert API response body, config part, into single map
-		convertedData := make(map[string]interface{})
+		convertedData := make(map[string]any)
 		for k, v := range data {
 			if k == "id" {
 				convertedData[k] = v
 			} else if k == "type" {
 				convertedData[k] = v
 			} else if k == "config" {
-				for configK, configV := range data["config"].(map[string]interface{}) {
+				for configK, configV := range data["config"].(map[string]any) {
 					convertedData[configK] = configV
 				}
 			}
@@ -80,11 +78,9 @@ func (api *API) ReadIntegration(instanceID int, intType, intID string) (
 }
 
 // UpdateIntegration updated the integration with new information
-func (api *API) UpdateIntegration(instanceID int, intType, intID string,
-	params map[string]interface{}) error {
-
+func (api *API) UpdateIntegration(instanceID int, intType, intID string, params map[string]any) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/integrations/%s/%s", instanceID, intType, intID)
 	)
 
@@ -106,7 +102,7 @@ func (api *API) UpdateIntegration(instanceID int, intType, intID string,
 // DeleteIntegration removes log or metric integration.
 func (api *API) DeleteIntegration(instanceID int, intType, intID string) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/integrations/%s/%s", instanceID, intType, intID)
 	)
 

--- a/api/integration.go
+++ b/api/integration.go
@@ -7,89 +7,120 @@ import (
 )
 
 // CreateIntegration enables integration communication, either for logs or metrics.
-func (api *API) CreateIntegration(instanceID int, intType string, intName string, params map[string]interface{}) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::integration::create params: %v", params)
-	path := fmt.Sprintf("/api/instances/%d/integrations/%s/%s", instanceID, intType, intName)
+func (api *API) CreateIntegration(instanceID int, intType string, intName string,
+	params map[string]interface{}) (map[string]interface{}, error) {
+
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/integrations/%s/%s", instanceID, intType, intName)
+	)
+
+	log.Printf("[DEBUG] api::integration#create path: %s, params: %v", path, params)
 	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::integration::create response data: %v", data)
 
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 201 {
-		return nil, fmt.Errorf(fmt.Sprintf("CreateIntegration failed, status: %v, message: %s", response.StatusCode, failed))
-	}
 
-	if v, ok := data["id"]; ok {
-		data["id"] = strconv.FormatFloat(v.(float64), 'f', 0, 64)
-	} else {
-		msg := fmt.Sprintf("go-api::integration::create Invalid integration identifier: %v", data["id"])
-		log.Printf("[ERROR] %s", msg)
-		return nil, fmt.Errorf(msg)
+	switch response.StatusCode {
+	case 201:
+		log.Printf("[DEBUG] api::integration#create response data: %v", data)
+		if v, ok := data["id"]; ok {
+			data["id"] = strconv.FormatFloat(v.(float64), 'f', 0, 64)
+		} else {
+			return nil, fmt.Errorf("create integration failed, invalid integration identifier: %v",
+				data["id"])
+		}
+		return data, err
+	default:
+		return nil, fmt.Errorf("create integration failed, status: %d, message: %s",
+			response.StatusCode, failed)
 	}
-
-	return data, err
 }
 
 // ReadIntegration retrieves a specific logs or metrics integration
-func (api *API) ReadIntegration(instanceID int, intType, intID string) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::integration::read instance ID: %d, intType: %s, intID: %s", instanceID, intType, intID)
-	path := fmt.Sprintf("/api/instances/%d/integrations/%s/%s", instanceID, intType, intID)
-	response, err := api.sling.New().Path(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::integration::read data: %v", data)
+func (api *API) ReadIntegration(instanceID int, intType, intID string) (
+	map[string]interface{}, error) {
 
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/integrations/%s/%s", instanceID, intType, intID)
+	)
+
+	log.Printf("[DEBUG] api::integration#read path: %s", path)
+	response, err := api.sling.New().Path(path).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("ReadIntegration failed, status: %v, message: %s", response.StatusCode, failed)
-	}
 
-	// Convert API response body, config part, into single map
-	convertedData := make(map[string]interface{})
-	for k, v := range data {
-		if k == "id" {
-			convertedData[k] = v
-		} else if k == "type" {
-			convertedData[k] = v
-		} else if k == "config" {
-			for configK, configV := range data["config"].(map[string]interface{}) {
-				convertedData[configK] = configV
+	switch response.StatusCode {
+	case 200:
+		log.Printf("[DEBUG] api::integration#read data: %v", data)
+		// Convert API response body, config part, into single map
+		convertedData := make(map[string]interface{})
+		for k, v := range data {
+			if k == "id" {
+				convertedData[k] = v
+			} else if k == "type" {
+				convertedData[k] = v
+			} else if k == "config" {
+				for configK, configV := range data["config"].(map[string]interface{}) {
+					convertedData[configK] = configV
+				}
 			}
 		}
+		log.Printf("[DEBUG] api::integration#read convertedDatat: %v", convertedData)
+		return convertedData, err
+	default:
+		return nil, fmt.Errorf("read integration failed, status: %d, message: %s",
+			response.StatusCode, failed)
 	}
-	log.Printf("[DEBUG] go-api::integration::read convertedDatat: %v", convertedData)
-	return convertedData, err
 }
 
 // UpdateIntegration updated the integration with new information
-func (api *API) UpdateIntegration(instanceID int, intType, intID string, params map[string]interface{}) error {
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::integration::update instance ID: %d, intType: %s, intID: %s", instanceID, intType, intID)
-	path := fmt.Sprintf("/api/instances/%d/integrations/%s/%s", instanceID, intType, intID)
-	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
+func (api *API) UpdateIntegration(instanceID int, intType, intID string,
+	params map[string]interface{}) error {
 
-	if response.StatusCode != 204 {
-		return fmt.Errorf("UpdateIntegration failed, status: %v, message: %s", response.StatusCode, failed)
+	var (
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/integrations/%s/%s", instanceID, intType, intID)
+	)
+
+	log.Printf("[DEBUG] api::integration#update path: %s", path)
+	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
+	if err != nil {
+		return err
 	}
 
-	return err
+	switch response.StatusCode {
+	case 204:
+		return nil
+	default:
+		return fmt.Errorf("update integration failed, status: %d, message: %s",
+			response.StatusCode, failed)
+	}
 }
 
 // DeleteIntegration removes log or metric integration.
 func (api *API) DeleteIntegration(instanceID int, intType, intID string) error {
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::integration::delete instance ID: %d, intType: %s, intID: %s", instanceID, intType, intID)
-	path := fmt.Sprintf("/api/instances/%d/integrations/%s/%s", instanceID, intType, intID)
-	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
+	var (
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/integrations/%s/%s", instanceID, intType, intID)
+	)
 
-	if response.StatusCode != 204 {
-		return fmt.Errorf("DeleteNotification failed, status: %v, message: %s", response.StatusCode, failed)
+	log.Printf("[DEBUG] api::integration#delete path: %s", path)
+	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
+	if err != nil {
+		return err
 	}
 
-	return err
+	switch response.StatusCode {
+	case 204:
+		return nil
+	default:
+		return fmt.Errorf("delete notification failed, status: %d, message: %s",
+			response.StatusCode, failed)
+	}
 }

--- a/api/metadata.go
+++ b/api/metadata.go
@@ -28,17 +28,18 @@ func (api *API) ValidatePlan(name string) error {
 		return err
 	}
 
-	if response.StatusCode != 200 {
-		return fmt.Errorf("validate subscription plan. Status code: %d, message: %v",
+	switch response.StatusCode {
+	case 200:
+		for _, plan := range data {
+			if name == plan.Name {
+				return nil
+			}
+		}
+		return fmt.Errorf("subscription plan: %s is not valid", name)
+	default:
+		return fmt.Errorf("failed to validate subscription plan, status code: %d, message: %s",
 			response.StatusCode, failed)
 	}
-
-	for _, plan := range data {
-		if name == plan.Name {
-			return nil
-		}
-	}
-	return fmt.Errorf("subscription plan: %s is not valid", name)
 }
 
 // PlanTypes: Fetch if old/new plans are shared/dedicated
@@ -56,19 +57,20 @@ func (api *API) PlanTypes(old, new string) (string, string, error) {
 		return "", "", err
 	}
 
-	if response.StatusCode != 200 {
+	switch response.StatusCode {
+	case 200:
+		for _, plan := range data {
+			if old == plan.Name {
+				oldPlanType = planType(plan.Shared)
+			} else if new == plan.Name {
+				newPlanType = planType(plan.Shared)
+			}
+		}
+		return oldPlanType, newPlanType, nil
+	default:
 		return "", "", fmt.Errorf("Plan types. "+
 			"Status code: %d, message: %v", response.StatusCode, failed)
 	}
-
-	for _, plan := range data {
-		if old == plan.Name {
-			oldPlanType = planType(plan.Shared)
-		} else if new == plan.Name {
-			newPlanType = planType(plan.Shared)
-		}
-	}
-	return oldPlanType, newPlanType, nil
 }
 
 func planType(shared bool) string {
@@ -93,17 +95,17 @@ func (api *API) ValidateRegion(region string) error {
 		return err
 	}
 
-	if response.StatusCode != 200 {
-		return fmt.Errorf("validate region. Status code: %d, message: %v",
+	switch response.StatusCode {
+	case 200:
+		for _, v := range data {
+			platform = fmt.Sprintf("%s::%s", v.Provider, v.Region)
+			if region == platform {
+				return nil
+			}
+		}
+		return fmt.Errorf("provider & region: %s is not valid", region)
+	default:
+		return fmt.Errorf("failed to validate region, status code: %d, message: %v",
 			response.StatusCode, failed)
 	}
-
-	for _, v := range data {
-		platform = fmt.Sprintf("%s::%s", v.Provider, v.Region)
-		if region == platform {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("provider & region: %s is not valid", region)
 }

--- a/api/metadata.go
+++ b/api/metadata.go
@@ -19,7 +19,7 @@ type Region struct {
 func (api *API) ValidatePlan(name string) error {
 	var (
 		data   []Plan
-		failed map[string]interface{}
+		failed map[string]any
 		path   = "api/plans"
 	)
 
@@ -46,7 +46,7 @@ func (api *API) ValidatePlan(name string) error {
 func (api *API) PlanTypes(old, new string) (string, string, error) {
 	var (
 		data        []Plan
-		failed      map[string]interface{}
+		failed      map[string]any
 		path        = "api/plans"
 		oldPlanType string
 		newPlanType string
@@ -85,7 +85,7 @@ func planType(shared bool) string {
 func (api *API) ValidateRegion(region string) error {
 	var (
 		data     []Region
-		failed   map[string]interface{}
+		failed   map[string]any
 		path     = "api/regions"
 		platform string
 	)

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -7,10 +7,10 @@ import (
 )
 
 // ListNodes - list all nodes of the cluster
-func (api *API) ListNodes(instanceID int) ([]map[string]interface{}, error) {
+func (api *API) ListNodes(instanceID int) ([]map[string]any, error) {
 	var (
-		data   []map[string]interface{}
-		failed map[string]interface{}
+		data   []map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("api/instances/%d/nodes", instanceID)
 	)
 
@@ -30,9 +30,9 @@ func (api *API) ListNodes(instanceID int) ([]map[string]interface{}, error) {
 }
 
 // ReadNode - read out node information of a single node
-func (api *API) ReadNode(instanceID int, nodeName string) (map[string]interface{}, error) {
+func (api *API) ReadNode(instanceID int, nodeName string) (map[string]any, error) {
 	var (
-		data map[string]interface{}
+		data map[string]any
 	)
 
 	log.Printf("[DEBUG] go-api::nodes#read_node instance id: %d node name: %s", instanceID, nodeName)
@@ -52,11 +52,11 @@ func (api *API) ReadNode(instanceID int, nodeName string) (map[string]interface{
 
 // PostAction - request an action for the node (e.g. start/stop/restart RabbitMQ)
 func (api *API) PostAction(instanceID int, nodeName string, action string) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	var (
-		data          map[string]interface{}
-		failed        map[string]interface{}
+		data          map[string]any
+		failed        map[string]any
 		actionAsRoute string
 		params        = make(map[string][]string)
 		path          = fmt.Sprintf("api/instances/%d/actions/%s", instanceID, actionAsRoute)
@@ -85,7 +85,7 @@ func (api *API) PostAction(instanceID int, nodeName string, action string) (
 }
 
 func (api *API) waitOnNodeAction(instanceID int, nodeName string, action string) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	log.Printf("[DEBUG] api::nodes#waitOnNodeAction waiting")
 	for {

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -6,30 +6,41 @@ import (
 	"time"
 )
 
-// ReadNodes - read out node information of the cluster
-func (api *API) ReadNodes(instanceID int) ([]map[string]interface{}, error) {
-	var data []map[string]interface{}
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::nodes::read_nodes instance id: %d", instanceID)
-	path := fmt.Sprintf("api/instances/%d/nodes", instanceID)
+// ListNodes - list all nodes of the cluster
+func (api *API) ListNodes(instanceID int) ([]map[string]interface{}, error) {
+	var (
+		data   []map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("api/instances/%d/nodes", instanceID)
+	)
+
+	log.Printf("[DEBUG] api::nodes#list_nodes path: %s", path)
 	response, err := api.sling.New().Path(path).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("ReadNodes failed, status: %v, message: %s", response.StatusCode, failed)
+
+	switch response.StatusCode {
+	case 200:
+		return data, nil
+	default:
+		return nil, fmt.Errorf("list nodes failed, status: %d, message: %s",
+			response.StatusCode, failed)
 	}
-	return data, nil
 }
 
 // ReadNode - read out node information of a single node
 func (api *API) ReadNode(instanceID int, nodeName string) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::nodes::read_node instance id: %d node name: %s", instanceID, nodeName)
-	response, err := api.ReadNodes(instanceID)
+	var (
+		data map[string]interface{}
+	)
+
+	log.Printf("[DEBUG] go-api::nodes#read_node instance id: %d node name: %s", instanceID, nodeName)
+	response, err := api.ListNodes(instanceID)
 	if err != nil {
 		return nil, err
 	}
+
 	for i := range response {
 		if response[i]["name"] == nodeName {
 			data = response[i]
@@ -40,32 +51,43 @@ func (api *API) ReadNode(instanceID int, nodeName string) (map[string]interface{
 }
 
 // PostAction - request an action for the node (e.g. start/stop/restart RabbitMQ)
-func (api *API) PostAction(instanceID int, nodeName string, action string) (map[string]interface{}, error) {
-	var actionAsRoute string
-	params := make(map[string][]string)
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
+func (api *API) PostAction(instanceID int, nodeName string, action string) (
+	map[string]interface{}, error) {
+
+	var (
+		data          map[string]interface{}
+		failed        map[string]interface{}
+		actionAsRoute string
+		params        = make(map[string][]string)
+		path          = fmt.Sprintf("api/instances/%d/actions/%s", instanceID, actionAsRoute)
+	)
+
 	if action == "mgmt.restart" {
 		actionAsRoute = "mgmt-restart"
 	} else {
 		actionAsRoute = action
 	}
 	params["nodes"] = append(params["nodes"], nodeName)
-	path := fmt.Sprintf("api/instances/%d/actions/%s", instanceID, actionAsRoute)
-	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
 
+	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("action failed, status: %v, message: %s", response.StatusCode, failed)
-	}
 
-	return api.waitOnNodeAction(instanceID, nodeName, action)
+	switch response.StatusCode {
+	case 200:
+		return api.waitOnNodeAction(instanceID, nodeName, action)
+	default:
+
+		return nil, fmt.Errorf("action %s failed, status: %d, message: %s",
+			action, response.StatusCode, failed)
+	}
 }
 
-func (api *API) waitOnNodeAction(instanceID int, nodeName string, action string) (map[string]interface{}, error) {
-	log.Printf("[DEBUG] go-api::nodes::waitOnNodeAction waiting")
+func (api *API) waitOnNodeAction(instanceID int, nodeName string, action string) (
+	map[string]interface{}, error) {
+
+	log.Printf("[DEBUG] api::nodes#waitOnNodeAction waiting")
 	for {
 		data, err := api.ReadNode(instanceID, nodeName)
 

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -59,16 +59,16 @@ func (api *API) PostAction(instanceID int, nodeName string, action string) (
 		failed        map[string]any
 		actionAsRoute string
 		params        = make(map[string][]string)
-		path          = fmt.Sprintf("api/instances/%d/actions/%s", instanceID, actionAsRoute)
 	)
+
+	params["nodes"] = append(params["nodes"], nodeName)
 
 	if action == "mgmt.restart" {
 		actionAsRoute = "mgmt-restart"
 	} else {
 		actionAsRoute = action
 	}
-	params["nodes"] = append(params["nodes"], nodeName)
-
+	path := fmt.Sprintf("api/instances/%d/actions/%s", instanceID, actionAsRoute)
 	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
 	if err != nil {
 		return nil, err

--- a/api/notifications.go
+++ b/api/notifications.go
@@ -6,12 +6,10 @@ import (
 	"strconv"
 )
 
-func (api *API) CreateNotification(instanceID int, params map[string]interface{}) (
-	map[string]interface{}, error) {
-
+func (api *API) CreateNotification(instanceID int, params map[string]any) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/alarms/recipients", instanceID)
 	)
 
@@ -36,12 +34,10 @@ func (api *API) CreateNotification(instanceID int, params map[string]interface{}
 	}
 }
 
-func (api *API) ReadNotification(instanceID int, recipientID string) (
-	map[string]interface{}, error) {
-
+func (api *API) ReadNotification(instanceID int, recipientID string) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/alarms/recipients/%s", instanceID, recipientID)
 	)
 
@@ -61,10 +57,10 @@ func (api *API) ReadNotification(instanceID int, recipientID string) (
 	}
 }
 
-func (api *API) ListNotifications(instanceID int) ([]map[string]interface{}, error) {
+func (api *API) ListNotifications(instanceID int) ([]map[string]any, error) {
 	var (
-		data   []map[string]interface{}
-		failed map[string]interface{}
+		data   []map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/alarms/recipients", instanceID)
 	)
 
@@ -85,10 +81,10 @@ func (api *API) ListNotifications(instanceID int) ([]map[string]interface{}, err
 }
 
 func (api *API) UpdateNotification(instanceID int, recipientID string,
-	params map[string]interface{}) error {
+	params map[string]any) error {
 
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/alarms/recipients/%s", instanceID, recipientID)
 	)
 
@@ -109,7 +105,7 @@ func (api *API) UpdateNotification(instanceID int, recipientID string,
 
 func (api *API) DeleteNotification(instanceID int, recipientID string) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/alarms/recipients/%s", instanceID, recipientID)
 	)
 

--- a/api/notifications.go
+++ b/api/notifications.go
@@ -6,93 +6,105 @@ import (
 	"strconv"
 )
 
-func (api *API) CreateNotification(instanceID int, params map[string]interface{}) (map[string]interface{}, error) {
+func (api *API) CreateNotification(instanceID int, params map[string]interface{}) (
+	map[string]interface{}, error) {
+
 	var (
 		data   map[string]interface{}
 		failed map[string]interface{}
 		path   = fmt.Sprintf("/api/instances/%d/alarms/recipients", instanceID)
 	)
 
-	log.Printf("[DEBUG] go-api::notification::create path: %s", path)
+	log.Printf("[DEBUG] api::notification#create path: %s", path)
 	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::notification::create data: %v", data)
-
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 201 {
+
+	switch response.StatusCode {
+	case 201:
+		log.Printf("[DEBUG] api::notification#create data: %v", data)
+		if v, ok := data["id"]; ok {
+			data["id"] = strconv.FormatFloat(v.(float64), 'f', 0, 64)
+		} else {
+			return nil, fmt.Errorf("create notification invalid identifier: %v", data["id"])
+		}
+		return data, err
+	default:
 		return nil, fmt.Errorf("create notification failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
-
-	if v, ok := data["id"]; ok {
-		data["id"] = strconv.FormatFloat(v.(float64), 'f', 0, 64)
-	} else {
-		return nil, fmt.Errorf("create notification invalid identifier: %v", data["id"])
-	}
-
-	return data, err
 }
 
-func (api *API) ReadNotification(instanceID int, recipientID string) (map[string]interface{}, error) {
+func (api *API) ReadNotification(instanceID int, recipientID string) (
+	map[string]interface{}, error) {
+
 	var (
 		data   map[string]interface{}
 		failed map[string]interface{}
 		path   = fmt.Sprintf("/api/instances/%d/alarms/recipients/%s", instanceID, recipientID)
 	)
 
-	log.Printf("[DEBUG] go-api::notification::read path: %s", path)
+	log.Printf("[DEBUG] api::notification#read path: %s", path)
 	response, err := api.sling.New().Path(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::notification::read data: %v", data)
-
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("read notification failed, status: %v, message: %s",
+
+	switch response.StatusCode {
+	case 200:
+		log.Printf("[DEBUG] api::notification#read data: %v", data)
+		return data, nil
+	default:
+		return nil, fmt.Errorf("read notification failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
-
-	return data, err
 }
 
-func (api *API) ReadNotifications(instanceID int) ([]map[string]interface{}, error) {
+func (api *API) ListNotifications(instanceID int) ([]map[string]interface{}, error) {
 	var (
 		data   []map[string]interface{}
 		failed map[string]interface{}
 		path   = fmt.Sprintf("/api/instances/%d/alarms/recipients", instanceID)
 	)
 
-	log.Printf("[DEBUG] go-api::ReadNotifications::read path: %s", path)
+	log.Printf("[DEBUG] api::ReadNotifications#read path: %s", path)
 	response, err := api.sling.New().Path(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::ReadNotifications::read data: %v", data)
-
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
+
+	switch response.StatusCode {
+	case 200:
+		log.Printf("[DEBUG] api::ReadNotifications#read data: %v", data)
+		return data, nil
+	default:
 		return nil, fmt.Errorf("read notification failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
-
-	return data, err
 }
 
-func (api *API) UpdateNotification(instanceID int, recipientID string, params map[string]interface{}) error {
+func (api *API) UpdateNotification(instanceID int, recipientID string,
+	params map[string]interface{}) error {
+
 	var (
 		failed map[string]interface{}
 		path   = fmt.Sprintf("/api/instances/%d/alarms/recipients/%s", instanceID, recipientID)
 	)
 
-	log.Printf("[DEBUG] go-api::notification::update path: %s", path)
+	log.Printf("[DEBUG] api::notification#update path: %s", path)
 	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
+	if err != nil {
+		return err
+	}
 
-	if response.StatusCode != 200 {
+	switch response.StatusCode {
+	case 200:
+		return nil
+	default:
 		return fmt.Errorf("update notification failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
-
-	return err
 }
 
 func (api *API) DeleteNotification(instanceID int, recipientID string) error {
@@ -101,13 +113,17 @@ func (api *API) DeleteNotification(instanceID int, recipientID string) error {
 		path   = fmt.Sprintf("/api/instances/%d/alarms/recipients/%s", instanceID, recipientID)
 	)
 
-	log.Printf("[DEBUG] go-api::notification::delete path: %s", path)
+	log.Printf("[DEBUG] api::notification#delete path: %s", path)
 	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
+	if err != nil {
+		return err
+	}
 
-	if response.StatusCode != 204 {
+	switch response.StatusCode {
+	case 204:
+		return nil
+	default:
 		return fmt.Errorf("delete notification failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
-
-	return err
 }

--- a/api/plugins.go
+++ b/api/plugins.go
@@ -18,9 +18,8 @@ func (api *API) EnablePlugin(instanceID int, pluginName string, sleep, timeout i
 	)
 
 	params["plugin_name"] = pluginName
-	log.Printf("[DEBUG] go-api::plugin::enable instance id: %v, params: %v", instanceID, params)
+	log.Printf("[DEBUG] api::plugin#enable instance id: %d, params: %v", instanceID, params)
 	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(nil, &failed)
-
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +29,7 @@ func (api *API) EnablePlugin(instanceID int, pluginName string, sleep, timeout i
 		return api.waitUntilPluginChanged(instanceID, pluginName, true, 1, sleep, timeout)
 	default:
 		return nil,
-			fmt.Errorf("enable plugin failed, status: %v, message: %s", response.StatusCode, failed)
+			fmt.Errorf("enable plugin failed, status: %d, message: %s", response.StatusCode, failed)
 	}
 }
 
@@ -38,7 +37,7 @@ func (api *API) EnablePlugin(instanceID int, pluginName string, sleep, timeout i
 func (api *API) ReadPlugin(instanceID int, pluginName string, sleep, timeout int) (
 	map[string]interface{}, error) {
 
-	log.Printf("[DEBUG] go-api::plugin::read instance id: %v, name: %v", instanceID, pluginName)
+	log.Printf("[DEBUG] api::plugin#read instance id: %d, name: %s", instanceID, pluginName)
 	data, err := api.ListPlugins(instanceID, sleep, timeout)
 	if err != nil {
 		return nil, err
@@ -46,7 +45,7 @@ func (api *API) ReadPlugin(instanceID int, pluginName string, sleep, timeout int
 
 	for _, plugin := range data {
 		if plugin["name"] == pluginName {
-			log.Printf("[DEBUG] go-api::plugin::read plugin found: %v", pluginName)
+			log.Printf("[DEBUG] api::plugin:#read plugin found: %s", pluginName)
 			return plugin, nil
 		}
 	}
@@ -81,18 +80,15 @@ func (api *API) listPluginsWithRetry(instanceID, attempt, sleep, timeout int) (
 		return data, nil
 	case 400:
 		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			log.Printf("[INFO] go-api::plugins::read Timeout talking to backend "+
+			log.Printf("[INFO] api::plugins#read Timeout talking to backend "+
 				"attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.listPluginsWithRetry(instanceID, attempt, sleep, timeout)
 		}
-		return nil, fmt.Errorf("ReadWithRetry failed, status: %v, message: %s", 400, failed)
-	default:
-		return nil,
-			fmt.Errorf("list plugin with retry failed, status: %v, message: %s",
-				response.StatusCode, failed)
 	}
+	return nil, fmt.Errorf("list plugin with retry failed, status: %d, message: %s",
+		response.StatusCode, failed)
 }
 
 // UpdatePlugin: updates a plugin from an instance.
@@ -107,9 +103,8 @@ func (api *API) UpdatePlugin(instanceID int, pluginName string, enabled bool, sl
 
 	params["plugin_name"] = pluginName
 	params["enabled"] = enabled
-	log.Printf("[DEBUG] go-api::plugin::update instance ID: %v, params: %v", instanceID, params)
+	log.Printf("[DEBUG] api::plugin#update path: %s", path)
 	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
-
 	if err != nil {
 		return nil, err
 	}
@@ -118,8 +113,8 @@ func (api *API) UpdatePlugin(instanceID int, pluginName string, enabled bool, sl
 	case 204:
 		return api.waitUntilPluginChanged(instanceID, pluginName, enabled, 1, sleep, timeout)
 	default:
-		return nil,
-			fmt.Errorf("update plugin failed, status: %v, message: %s", response.StatusCode, failed)
+		return nil, fmt.Errorf("update plugin failed, status: %d, message: %s",
+			response.StatusCode, failed)
 	}
 }
 
@@ -132,9 +127,8 @@ func (api *API) DisablePlugin(instanceID int, pluginName string, sleep, timeout 
 		path   = fmt.Sprintf("/api/instances/%d/plugins/%s?async=true", instanceID, pluginName)
 	)
 
-	log.Printf("[DEBUG] go-api::plugin::disable path: %s", path)
+	log.Printf("[DEBUG] api::plugin#disable path: %s", path)
 	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
-
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +137,7 @@ func (api *API) DisablePlugin(instanceID int, pluginName string, sleep, timeout 
 	case 204:
 		return api.waitUntilPluginChanged(instanceID, pluginName, false, 1, sleep, timeout)
 	default:
-		return nil, fmt.Errorf("disable plugin failed, status: %v, message: %s",
+		return nil, fmt.Errorf("disable plugin failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
 }
@@ -155,7 +149,7 @@ func (api *API) DeletePlugin(instanceID int, pluginName string, sleep, timeout i
 		path   = fmt.Sprintf("/api/instances/%d/plugins/%s?async=true", instanceID, pluginName)
 	)
 
-	log.Printf("[DEBUG] go-api::plugin::delete path: %s", path)
+	log.Printf("[DEBUG] api::plugin#delete path: %s", path)
 	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
 	if err != nil {
 		return err
@@ -166,7 +160,7 @@ func (api *API) DeletePlugin(instanceID int, pluginName string, sleep, timeout i
 		_, err = api.waitUntilPluginChanged(instanceID, pluginName, false, 1, sleep, timeout)
 		return err
 	default:
-		return fmt.Errorf("delete plugin failed, status: %v, message: %s",
+		return fmt.Errorf("delete plugin failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
 }
@@ -181,7 +175,7 @@ func (api *API) waitUntilPluginChanged(instanceID int, pluginName string, enable
 		}
 
 		response, err := api.ReadPlugin(instanceID, pluginName, sleep, timeout)
-		log.Printf("[DEBUG] go-api::plugin::waitUntilPluginChanged response: %v", response)
+		log.Printf("[DEBUG] api::plugin#waitUntilPluginChanged response: %v", response)
 		if err != nil {
 			return nil, err
 		}

--- a/api/plugins.go
+++ b/api/plugins.go
@@ -9,11 +9,11 @@ import (
 
 // EnablePlugin: enable a plugin on an instance.
 func (api *API) EnablePlugin(instanceID int, pluginName string, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	var (
-		failed map[string]interface{}
-		params = make(map[string]interface{})
+		failed map[string]any
+		params = make(map[string]any)
 		path   = fmt.Sprintf("/api/instances/%d/plugins?async=true", instanceID)
 	)
 
@@ -35,7 +35,7 @@ func (api *API) EnablePlugin(instanceID int, pluginName string, sleep, timeout i
 
 // ReadPlugin: reads a specific plugin from an instance.
 func (api *API) ReadPlugin(instanceID int, pluginName string, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	log.Printf("[DEBUG] api::plugin#read instance id: %d, name: %s", instanceID, pluginName)
 	data, err := api.ListPlugins(instanceID, sleep, timeout)
@@ -54,17 +54,17 @@ func (api *API) ReadPlugin(instanceID int, pluginName string, sleep, timeout int
 }
 
 // ListPlugins: list plugins from an instance.
-func (api *API) ListPlugins(instanceID, sleep, timeout int) ([]map[string]interface{}, error) {
+func (api *API) ListPlugins(instanceID, sleep, timeout int) ([]map[string]any, error) {
 	return api.listPluginsWithRetry(instanceID, 1, sleep, timeout)
 }
 
 // listPluginsWithRetry: list plugins from an instance, with retry if backend is busy.
 func (api *API) listPluginsWithRetry(instanceID, attempt, sleep, timeout int) (
-	[]map[string]interface{}, error) {
+	[]map[string]any, error) {
 
 	var (
-		data   []map[string]interface{}
-		failed map[string]interface{}
+		data   []map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/plugins", instanceID)
 	)
 
@@ -93,11 +93,11 @@ func (api *API) listPluginsWithRetry(instanceID, attempt, sleep, timeout int) (
 
 // UpdatePlugin: updates a plugin from an instance.
 func (api *API) UpdatePlugin(instanceID int, pluginName string, enabled bool, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	var (
-		failed map[string]interface{}
-		params = make(map[string]interface{})
+		failed map[string]any
+		params = make(map[string]any)
 		path   = fmt.Sprintf("/api/instances/%d/plugins?async=true", instanceID)
 	)
 
@@ -120,10 +120,10 @@ func (api *API) UpdatePlugin(instanceID int, pluginName string, enabled bool, sl
 
 // DisablePlugin: disables a plugin from an instance.
 func (api *API) DisablePlugin(instanceID int, pluginName string, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/plugins/%s?async=true", instanceID, pluginName)
 	)
 
@@ -145,7 +145,7 @@ func (api *API) DisablePlugin(instanceID int, pluginName string, sleep, timeout 
 // DeletePlugin: deletes a plugin from an instance.
 func (api *API) DeletePlugin(instanceID int, pluginName string, sleep, timeout int) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/plugins/%s?async=true", instanceID, pluginName)
 	)
 
@@ -167,7 +167,7 @@ func (api *API) DeletePlugin(instanceID int, pluginName string, sleep, timeout i
 
 // waitUntilPluginChanged: wait until plugin changed.
 func (api *API) waitUntilPluginChanged(instanceID int, pluginName string, enabled bool,
-	attempt, sleep, timeout int) (map[string]interface{}, error) {
+	attempt, sleep, timeout int) (map[string]any, error) {
 
 	for {
 		if attempt*sleep > timeout {

--- a/api/plugins_community.go
+++ b/api/plugins_community.go
@@ -9,11 +9,11 @@ import (
 
 // InstallPluginCommunity: install a community plugin on an instance.
 func (api *API) InstallPluginCommunity(instanceID int, pluginName string, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	var (
-		failed map[string]interface{}
-		params = make(map[string]interface{})
+		failed map[string]any
+		params = make(map[string]any)
 		path   = fmt.Sprintf("/api/instances/%d/plugins/community?async=true", instanceID)
 	)
 
@@ -35,7 +35,7 @@ func (api *API) InstallPluginCommunity(instanceID int, pluginName string, sleep,
 
 // ReadPluginCommunity: reads a specific community plugin from an instance.
 func (api *API) ReadPluginCommunity(instanceID int, pluginName string, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	log.Printf("[DEBUG] api::plugin_community#read instance ID: %v, name: %v", instanceID, pluginName)
 	data, err := api.ListPluginsCommunity(instanceID, sleep, timeout)
@@ -54,26 +54,23 @@ func (api *API) ReadPluginCommunity(instanceID int, pluginName string, sleep, ti
 }
 
 // ListPluginsCommunity: list all community plugins for an instance.
-func (api *API) ListPluginsCommunity(instanceID, sleep, timeout int) (
-	[]map[string]interface{}, error) {
-
+func (api *API) ListPluginsCommunity(instanceID, sleep, timeout int) ([]map[string]any, error) {
 	return api.listPluginsCommunityWithRetry(instanceID, 1, sleep, timeout)
 }
 
 // listPluginsCommunityWithRetry: list all community plugins for an instance,
 // with retry if the backend is busy.
 func (api *API) listPluginsCommunityWithRetry(instanceID, attempt, sleep, timeout int) (
-	[]map[string]interface{}, error) {
+	[]map[string]any, error) {
 
 	var (
-		data   []map[string]interface{}
-		failed map[string]interface{}
+		data   []map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/plugins/community", instanceID)
 	)
 
 	log.Printf("[DEBUG] api::plugin_community#listPluginsCommunityWithRetry path: %s", path)
 	response, err := api.sling.New().Get(path).Receive(&data, &failed)
-
 	if err != nil {
 		return nil, err
 	} else if attempt*sleep > timeout {
@@ -100,11 +97,11 @@ func (api *API) listPluginsCommunityWithRetry(instanceID, attempt, sleep, timeou
 
 // UpdatePluginCommunity: updates a community plugin from an instance.
 func (api *API) UpdatePluginCommunity(instanceID int, pluginName string, enabled bool,
-	sleep, timeout int) (map[string]interface{}, error) {
+	sleep, timeout int) (map[string]any, error) {
 
 	var (
-		failed map[string]interface{}
-		params = make(map[string]interface{})
+		failed map[string]any
+		params = make(map[string]any)
 		path   = fmt.Sprintf("/api/instances/%d/plugins/community?async=true", instanceID)
 	)
 
@@ -127,10 +124,10 @@ func (api *API) UpdatePluginCommunity(instanceID int, pluginName string, enabled
 
 // UninstallPluginCommunity: uninstall a community plugin from an instance.
 func (api *API) UninstallPluginCommunity(instanceID int, pluginName string, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/plugins/community/%s?async=true", instanceID, pluginName)
 	)
 
@@ -151,7 +148,7 @@ func (api *API) UninstallPluginCommunity(instanceID int, pluginName string, slee
 
 // waitUntilPluginUninstalled: wait until a community plugin been uninstalled.
 func (api *API) waitUntilPluginUninstalled(instanceID int, pluginName string,
-	attempt, sleep, timeout int) (map[string]interface{}, error) {
+	attempt, sleep, timeout int) (map[string]any, error) {
 
 	log.Printf("[DEBUG] api::plugin_community#waitUntilPluginUninstalled instance id: %v, name: %v",
 		instanceID, pluginName)

--- a/api/privatelink.go
+++ b/api/privatelink.go
@@ -31,7 +31,7 @@ func (api *API) EnablePrivatelink(instanceID int, params map[string][]interface{
 	case 204:
 		return api.waitForEnablePrivatelinkWithRetry(instanceID, 1, sleep, timeout)
 	default:
-		return fmt.Errorf("enable PrivateLink failed, status: %v, message: %s",
+		return fmt.Errorf("enable PrivateLink failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
 }
@@ -62,7 +62,7 @@ func (api *API) readPrivateLinkWithRetry(instanceID, attempt, sleep, timeout int
 		return data, nil
 	case 400:
 		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			log.Printf("[INFO] go-api::privatelink::read Timeout talking to backend "+
+			log.Printf("[INFO] api::privatelink#read Timeout talking to backend "+
 				"attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
@@ -70,7 +70,7 @@ func (api *API) readPrivateLinkWithRetry(instanceID, attempt, sleep, timeout int
 		}
 	}
 
-	return nil, fmt.Errorf("read PrivateLink failed, status: %v, message: %s",
+	return nil, fmt.Errorf("read PrivateLink failed, status: %d, message: %s",
 		response.StatusCode, failed)
 }
 
@@ -90,7 +90,7 @@ func (api *API) UpdatePrivatelink(instanceID int, params map[string][]interface{
 	case 204:
 		return nil
 	default:
-		return fmt.Errorf("update Privatelink failed, status: %v, message: %s",
+		return fmt.Errorf("update Privatelink failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
 }
@@ -111,7 +111,7 @@ func (api *API) DisablePrivatelink(instanceID int) error {
 	case 204:
 		return nil
 	default:
-		return fmt.Errorf("disable Privatelink failed, status: %v, message: %s",
+		return fmt.Errorf("disable Privatelink failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
 }
@@ -130,15 +130,15 @@ func (api *API) waitForEnablePrivatelinkWithRetry(instanceID, attempt, sleep, ti
 	} else if attempt*sleep > timeout {
 		return fmt.Errorf("enable PrivateLink failed, reached timeout of %d seconds", timeout)
 	}
-	log.Printf("[DEBUG] PrivateLink: waitForEnablePrivatelinkWithRetry data: %v", data)
 
 	switch response.StatusCode {
 	case 200:
+		log.Printf("[DEBUG] PrivateLink: waitForEnablePrivatelinkWithRetry data: %v", data)
 		switch data["status"].(string) {
 		case "enabled":
 			return nil
 		case "pending":
-			log.Printf("[DEBUG] go-api::privatelink::enable not finished and will retry, "+
+			log.Printf("[DEBUG] api::privatelink#enable not finished and will retry, "+
 				"attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
@@ -146,6 +146,6 @@ func (api *API) waitForEnablePrivatelinkWithRetry(instanceID, attempt, sleep, ti
 		}
 	}
 
-	return fmt.Errorf("wait for enable PrivateLink failed, status: %v, message: %s",
+	return fmt.Errorf("wait for enable PrivateLink failed, status: %d, message: %s",
 		response.StatusCode, failed)
 }

--- a/api/privatelink.go
+++ b/api/privatelink.go
@@ -10,11 +10,11 @@ import (
 // EnablePrivatelink: Enable PrivateLink and wait until finished.
 // Need to enable VPC for an instance, if no standalone VPC used.
 // Wait until finished with configureable sleep and timeout.
-func (api *API) EnablePrivatelink(instanceID int, params map[string][]interface{},
+func (api *API) EnablePrivatelink(instanceID int, params map[string][]any,
 	sleep, timeout int) error {
 
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
 	)
 
@@ -37,16 +37,16 @@ func (api *API) EnablePrivatelink(instanceID int, params map[string][]interface{
 }
 
 // ReadPrivatelink: Reads PrivateLink information
-func (api *API) ReadPrivatelink(instanceID, sleep, timeout int) (map[string]interface{}, error) {
+func (api *API) ReadPrivatelink(instanceID, sleep, timeout int) (map[string]any, error) {
 	return api.readPrivateLinkWithRetry(instanceID, 1, sleep, timeout)
 }
 
 func (api *API) readPrivateLinkWithRetry(instanceID, attempt, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
 	)
 
@@ -75,9 +75,9 @@ func (api *API) readPrivateLinkWithRetry(instanceID, attempt, sleep, timeout int
 }
 
 // UpdatePrivatelink: Update allowed principals or subscriptions
-func (api *API) UpdatePrivatelink(instanceID int, params map[string][]interface{}) error {
+func (api *API) UpdatePrivatelink(instanceID int, params map[string][]any) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
 	)
 
@@ -98,7 +98,7 @@ func (api *API) UpdatePrivatelink(instanceID int, params map[string][]interface{
 // DisablePrivatelink: Disable the PrivateLink feature
 func (api *API) DisablePrivatelink(instanceID int) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
 	)
 
@@ -119,8 +119,8 @@ func (api *API) DisablePrivatelink(instanceID int) error {
 // waitForEnablePrivatelinkWithRetry: Wait until status change from pending to enable
 func (api *API) waitForEnablePrivatelinkWithRetry(instanceID, attempt, sleep, timeout int) error {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/privatelink", instanceID)
 	)
 

--- a/api/rabbitmq_configuration.go
+++ b/api/rabbitmq_configuration.go
@@ -7,46 +7,48 @@ import (
 	"time"
 )
 
-func (api *API) ReadRabbitMqConfiguration(instanceID, sleep, timeout int) (map[string]interface{}, error) {
+func (api *API) ReadRabbitMqConfiguration(instanceID, sleep, timeout int) (
+	map[string]interface{}, error) {
+
 	return api.readRabbitMqConfigurationWithRetry(instanceID, 1, sleep, timeout)
 }
 
-func (api *API) readRabbitMqConfigurationWithRetry(instanceID, attempt, sleep, timeout int) (map[string]interface{}, error) {
+func (api *API) readRabbitMqConfigurationWithRetry(instanceID, attempt, sleep, timeout int) (
+	map[string]interface{}, error) {
+
 	var (
 		data   map[string]interface{}
 		failed map[string]interface{}
 		path   = fmt.Sprintf("/api/instances/%d/config", instanceID)
 	)
 	response, err := api.sling.New().Get(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::rabbitmq-configuration#readWithRetry data: %v", data)
-
 	if err != nil {
 		return nil, err
 	}
 
 	switch response.StatusCode {
 	case 200:
+		log.Printf("[DEBUG] api::rabbitmq_configuration#readWithRetry data: %v", data)
 		return data, nil
 	case 400:
 		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			log.Printf("[DEBUG] go-api::rabbitmq-configuration::readWithRetry Timeout talking to backend, "+
+			log.Printf("[DEBUG] api::rabbitmq-configuration#readWithRetry Timeout talking to backend, "+
 				"attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.readRabbitMqConfigurationWithRetry(instanceID, attempt, sleep, timeout)
-		} else {
-			break
 		}
 	case 503:
 		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			log.Printf("[DEBUG] go-api::rabbitmq-configuration::readWithRetry Timeout talking to backend, "+
+			log.Printf("[DEBUG] api::rabbitmq_configuration#readWithRetry Timeout talking to backend, "+
 				"attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.readRabbitMqConfigurationWithRetry(instanceID, attempt, sleep, timeout)
 		}
 	}
-	return nil, fmt.Errorf("read RabbitMQ configuration failed, status: %v, message: %s", response.StatusCode, failed)
+	return nil, fmt.Errorf("read RabbitMQ configuration failed, status: %d, message: %s",
+		response.StatusCode, failed)
 }
 
 func (api *API) UpdateRabbitMqConfiguration(instanceID int, params map[string]interface{},
@@ -64,7 +66,8 @@ func (api *API) updateRabbitMqConfigurationWithRetry(instanceID int, params map[
 	if err != nil {
 		return err
 	} else if attempt*sleep > timeout {
-		return fmt.Errorf("update RabbitMQ configuraiton failed, reached timeout of %d seconds", timeout)
+		return fmt.Errorf("update RabbitMQ configuraiton failed, reached timeout of %d seconds",
+			timeout)
 	}
 
 	switch response.StatusCode {
@@ -72,26 +75,23 @@ func (api *API) updateRabbitMqConfigurationWithRetry(instanceID int, params map[
 		return nil
 	case 400:
 		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			log.Printf("[DEBUG] go-api::rabbitmq-configuration::updateWithRetry Timeout talking to backend, "+
+			log.Printf("[DEBUG] api::rabbitmq_configuration#updateWithRetry Timeout talking to backend, "+
 				"attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.updateRabbitMqConfigurationWithRetry(instanceID, params, attempt, sleep, timeout)
-		} else {
-			break
 		}
 	case 503:
 		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			log.Printf("[DEBUG] go-api::rabbitmq-configuration::updateWithRetry Timeout talking to backend, "+
+			log.Printf("[DEBUG] api::rabbitmq_configuration#updateWithRetry Timeout talking to backend, "+
 				"attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.updateRabbitMqConfigurationWithRetry(instanceID, params, attempt, sleep, timeout)
-		} else {
-			break
 		}
 	}
-	return fmt.Errorf("update RabbitMQ configuration failed, status: %v, message: %s", response.StatusCode, failed)
+	return fmt.Errorf("update RabbitMQ configuration failed, status: %d, message: %s",
+		response.StatusCode, failed)
 }
 
 func (api *API) DeleteRabbitMqConfiguration() error {

--- a/api/rabbitmq_configuration.go
+++ b/api/rabbitmq_configuration.go
@@ -7,20 +7,19 @@ import (
 	"time"
 )
 
-func (api *API) ReadRabbitMqConfiguration(instanceID, sleep, timeout int) (
-	map[string]interface{}, error) {
-
+func (api *API) ReadRabbitMqConfiguration(instanceID, sleep, timeout int) (map[string]any, error) {
 	return api.readRabbitMqConfigurationWithRetry(instanceID, 1, sleep, timeout)
 }
 
 func (api *API) readRabbitMqConfigurationWithRetry(instanceID, attempt, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/config", instanceID)
 	)
+
 	response, err := api.sling.New().Get(path).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
@@ -51,17 +50,19 @@ func (api *API) readRabbitMqConfigurationWithRetry(instanceID, attempt, sleep, t
 		response.StatusCode, failed)
 }
 
-func (api *API) UpdateRabbitMqConfiguration(instanceID int, params map[string]interface{},
+func (api *API) UpdateRabbitMqConfiguration(instanceID int, params map[string]any,
 	sleep, timeout int) error {
 	return api.updateRabbitMqConfigurationWithRetry(instanceID, params, 1, sleep, timeout)
 }
 
-func (api *API) updateRabbitMqConfigurationWithRetry(instanceID int, params map[string]interface{},
+func (api *API) updateRabbitMqConfigurationWithRetry(instanceID int, params map[string]any,
 	attempt, sleep, timeout int) error {
+
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("api/instances/%d/config", instanceID)
 	)
+
 	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
 	if err != nil {
 		return err

--- a/api/security_firewall.go
+++ b/api/security_firewall.go
@@ -8,8 +8,8 @@ import (
 
 func (api *API) waitUntilFirewallConfigured(instanceID, attempt, sleep, timeout int) error {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/security/firewall/configured", instanceID)
 	)
 
@@ -39,8 +39,8 @@ func (api *API) waitUntilFirewallConfigured(instanceID, attempt, sleep, timeout 
 	}
 }
 
-func (api *API) CreateFirewallSettings(instanceID int, params []map[string]interface{}, sleep,
-	timeout int) ([]map[string]interface{}, error) {
+func (api *API) CreateFirewallSettings(instanceID int, params []map[string]any, sleep, timeout int) (
+	[]map[string]any, error) {
 
 	attempt, err := api.createFirewallSettingsWithRetry(instanceID, params, 1, sleep, timeout)
 	if err != nil {
@@ -55,10 +55,11 @@ func (api *API) CreateFirewallSettings(instanceID int, params []map[string]inter
 	return api.ReadFirewallSettings(instanceID)
 }
 
-func (api *API) createFirewallSettingsWithRetry(instanceID int, params []map[string]interface{},
+func (api *API) createFirewallSettingsWithRetry(instanceID int, params []map[string]any,
 	attempt, sleep, timeout int) (int, error) {
+
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/security/firewall", instanceID)
 	)
 
@@ -93,10 +94,10 @@ func (api *API) createFirewallSettingsWithRetry(instanceID int, params []map[str
 		response.StatusCode, failed)
 }
 
-func (api *API) ReadFirewallSettings(instanceID int) ([]map[string]interface{}, error) {
+func (api *API) ReadFirewallSettings(instanceID int) ([]map[string]any, error) {
 	var (
-		data   []map[string]interface{}
-		failed map[string]interface{}
+		data   []map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/security/firewall", instanceID)
 	)
 
@@ -115,8 +116,8 @@ func (api *API) ReadFirewallSettings(instanceID int) ([]map[string]interface{}, 
 	}
 }
 
-func (api *API) UpdateFirewallSettings(instanceID int, params []map[string]interface{},
-	sleep, timeout int) ([]map[string]interface{}, error) {
+func (api *API) UpdateFirewallSettings(instanceID int, params []map[string]any,
+	sleep, timeout int) ([]map[string]any, error) {
 
 	log.Printf("[DEBUG] api::security_firewall#update instance id: %d, params: %v, sleep: %d, "+
 		"timeout: %d", instanceID, params, sleep, timeout)
@@ -131,11 +132,11 @@ func (api *API) UpdateFirewallSettings(instanceID int, params []map[string]inter
 	return api.ReadFirewallSettings(instanceID)
 }
 
-func (api *API) updateFirewallSettingsWithRetry(instanceID int, params []map[string]interface{},
+func (api *API) updateFirewallSettingsWithRetry(instanceID int, params []map[string]any,
 	attempt, sleep, timeout int) (int, error) {
 
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/security/firewall", instanceID)
 	)
 
@@ -169,9 +170,7 @@ func (api *API) updateFirewallSettingsWithRetry(instanceID int, params []map[str
 		response.StatusCode, failed)
 }
 
-func (api *API) DeleteFirewallSettings(instanceID, sleep, timeout int) (
-	[]map[string]interface{}, error) {
-
+func (api *API) DeleteFirewallSettings(instanceID, sleep, timeout int) ([]map[string]any, error) {
 	log.Printf("[DEBUG] api::security_firewall#delete instance id: %d, sleep: %d, timeout: %d",
 		instanceID, sleep, timeout)
 	attempt, err := api.deleteFirewallSettingsWithRetry(instanceID, 1, sleep, timeout)
@@ -191,8 +190,8 @@ func (api *API) deleteFirewallSettingsWithRetry(instanceID, attempt, sleep, time
 	int, error) {
 
 	var (
-		params [1]map[string]interface{}
-		failed map[string]interface{}
+		params [1]map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/security/firewall", instanceID)
 	)
 
@@ -229,8 +228,8 @@ func (api *API) deleteFirewallSettingsWithRetry(instanceID, attempt, sleep, time
 		response.StatusCode, failed)
 }
 
-func DefaultFirewallSettings() map[string]interface{} {
-	defaultRule := map[string]interface{}{
+func DefaultFirewallSettings() map[string]any {
+	defaultRule := map[string]any{
 		"services": []string{"AMQP", "AMQPS", "STOMP", "STOMPS", "MQTT", "MQTTS", "HTTPS", "STREAM",
 			"STREAM_SSL"},
 		"ports":       []int{},

--- a/api/security_firewall.go
+++ b/api/security_firewall.go
@@ -18,35 +18,40 @@ func (api *API) waitUntilFirewallConfigured(instanceID, attempt, sleep, timeout 
 		if err != nil {
 			return err
 		} else if attempt*sleep > timeout {
-			return fmt.Errorf("wait until firewall configured failed, reached timeout of %d seconds", timeout)
+			return fmt.Errorf("wait until firewall configured failed, reached timeout of %d seconds",
+				timeout)
 		}
 
 		switch response.StatusCode {
 		case 200:
 			return nil
 		case 400:
-			log.Printf("[DEBUG] go-api::security_firewall#waitUntilFirewallConfigured: The cluster is unavailable, firewall configuring")
+			log.Printf("[DEBUG] api::security_firewall#waitUntilFirewallConfigured: " +
+				"The cluster is unavailable, firewall configuring")
+			log.Printf("[INFO] api::security_firewall#waitUntilFirewallConfigured Attempt: %d, until "+
+				"timeout: %d", attempt, (timeout - (attempt * sleep)))
+			attempt++
+			time.Sleep(time.Duration(sleep) * time.Second)
 		default:
-			return fmt.Errorf("waitUntilReady failed, status: %v, message: %s", response.StatusCode, failed)
+			return fmt.Errorf("waitUntilReady failed, status: %d, message: %s",
+				response.StatusCode, failed)
 		}
-
-		log.Printf("[INFO] go-api::security_firewall::waitUntilFirewallConfigured The cluster is unavailable, "+
-			"firewall configuring. Attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
-		attempt++
-		time.Sleep(time.Duration(sleep) * time.Second)
 	}
 }
 
 func (api *API) CreateFirewallSettings(instanceID int, params []map[string]interface{}, sleep,
 	timeout int) ([]map[string]interface{}, error) {
+
 	attempt, err := api.createFirewallSettingsWithRetry(instanceID, params, 1, sleep, timeout)
 	if err != nil {
 		return nil, err
 	}
+
 	err = api.waitUntilFirewallConfigured(instanceID, attempt, sleep, timeout)
 	if err != nil {
 		return nil, err
 	}
+
 	return api.ReadFirewallSettings(instanceID)
 }
 
@@ -56,13 +61,14 @@ func (api *API) createFirewallSettingsWithRetry(instanceID int, params []map[str
 		failed map[string]interface{}
 		path   = fmt.Sprintf("/api/instances/%d/security/firewall", instanceID)
 	)
-	log.Printf("[DEBUG] go-api::security_firewall::create instance ID: %v, params: %v", instanceID, params)
-	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(nil, &failed)
 
+	log.Printf("[DEBUG] api::security_firewall#create path: %s", path)
+	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(nil, &failed)
 	if err != nil {
 		return attempt, err
 	} else if attempt*sleep > timeout {
-		return attempt, fmt.Errorf("create firewall settings failed, reached timeout of %d seconds", timeout)
+		return attempt, fmt.Errorf("create firewall settings failed, reached timeout of %d seconds",
+			timeout)
 	}
 
 	switch {
@@ -73,16 +79,18 @@ func (api *API) createFirewallSettingsWithRetry(instanceID int, params []map[str
 		case failed["error_code"] == nil:
 			break
 		case failed["error_code"].(float64) == 40001:
-			log.Printf("[INFO] go-api::security_firewall::create Firewall not finished configuring "+
+			log.Printf("[INFO] api::security_firewall#create Firewall not finished configuring "+
 				"attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.createFirewallSettingsWithRetry(instanceID, params, attempt, sleep, timeout)
 		case failed["error_code"].(float64) == 40002:
-			return attempt, fmt.Errorf("firewall rules validation failed due to: %s", failed["error"].(string))
+			return attempt, fmt.Errorf("firewall rules validation failed due to: %s",
+				failed["error"].(string))
 		}
 	}
-	return attempt, fmt.Errorf("create new firewall rules failed, status: %v, message: %s", response.StatusCode, failed)
+	return attempt, fmt.Errorf("create new firewall rules failed, status: %d, message: %s",
+		response.StatusCode, failed)
 }
 
 func (api *API) ReadFirewallSettings(instanceID int) ([]map[string]interface{}, error) {
@@ -91,23 +99,27 @@ func (api *API) ReadFirewallSettings(instanceID int) ([]map[string]interface{}, 
 		failed map[string]interface{}
 		path   = fmt.Sprintf("/api/instances/%d/security/firewall", instanceID)
 	)
-	response, err := api.sling.New().Path(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::security_firewall::read data: %v", data)
 
+	response, err := api.sling.New().Path(path).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	}
 
-	if response.StatusCode == 200 {
+	switch response.StatusCode {
+	case 200:
+		log.Printf("[DEBUG] api::security_firewall#read data: %v", data)
 		return data, nil
+	default:
+		return nil, fmt.Errorf("ReadFirewallSettings failed, status: %d, message: %s",
+			response.StatusCode, failed)
 	}
-	return nil, fmt.Errorf("ReadFirewallSettings failed, status: %v, message: %s", response.StatusCode, failed)
 }
 
 func (api *API) UpdateFirewallSettings(instanceID int, params []map[string]interface{},
 	sleep, timeout int) ([]map[string]interface{}, error) {
-	log.Printf("[DEBUG] go-api::security_firewall::update instance id: %v, params: %v, sleep: %d, timeout: %d",
-		instanceID, params, sleep, timeout)
+
+	log.Printf("[DEBUG] api::security_firewall#update instance id: %d, params: %v, sleep: %d, "+
+		"timeout: %d", instanceID, params, sleep, timeout)
 	attempt, err := api.updateFirewallSettingsWithRetry(instanceID, params, 1, sleep, timeout)
 	if err != nil {
 		return nil, err
@@ -121,6 +133,7 @@ func (api *API) UpdateFirewallSettings(instanceID int, params []map[string]inter
 
 func (api *API) updateFirewallSettingsWithRetry(instanceID int, params []map[string]interface{},
 	attempt, sleep, timeout int) (int, error) {
+
 	var (
 		failed map[string]interface{}
 		path   = fmt.Sprintf("/api/instances/%d/security/firewall", instanceID)
@@ -130,7 +143,8 @@ func (api *API) updateFirewallSettingsWithRetry(instanceID int, params []map[str
 	if err != nil {
 		return attempt, err
 	} else if attempt*sleep > timeout {
-		return attempt, fmt.Errorf("update firewall settings failed, reached timeout of %d seconds", timeout)
+		return attempt, fmt.Errorf("update firewall settings failed, reached timeout of %d seconds",
+			timeout)
 	}
 
 	switch response.StatusCode {
@@ -141,21 +155,24 @@ func (api *API) updateFirewallSettingsWithRetry(instanceID int, params []map[str
 		case failed["error_code"] == nil:
 			break
 		case failed["error_code"].(float64) == 40001:
-			log.Printf("[INFO] go-api::security_firewall::update Firewall not finished configuring "+
+			log.Printf("[INFO] api::security_firewall#update Firewall not finished configuring "+
 				"attempt: %d until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.updateFirewallSettingsWithRetry(instanceID, params, attempt, sleep, timeout)
 		case failed["error_code"].(float64) == 40002:
-			return attempt, fmt.Errorf("firewall rules validation failed due to: %s", failed["error"].(string))
+			return attempt, fmt.Errorf("firewall rules validation failed due to: %s",
+				failed["error"].(string))
 		}
 	}
-	return attempt, fmt.Errorf("update firewall rules failed, status: %v, message: %v",
+	return attempt, fmt.Errorf("update firewall rules failed, status: %d, message: %v",
 		response.StatusCode, failed)
 }
 
-func (api *API) DeleteFirewallSettings(instanceID, sleep, timeout int) ([]map[string]interface{}, error) {
-	log.Printf("[DEBUG] go-api::security_firewall::delete instance id: %v, sleep: %d, timeout: %d",
+func (api *API) DeleteFirewallSettings(instanceID, sleep, timeout int) (
+	[]map[string]interface{}, error) {
+
+	log.Printf("[DEBUG] api::security_firewall#delete instance id: %d, sleep: %d, timeout: %d",
 		instanceID, sleep, timeout)
 	attempt, err := api.deleteFirewallSettingsWithRetry(instanceID, 1, sleep, timeout)
 	if err != nil {
@@ -166,10 +183,13 @@ func (api *API) DeleteFirewallSettings(instanceID, sleep, timeout int) ([]map[st
 	if err != nil {
 		return nil, err
 	}
+
 	return api.ReadFirewallSettings(instanceID)
 }
 
-func (api *API) deleteFirewallSettingsWithRetry(instanceID, attempt, sleep, timeout int) (int, error) {
+func (api *API) deleteFirewallSettingsWithRetry(instanceID, attempt, sleep, timeout int) (
+	int, error) {
+
 	var (
 		params [1]map[string]interface{}
 		failed map[string]interface{}
@@ -178,12 +198,13 @@ func (api *API) deleteFirewallSettingsWithRetry(instanceID, attempt, sleep, time
 
 	// Use default firewall rule and update firewall upon delete.
 	params[0] = DefaultFirewallSettings()
-	log.Printf("[DEBUG] go-api::security_firewall::delete default firewall: %v", params[0])
+	log.Printf("[DEBUG] api::security_firewall#delete default firewall: %v", params[0])
 	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
 	if err != nil {
 		return attempt, err
 	} else if attempt*sleep > timeout {
-		return attempt, fmt.Errorf("delete firewall settings failed, reached timeout of %d seconds", timeout)
+		return attempt, fmt.Errorf("delete firewall settings failed, reached timeout of %d seconds",
+			timeout)
 	}
 
 	switch response.StatusCode {
@@ -194,22 +215,24 @@ func (api *API) deleteFirewallSettingsWithRetry(instanceID, attempt, sleep, time
 		case failed["error_code"] == nil:
 			break
 		case failed["error_code"].(float64) == 40001:
-			log.Printf("[INFO] go-api::security_firewall::delete Firewall not finished configuring "+
+			log.Printf("[INFO] api::security_firewall#delete Firewall not finished configuring "+
 				"attempt: %d until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.deleteFirewallSettingsWithRetry(instanceID, attempt, sleep, timeout)
 		case failed["error_code"].(float64) == 40002:
-			return attempt, fmt.Errorf("firewall rules validation failed due to: %s", failed["error"].(string))
+			return attempt, fmt.Errorf("firewall rules validation failed due to: %s",
+				failed["error"].(string))
 		}
 	}
-	return attempt, fmt.Errorf("delete firewall rules failed, status: %v, message: %v",
+	return attempt, fmt.Errorf("delete firewall rules failed, status: %d, message: %s",
 		response.StatusCode, failed)
 }
 
 func DefaultFirewallSettings() map[string]interface{} {
 	defaultRule := map[string]interface{}{
-		"services":    []string{"AMQP", "AMQPS", "STOMP", "STOMPS", "MQTT", "MQTTS", "HTTPS", "STREAM", "STREAM_SSL"},
+		"services": []string{"AMQP", "AMQPS", "STOMP", "STOMPS", "MQTT", "MQTTS", "HTTPS", "STREAM",
+			"STREAM_SSL"},
 		"ports":       []int{},
 		"ip":          "0.0.0.0/0",
 		"description": "Default",

--- a/api/upgrade_rabbitmq.go
+++ b/api/upgrade_rabbitmq.go
@@ -7,10 +7,10 @@ import (
 )
 
 // ReadVersions - Read versions RabbitMQ and Erlang can upgrade to
-func (api *API) ReadVersions(instanceID int) (map[string]interface{}, error) {
+func (api *API) ReadVersions(instanceID int) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("api/instances/%d/actions/new-rabbitmq-erlang-versions", instanceID)
 	)
 
@@ -32,8 +32,8 @@ func (api *API) ReadVersions(instanceID int) (map[string]interface{}, error) {
 // UpgradeRabbitMQ - Upgrade to latest possible versions for both RabbitMQ and Erlang.
 func (api *API) UpgradeRabbitMQ(instanceID int) (string, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("api/instances/%d/actions/upgrade-rabbitmq-erlang", instanceID)
 	)
 
@@ -59,8 +59,8 @@ func (api *API) UpgradeRabbitMQ(instanceID int) (string, error) {
 
 func (api *API) waitUntilUpgraded(instanceID int) (string, error) {
 	var (
-		data   []map[string]interface{}
-		failed map[string]interface{}
+		data   []map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("api/instances/%d/nodes", instanceID)
 	)
 

--- a/api/upgrade_rabbitmq.go
+++ b/api/upgrade_rabbitmq.go
@@ -8,62 +8,79 @@ import (
 
 // ReadVersions - Read versions RabbitMQ and Erlang can upgrade to
 func (api *API) ReadVersions(instanceID int) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::upgrade_rabbitmq::read_versions instance id: %d", instanceID)
-	path := fmt.Sprintf("api/instances/%d/actions/new-rabbitmq-erlang-versions", instanceID)
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("api/instances/%d/actions/new-rabbitmq-erlang-versions", instanceID)
+	)
+
+	log.Printf("[DEBUG] api::upgrade_rabbitmq#read_versions path: %s", path)
 	response, err := api.sling.New().Path(path).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("ReadVersions failed, status: %v, message: %s", response.StatusCode, failed)
+
+	switch response.StatusCode {
+	case 200:
+		return data, nil
+	default:
+		return nil, fmt.Errorf("ReadVersions failed, status: %d, message: %s",
+			response.StatusCode, failed)
 	}
-	return data, nil
 }
 
 // UpgradeRabbitMQ - Upgrade to latest possible versions for both RabbitMQ and Erlang.
 func (api *API) UpgradeRabbitMQ(instanceID int) (string, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	path := fmt.Sprintf("api/instances/%d/actions/upgrade-rabbitmq-erlang", instanceID)
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("api/instances/%d/actions/upgrade-rabbitmq-erlang", instanceID)
+	)
+
+	log.Printf("[DEBUG] api::upgrade_rabbitmq#upgrade_rabbitmq path: %s", path)
 	response, err := api.sling.New().Post(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::upgrade_rabbitmq::upgrade_rabbitmq_mq data: %v, status code: %v", data, response.StatusCode)
 	if err != nil {
 		return "", err
 	}
-	if response.StatusCode == 200 {
-		return "Already at highest possible version", nil
-	} else if response.StatusCode != 202 {
-		return "", fmt.Errorf("upgrade RabbitMQ failed, status: %v, message: %s", response.StatusCode, failed)
-	}
 
-	return api.waitUntilUpgraded(instanceID)
+	log.Printf("[DEBUG] api::upgrade_rabbitmq::upgrade_rabbitmq_mq data: %v, status code: %d",
+		data, response.StatusCode)
+
+	switch response.StatusCode {
+	case 200:
+		return "Already at highest possible version", nil
+	case 202:
+		return api.waitUntilUpgraded(instanceID)
+	default:
+		return "", fmt.Errorf("upgrade RabbitMQ failed, status: %d, message: %s",
+			response.StatusCode, failed)
+	}
 }
 
 func (api *API) waitUntilUpgraded(instanceID int) (string, error) {
-	var data []map[string]interface{}
-	failed := make(map[string]interface{})
+	var (
+		data   []map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("api/instances/%d/nodes", instanceID)
+	)
 
 	for {
-		path := fmt.Sprintf("api/instances/%v/nodes", instanceID)
 		_, err := api.sling.New().Path(path).Receive(&data, &failed)
 		if err != nil {
-			log.Printf("[ERROR] go-api::upgrade_rabbitmq::waitUntilUpgraded error: %v", err)
 			return "", err
 		}
-		log.Printf("[DEBUG] go-api::upgrade_rabbitmq::waitUntilUpgraded numberOfNodes: %v", len(data))
-		log.Printf("[DEBUG] go-api::upgrade_rabbitmq::waitUntilUpgraded data: %v", data)
+		log.Printf("[DEBUG] api::upgrade_rabbitmq#waitUntilUpgraded numberOfNodes: %d", len(data))
+		log.Printf("[DEBUG] api::upgrade_rabbitmq#waitUntilUpgraded data: %v", data)
 		ready := true
 		for _, node := range data {
-			log.Printf("[DEBUG] go-api::upgrade_rabbitmq::waitUntilUpgraded ready: %v, configured: %v",
+			log.Printf("[DEBUG] api::upgrade_rabbitmq#waitUntilUpgraded ready: %v, configured: %v",
 				ready, node["configured"])
 			ready = ready && node["configured"].(bool)
 		}
-		log.Printf("[DEBUG] go-api::upgrade_rabbitmq::waitUntilUpgraded ready: %v", ready)
+		log.Printf("[DEBUG] api::upgrade_rabbitmq#waitUntilUpgraded ready: %v", ready)
 		if ready {
 			return "", nil
 		}
-		time.Sleep(30 * time.Second)
+		time.Sleep(10 * time.Second)
 	}
 }

--- a/api/vpc.go
+++ b/api/vpc.go
@@ -9,8 +9,8 @@ import (
 
 func (api *API) waitUntilVpcReady(vpcID string) error {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("api/vpcs/%s/vpc-peering/info", vpcID)
 	)
 
@@ -35,10 +35,10 @@ func (api *API) waitUntilVpcReady(vpcID string) error {
 	}
 }
 
-func (api *API) readVpcName(vpcID string) (map[string]interface{}, error) {
+func (api *API) readVpcName(vpcID string) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("api/vpcs/%s/vpc-peering/info", vpcID)
 	)
 
@@ -56,10 +56,10 @@ func (api *API) readVpcName(vpcID string) (map[string]interface{}, error) {
 	}
 }
 
-func (api *API) CreateVpcInstance(params map[string]interface{}) (map[string]interface{}, error) {
+func (api *API) CreateVpcInstance(params map[string]any) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 	)
 
 	log.Printf("[DEBUG] api::vpc#create params: %v", params)
@@ -83,10 +83,10 @@ func (api *API) CreateVpcInstance(params map[string]interface{}) (map[string]int
 	}
 }
 
-func (api *API) ReadVpcInstance(vpcID string) (map[string]interface{}, error) {
+func (api *API) ReadVpcInstance(vpcID string) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/vpcs/%s", vpcID)
 	)
 
@@ -109,9 +109,9 @@ func (api *API) ReadVpcInstance(vpcID string) (map[string]interface{}, error) {
 	}
 }
 
-func (api *API) UpdateVpcInstance(vpcID string, params map[string]interface{}) error {
+func (api *API) UpdateVpcInstance(vpcID string, params map[string]any) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("api/vpcs/%s", vpcID)
 	)
 
@@ -134,7 +134,7 @@ func (api *API) UpdateVpcInstance(vpcID string, params map[string]interface{}) e
 
 func (api *API) DeleteVpcInstance(vpcID string) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("api/vpcs/%s", vpcID)
 	)
 

--- a/api/vpc_connect.go
+++ b/api/vpc_connect.go
@@ -30,7 +30,7 @@ func (api *API) EnableVpcConnect(instanceID int, params map[string][]interface{}
 	case 204:
 		return api.waitForEnableVpcConnectWithRetry(instanceID, 1, sleep, timeout)
 	default:
-		return fmt.Errorf("enable VPC Connect failed, status: %v, message: %s",
+		return fmt.Errorf("enable VPC Connect failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
 }
@@ -52,7 +52,7 @@ func (api *API) ReadVpcConnect(instanceID int) (map[string]interface{}, error) {
 	case 200:
 		return data, nil
 	default:
-		return nil, fmt.Errorf("read VPC Connect failed, status: %v, message: %s",
+		return nil, fmt.Errorf("read VPC Connect failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
 }
@@ -73,7 +73,7 @@ func (api *API) UpdateVpcConnect(instanceID int, params map[string][]interface{}
 	case 204:
 		return nil
 	default:
-		return fmt.Errorf("update VPC connect failed, status: %v, message: %s",
+		return fmt.Errorf("update VPC connect failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
 }
@@ -94,7 +94,7 @@ func (api *API) DisableVpcConnect(instanceID int) error {
 	case 204:
 		return nil
 	default:
-		return fmt.Errorf("disable VPC Connect failed, status: %v, message: %s",
+		return fmt.Errorf("disable VPC Connect failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
 }
@@ -113,15 +113,15 @@ func (api *API) waitForEnableVpcConnectWithRetry(instanceID, attempt, sleep, tim
 	} else if attempt*sleep > timeout {
 		return fmt.Errorf("enable VPC Connect failed, reached timeout of %d seconds", timeout)
 	}
-	log.Printf("[DEBUG] VPC-Connect: waitForEnableVpcConnectWithRetry data: %v", data)
 
 	switch response.StatusCode {
 	case 200:
+		log.Printf("[DEBUG] VPC-Connect: waitForEnableVpcConnectWithRetry data: %v", data)
 		switch data["status"].(string) {
 		case "enabled":
 			return nil
 		case "pending":
-			log.Printf("[DEBUG] go-api::vpc-connect::enable not finished and will retry, "+
+			log.Printf("[DEBUG] api::vpc-connect#enable not finished and will retry, "+
 				"attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
@@ -129,7 +129,7 @@ func (api *API) waitForEnableVpcConnectWithRetry(instanceID, attempt, sleep, tim
 		}
 	}
 
-	return fmt.Errorf("wait for enable VPC Connect failed, status: %v, message: %s",
+	return fmt.Errorf("wait for enable VPC Connect failed, status: %d, message: %s",
 		response.StatusCode, failed)
 }
 
@@ -153,7 +153,7 @@ func (api *API) EnableVPC(instanceID int) error {
 			log.Printf("[DEBUG] VPC-Connect: VPC features enabled")
 			return nil
 		default:
-			return fmt.Errorf("enable VPC failed, status: %v, message: %s",
+			return fmt.Errorf("enable VPC failed, status: %d, message: %s",
 				response.StatusCode, failed)
 		}
 	}

--- a/api/vpc_connect.go
+++ b/api/vpc_connect.go
@@ -13,7 +13,7 @@ func (api *API) EnableVpcConnect(instanceID int, params map[string][]interface{}
 	sleep, timeout int) error {
 
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/vpc-connect", instanceID)
 	)
 
@@ -36,10 +36,10 @@ func (api *API) EnableVpcConnect(instanceID int, params map[string][]interface{}
 }
 
 // ReadVpcConnect: Reads VPC Connect information
-func (api *API) ReadVpcConnect(instanceID int) (map[string]interface{}, error) {
+func (api *API) ReadVpcConnect(instanceID int) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/vpc-connect", instanceID)
 	)
 
@@ -60,7 +60,7 @@ func (api *API) ReadVpcConnect(instanceID int) (map[string]interface{}, error) {
 // UpdateVpcConnect: Update allowlist for the VPC Connect
 func (api *API) UpdateVpcConnect(instanceID int, params map[string][]interface{}) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/vpc-connect", instanceID)
 	)
 
@@ -81,7 +81,7 @@ func (api *API) UpdateVpcConnect(instanceID int, params map[string][]interface{}
 // DisableVpcConnect: Disable the VPC Connect feature
 func (api *API) DisableVpcConnect(instanceID int) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/vpc-connect", instanceID)
 	)
 
@@ -102,8 +102,8 @@ func (api *API) DisableVpcConnect(instanceID int) error {
 // waitForEnableVpcConnectWithRetry: Wait until status change from pending to enable
 func (api *API) waitForEnableVpcConnectWithRetry(instanceID, attempt, sleep, timeout int) error {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/vpc-connect", instanceID)
 	)
 
@@ -137,7 +137,7 @@ func (api *API) waitForEnableVpcConnectWithRetry(instanceID, attempt, sleep, tim
 // Check if the instance already have a standalone VPC
 func (api *API) EnableVPC(instanceID int) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/vpc", instanceID)
 	)
 

--- a/api/vpc_gcp_peering.go
+++ b/api/vpc_gcp_peering.go
@@ -38,7 +38,7 @@ func (api *API) waitForGcpPeeringStatus(path, peerID string,
 				}
 			}
 		}
-		log.Printf("[INFO] go-api::vpc_gcp_peering::waitForGcpPeeringStatus Waiting for state = ACTIVE "+
+		log.Printf("[INFO] api::vpc_gcp_peering#waitForGcpPeeringStatus Waiting for state = ACTIVE "+
 			"attempt %d until timeout: %d", attempt, (timeout - (attempt * sleep)))
 		attempt++
 		time.Sleep(time.Duration(sleep) * time.Second)
@@ -56,7 +56,7 @@ func (api *API) RequestVpcGcpPeering(instanceID int, params map[string]interface
 	}
 
 	if waitOnStatus {
-		log.Printf("[DEBUG] go-api::vpc_gcp_peering_withvpcid::request waiting for active state")
+		log.Printf("[DEBUG] api::vpc_gcp_peering_withvpcid#request waiting for active state")
 		err = api.waitForGcpPeeringStatus(path, data["peering"].(string), attempt, sleep, timeout)
 		if err != nil {
 			return nil, err
@@ -74,7 +74,7 @@ func (api *API) requestVpcGcpPeeringWithRetry(path string, params map[string]int
 		failed map[string]interface{}
 	)
 
-	log.Printf("[DEBUG] go-api::vpc_gcp_peering::request path: %s, params: %v", path, params)
+	log.Printf("[DEBUG] api::vpc_gcp_peering#request path: %s, params: %v", path, params)
 	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
 	if err != nil {
 		return attempt, nil, err
@@ -88,14 +88,14 @@ func (api *API) requestVpcGcpPeeringWithRetry(path string, params map[string]int
 		return attempt, data, nil
 	case 400:
 		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			log.Printf("[INFO] go-api::vpc_gcp_peering::request Timeout talking to backend "+
+			log.Printf("[INFO] api::vpc_gcp_peering#request Timeout talking to backend "+
 				"attempt %d until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.requestVpcGcpPeeringWithRetry(path, params, waitOnStatus, attempt, sleep, timeout)
 		}
 	}
-	return attempt, nil, fmt.Errorf("request VPC peering failed, status: %v, message: %s",
+	return attempt, nil, fmt.Errorf("request VPC peering failed, status: %d, message: %s",
 		response.StatusCode, failed)
 }
 
@@ -117,7 +117,7 @@ func (api *API) readVpcGcpPeeringWithRetry(path string, attempt, sleep, timeout 
 		failed map[string]interface{}
 	)
 
-	log.Printf("[DEBUG] go-api::vpc_gcp_peering::read path: %s", path)
+	log.Printf("[DEBUG] api::vpc_gcp_peering#read path: %s", path)
 	response, err := api.sling.New().Get(path).Receive(&data, &failed)
 	if err != nil {
 		return attempt, nil, err
@@ -130,14 +130,14 @@ func (api *API) readVpcGcpPeeringWithRetry(path string, attempt, sleep, timeout 
 		return attempt, data, nil
 	case 400:
 		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			log.Printf("[INFO] go-api::vpc_gcp_peering::read Timeout talking to backend "+
+			log.Printf("[INFO] api::vpc_gcp_peering#read Timeout talking to backend "+
 				"attempt %d until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.readVpcGcpPeeringWithRetry(path, attempt, sleep, timeout)
 		}
 	}
-	return attempt, nil, fmt.Errorf("read VPC peering with retry failed, status: %v, message: %s",
+	return attempt, nil, fmt.Errorf("read VPC peering with retry failed, status: %d, message: %s",
 		response.StatusCode, failed)
 }
 
@@ -153,10 +153,10 @@ func (api *API) UpdateVpcGcpPeering(instanceID int, sleep, timeout int) (
 func (api *API) RemoveVpcGcpPeering(instanceID int, peerID string) error {
 	var (
 		failed map[string]interface{}
-		path   = fmt.Sprintf("/api/instances/%v/vpc-peering/%v", instanceID, peerID)
+		path   = fmt.Sprintf("/api/instances/%d/vpc-peering/%s", instanceID, peerID)
 	)
 
-	log.Printf("[DEBUG] go-api::vpc_gcp_peering::remove instance id: %v, peering id: %v", instanceID, peerID)
+	log.Printf("[DEBUG] api::vpc_gcp_peering#remove path: %s", path)
 	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
 	if err != nil {
 		return err
@@ -166,14 +166,14 @@ func (api *API) RemoveVpcGcpPeering(instanceID int, peerID string) error {
 	case 204:
 		return nil
 	default:
-		return fmt.Errorf("remove VPC peering failed, status: %v, message: %s",
+		return fmt.Errorf("remove VPC peering failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
 }
 
 // ReadVpcGcpInfo: reads the VPC info from the API
 func (api *API) ReadVpcGcpInfo(instanceID, sleep, timeout int) (map[string]interface{}, error) {
-	path := fmt.Sprintf("/api/instances/%v/vpc-peering/info", instanceID)
+	path := fmt.Sprintf("/api/instances/%d/vpc-peering/info", instanceID)
 	return api.readVpcGcpInfoWithRetry(path, 1, sleep, timeout)
 }
 
@@ -186,7 +186,7 @@ func (api *API) readVpcGcpInfoWithRetry(path string, attempt, sleep, timeout int
 		failed map[string]interface{}
 	)
 
-	log.Printf("[DEBUG] go-api::vpc_gcp_peering::info path: %s", path)
+	log.Printf("[DEBUG] api::vpc_gcp_peering#info path: %s", path)
 	response, err := api.sling.New().Get(path).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
@@ -199,13 +199,13 @@ func (api *API) readVpcGcpInfoWithRetry(path string, attempt, sleep, timeout int
 		return data, nil
 	case 400:
 		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			log.Printf("[INFO] go-api::vpc_gcp_peering::info Timeout talking to backend "+
+			log.Printf("[INFO] api::vpc_gcp_peering#info Timeout talking to backend "+
 				"attempt %d until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.readVpcGcpInfoWithRetry(path, attempt, sleep, timeout)
 		}
 	}
-	return nil, fmt.Errorf("read VPC info failed, status: %v, message: %s",
+	return nil, fmt.Errorf("read VPC info failed, status: %d, message: %s",
 		response.StatusCode, failed)
 }

--- a/api/vpc_gcp_peering.go
+++ b/api/vpc_gcp_peering.go
@@ -12,7 +12,7 @@ func (api *API) waitForGcpPeeringStatus(path, peerID string,
 	attempt, sleep, timeout int) error {
 
 	var (
-		data map[string]interface{}
+		data map[string]any
 		err  error
 	)
 
@@ -29,7 +29,7 @@ func (api *API) waitForGcpPeeringStatus(path, peerID string,
 		rows := data["rows"].([]interface{})
 		if len(rows) > 0 {
 			for _, row := range rows {
-				tempRow := row.(map[string]interface{})
+				tempRow := row.(map[string]any)
 				if tempRow["name"] != peerID {
 					continue
 				}
@@ -46,8 +46,8 @@ func (api *API) waitForGcpPeeringStatus(path, peerID string,
 }
 
 // RequestVpcGcpPeering: requests a VPC peering from an instance.
-func (api *API) RequestVpcGcpPeering(instanceID int, params map[string]interface{},
-	waitOnStatus bool, sleep, timeout int) (map[string]interface{}, error) {
+func (api *API) RequestVpcGcpPeering(instanceID int, params map[string]any,
+	waitOnStatus bool, sleep, timeout int) (map[string]any, error) {
 
 	path := fmt.Sprintf("api/instances/%v/vpc-peering", instanceID)
 	attempt, data, err := api.requestVpcGcpPeeringWithRetry(path, params, waitOnStatus, 1, sleep, timeout)
@@ -67,11 +67,11 @@ func (api *API) RequestVpcGcpPeering(instanceID int, params map[string]interface
 }
 
 // requestVpcGcpPeeringWithRetry: requests a VPC peering from a path with retry logic
-func (api *API) requestVpcGcpPeeringWithRetry(path string, params map[string]interface{},
-	waitOnStatus bool, attempt, sleep, timeout int) (int, map[string]interface{}, error) {
+func (api *API) requestVpcGcpPeeringWithRetry(path string, params map[string]any,
+	waitOnStatus bool, attempt, sleep, timeout int) (int, map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 	)
 
 	log.Printf("[DEBUG] api::vpc_gcp_peering#request path: %s, params: %v", path, params)
@@ -101,7 +101,7 @@ func (api *API) requestVpcGcpPeeringWithRetry(path string, params map[string]int
 
 // ReadVpcGcpPeering: reads the VPC peering from the API
 func (api *API) ReadVpcGcpPeering(instanceID, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	path := fmt.Sprintf("/api/instances/%v/vpc-peering", instanceID)
 	_, data, err := api.readVpcGcpPeeringWithRetry(path, 1, sleep, timeout)
@@ -110,11 +110,11 @@ func (api *API) ReadVpcGcpPeering(instanceID, sleep, timeout int) (
 
 // readVpcGcpPeeringWithRetry: reads the VPC peering from the API with retry logic
 func (api *API) readVpcGcpPeeringWithRetry(path string, attempt, sleep, timeout int) (
-	int, map[string]interface{}, error) {
+	int, map[string]any, error) {
 
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 	)
 
 	log.Printf("[DEBUG] api::vpc_gcp_peering#read path: %s", path)
@@ -143,7 +143,7 @@ func (api *API) readVpcGcpPeeringWithRetry(path string, attempt, sleep, timeout 
 
 // UpdateVpcGcpPeering: updates a VPC peering from an instance.
 func (api *API) UpdateVpcGcpPeering(instanceID int, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	// NOP just read out the VPC peering
 	return api.ReadVpcGcpPeering(instanceID, sleep, timeout)
@@ -152,7 +152,7 @@ func (api *API) UpdateVpcGcpPeering(instanceID int, sleep, timeout int) (
 // RemoveVpcGcpPeering: removes a VPC peering from an instance.
 func (api *API) RemoveVpcGcpPeering(instanceID int, peerID string) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/vpc-peering/%s", instanceID, peerID)
 	)
 
@@ -172,18 +172,18 @@ func (api *API) RemoveVpcGcpPeering(instanceID int, peerID string) error {
 }
 
 // ReadVpcGcpInfo: reads the VPC info from the API
-func (api *API) ReadVpcGcpInfo(instanceID, sleep, timeout int) (map[string]interface{}, error) {
+func (api *API) ReadVpcGcpInfo(instanceID, sleep, timeout int) (map[string]any, error) {
 	path := fmt.Sprintf("/api/instances/%d/vpc-peering/info", instanceID)
 	return api.readVpcGcpInfoWithRetry(path, 1, sleep, timeout)
 }
 
 // readVpcGcpInfoWithRetry: reads the VPC info from the API with retry logic
 func (api *API) readVpcGcpInfoWithRetry(path string, attempt, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 	)
 
 	log.Printf("[DEBUG] api::vpc_gcp_peering#info path: %s", path)

--- a/api/vpc_gcp_peering_withvpcid.go
+++ b/api/vpc_gcp_peering_withvpcid.go
@@ -8,8 +8,8 @@ import (
 )
 
 // RequestVpcGcpPeeringWithVpcId: requests a VPC peering from an instance.
-func (api *API) RequestVpcGcpPeeringWithVpcId(vpcID string, params map[string]interface{},
-	waitOnStatus bool, sleep, timeout int) (map[string]interface{}, error) {
+func (api *API) RequestVpcGcpPeeringWithVpcId(vpcID string, params map[string]any,
+	waitOnStatus bool, sleep, timeout int) (map[string]any, error) {
 
 	path := fmt.Sprintf("api/vpcs/%s/vpc-peering", vpcID)
 	attempt, data, err := api.requestVpcGcpPeeringWithRetry(path, params, waitOnStatus, 1, sleep, timeout)
@@ -29,7 +29,7 @@ func (api *API) RequestVpcGcpPeeringWithVpcId(vpcID string, params map[string]in
 }
 
 func (api *API) ReadVpcGcpPeeringWithVpcId(vpcID string, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering", vpcID)
 	_, data, err := api.readVpcGcpPeeringWithRetry(path, 1, sleep, timeout)
@@ -38,7 +38,7 @@ func (api *API) ReadVpcGcpPeeringWithVpcId(vpcID string, sleep, timeout int) (
 
 // UpdateVpcGcpPeeringWithVpcId: updates the VPC peering from the API
 func (api *API) UpdateVpcGcpPeeringWithVpcId(vpcID string, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	// NOP just read out the VPC peering
 	return api.ReadVpcGcpPeeringWithVpcId(vpcID, sleep, timeout)
@@ -47,7 +47,7 @@ func (api *API) UpdateVpcGcpPeeringWithVpcId(vpcID string, sleep, timeout int) (
 // RemoveVpcGcpPeeringWithVpcId: removes the VPC peering from the API
 func (api *API) RemoveVpcGcpPeeringWithVpcId(vpcID, peerID string) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 		path   = fmt.Sprintf("/api/vpcs/%s/vpc-peering/%s", vpcID, peerID)
 	)
 
@@ -68,7 +68,7 @@ func (api *API) RemoveVpcGcpPeeringWithVpcId(vpcID, peerID string) error {
 
 // ReadVpcGcpInfoWithVpcId: reads the VPC info from the API
 func (api *API) ReadVpcGcpInfoWithVpcId(vpcID string, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/info", vpcID)
 	_, data, err := api.readVpcGcpPeeringWithRetry(path, 1, sleep, timeout)

--- a/api/vpc_gcp_peering_withvpcid.go
+++ b/api/vpc_gcp_peering_withvpcid.go
@@ -18,7 +18,7 @@ func (api *API) RequestVpcGcpPeeringWithVpcId(vpcID string, params map[string]in
 	}
 
 	if waitOnStatus {
-		log.Printf("[DEBUG] go-api::vpc_gcp_peering_withvpcid::request waiting for active state")
+		log.Printf("[DEBUG] api::vpc_gcp_peering_withvpcid#request waiting for active state")
 		err = api.waitForGcpPeeringStatus(path, data["peering"].(string), attempt, sleep, timeout)
 		if err != nil {
 			return nil, err
@@ -51,8 +51,7 @@ func (api *API) RemoveVpcGcpPeeringWithVpcId(vpcID, peerID string) error {
 		path   = fmt.Sprintf("/api/vpcs/%s/vpc-peering/%s", vpcID, peerID)
 	)
 
-	log.Printf("[DEBUG] go-api::vpc_gcp_peering_withvpcid::remove vpc id: %s, peering id: %s",
-		vpcID, peerID)
+	log.Printf("[DEBUG] api::vpc_gcp_peering_withvpcid#remove path: %s", path)
 	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
 	if err != nil {
 		return err
@@ -62,7 +61,7 @@ func (api *API) RemoveVpcGcpPeeringWithVpcId(vpcID, peerID string) error {
 	case 204:
 		return nil
 	default:
-		return fmt.Errorf("remove VPC peering failed, status: %v, message: %s",
+		return fmt.Errorf("remove VPC peering failed, status: %d, message: %s",
 			response.StatusCode, failed)
 	}
 }

--- a/api/vpc_peering.go
+++ b/api/vpc_peering.go
@@ -7,37 +7,48 @@ import (
 	"time"
 )
 
-func (api *API) AcceptVpcPeering(instanceID int, peeringID string, sleep, timeout int) (map[string]interface{}, error) {
+func (api *API) AcceptVpcPeering(instanceID int, peeringID string, sleep, timeout int) (
+	map[string]interface{}, error) {
+
 	attempt, err := api.waitForPeeringStatus(instanceID, peeringID, 1, sleep, timeout)
-	log.Printf("[DEBUG] go-api::vpc_peering::accept attempt: %d, sleep: %d, timeout: %d", attempt, sleep, timeout)
+	log.Printf("[DEBUG] api::vpc_peering#accept attempt: %d, sleep: %d, timeout: %d",
+		attempt, sleep, timeout)
 	if err != nil {
 		return nil, err
 	}
-	path := fmt.Sprintf("/api/instances/%v/vpc-peering/request/%v", instanceID, peeringID)
+	path := fmt.Sprintf("/api/instances/%d/vpc-peering/request/%s", instanceID, peeringID)
 	return api.retryAcceptVpcPeering(path, attempt, sleep, timeout)
 }
 
 func (api *API) ReadVpcInfo(instanceID int) (map[string]interface{}, error) {
-	path := fmt.Sprintf("/api/instances/%v/vpc-peering/info", instanceID)
+	path := fmt.Sprintf("/api/instances/%d/vpc-peering/info", instanceID)
 	// Initiale values, 5 attempts and 20 second sleep
 	return api.readVpcInfoWithRetry(path, 5, 20)
 }
 
-func (api *API) ReadVpcPeeringRequest(instanceID int, peeringID string) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::vpc_peering::request instance id: %v, peering id: %v", instanceID, peeringID)
-	path := fmt.Sprintf("/api/instances/%v/vpc-peering/request/%v", instanceID, peeringID)
-	response, err := api.sling.New().Get(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::vpc_peering::request data: %v", data)
+func (api *API) ReadVpcPeeringRequest(instanceID int, peeringID string) (
+	map[string]interface{}, error) {
 
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/instances/%d/vpc-peering/request/%s", instanceID, peeringID)
+	)
+
+	log.Printf("[DEBUG] api::vpc_peering#request path: %s", path)
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
-	} else if response.StatusCode != 200 {
-		return nil, fmt.Errorf("readRequest failed, status: %v, message: %s", response.StatusCode, failed)
 	}
 
-	return data, nil
+	switch response.StatusCode {
+	case 200:
+		log.Printf("[DEBUG] api::vpc_peering#request data: %v", data)
+		return data, nil
+	default:
+		return nil, fmt.Errorf("read request failed, status: %d, message: %s",
+			response.StatusCode, failed)
+	}
 }
 
 func (api *API) RemoveVpcPeering(instanceID int, peeringID string, sleep, timeout int) error {
@@ -45,13 +56,17 @@ func (api *API) RemoveVpcPeering(instanceID int, peeringID string, sleep, timeou
 	return api.retryRemoveVpcPeering(path, 1, sleep, timeout)
 }
 
-func (api *API) retryAcceptVpcPeering(path string, attempt, sleep, timeout int) (map[string]interface{}, error) {
-	log.Printf("[DEBUG] go-api::vpc_peering::retryRemoveVpcPeering path: %s, "+
-		"attempt: %d, sleep: %d, timeout: %d", path, attempt, sleep, timeout)
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	response, err := api.sling.New().Put(path).Receive(&data, &failed)
+func (api *API) retryAcceptVpcPeering(path string, attempt, sleep, timeout int) (
+	map[string]interface{}, error) {
 
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+	)
+
+	log.Printf("[DEBUG] api::vpc_peering#retryRemoveVpcPeering path: %s, "+
+		"attempt: %d, sleep: %d, timeout: %d", path, attempt, sleep, timeout)
+	response, err := api.sling.New().Put(path).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	} else if attempt*sleep > timeout {
@@ -66,7 +81,7 @@ func (api *API) retryAcceptVpcPeering(path string, attempt, sleep, timeout int) 
 		case failed["error_code"] == nil:
 			break
 		case failed["error_code"].(float64) == 40001:
-			log.Printf("[DEBUG] go-api::vpc_peering::accept firewall not finished configuring will retry "+
+			log.Printf("[DEBUG] api::vpc_peering#accept firewall not finished configuring will retry "+
 				"accept VPC peering, attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
@@ -74,45 +89,54 @@ func (api *API) retryAcceptVpcPeering(path string, attempt, sleep, timeout int) 
 		}
 	}
 
-	return nil, fmt.Errorf("accept VPC peering failed, status: %v, message: %s", response.StatusCode, failed)
+	return nil, fmt.Errorf("accept VPC peering failed, status: %d, message: %s",
+		response.StatusCode, failed)
 }
 
-func (api *API) readVpcInfoWithRetry(path string, attempts, sleep int) (map[string]interface{}, error) {
-	log.Printf("[DEBUG] go-api::vpc_peering::readVpcInfoWithRetry path: %s, "+
-		"attempts: %d, sleep: %d", path, attempts, sleep)
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	response, err := api.sling.New().Get(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::vpc_peering::info data: %v", data)
+func (api *API) readVpcInfoWithRetry(path string, attempts, sleep int) (
+	map[string]interface{}, error) {
 
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+	)
+
+	log.Printf("[DEBUG] api::vpc_peering#readVpcInfoWithRetry path: %s, "+
+		"attempts: %d, sleep: %d", path, attempts, sleep)
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
 	}
 
 	switch response.StatusCode {
 	case 200:
+		log.Printf("[DEBUG] api::vpc_peering#info data: %v", data)
 		return data, nil
 	case 400:
 		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
 			if attempts--; attempts > 0 {
-				log.Printf("[INFO] go-api::vpc_peering::info Timeout talking to backend "+
+				log.Printf("[INFO] api::vpc_peering#info Timeout talking to backend "+
 					"attempts left %d and retry in %d seconds", attempts, sleep)
 				time.Sleep(time.Duration(sleep) * time.Second)
 				return api.readVpcInfoWithRetry(path, attempts, 2*sleep)
 			}
-			return nil, fmt.Errorf("readInfo failed, status: %v, message: %s", response.StatusCode, failed)
+			return nil, fmt.Errorf("read VPC info failed, status: %d, message: %s",
+				response.StatusCode, failed)
 		}
 	}
 
-	return nil, fmt.Errorf("readInfo failed, status: %v, message: %s", response.StatusCode, failed)
+	return nil, fmt.Errorf("read VPC info failed, status: %d, message: %s",
+		response.StatusCode, failed)
 }
 
 func (api *API) retryRemoveVpcPeering(path string, attempt, sleep, timeout int) error {
-	log.Printf("[DEBUG] go-api::vpc_peering::retryRemoveVpcPeering path: %s, "+
-		"attempt: %d, sleep: %d, timeout: %d", path, attempt, sleep, timeout)
-	failed := make(map[string]interface{})
-	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
+	var (
+		failed map[string]interface{}
+	)
 
+	log.Printf("[DEBUG] api::vpc_peering#retryRemoveVpcPeering path: %s, "+
+		"attempt: %d, sleep: %d, timeout: %d", path, attempt, sleep, timeout)
+	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
 	if err != nil {
 		return err
 	} else if attempt*sleep > timeout {
@@ -127,7 +151,7 @@ func (api *API) retryRemoveVpcPeering(path string, attempt, sleep, timeout int) 
 		case failed["error_code"] == nil:
 			break
 		case failed["error_code"].(float64) == 40001:
-			log.Printf("[DEBUG] go-api::vpc_peering::remove firewall not finished configuring will retry "+
+			log.Printf("[DEBUG] api::vpc_peering#remove firewall not finished configuring will retry "+
 				"removing VPC peering, attempt: %d, until timeout: %d", attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
@@ -135,22 +159,29 @@ func (api *API) retryRemoveVpcPeering(path string, attempt, sleep, timeout int) 
 		}
 	}
 
-	return fmt.Errorf("remove VPC peering failed, status: %v, message: %s", response.StatusCode, failed)
+	return fmt.Errorf("remove VPC peering failed, status: %d, message: %s",
+		response.StatusCode, failed)
 }
 
-func (api *API) waitForPeeringStatus(instanceID int, peeringID string, attempt, sleep, timeout int) (int, error) {
+func (api *API) waitForPeeringStatus(instanceID int, peeringID string, attempt, sleep,
+	timeout int) (int, error) {
+
 	time.Sleep(10 * time.Second)
 	path := fmt.Sprintf("/api/instances/%v/vpc-peering/status/%v", instanceID, peeringID)
 	return api.waitForPeeringStatusWithRetry(path, peeringID, attempt, sleep, timeout)
 }
 
-func (api *API) waitForPeeringStatusWithRetry(path, peeringID string, attempt, sleep, timeout int) (int, error) {
-	log.Printf("[DEBUG] go-api::vpc_peering::waitForPeeringStatusWithRetry path: %s "+
-		"attempt: %d, sleep: %d, timeout: %d", path, attempt, sleep, timeout)
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	response, err := api.sling.New().Path(path).Receive(&data, &failed)
+func (api *API) waitForPeeringStatusWithRetry(path, peeringID string, attempt, sleep,
+	timeout int) (int, error) {
 
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+	)
+
+	log.Printf("[DEBUG] api::vpc_peering#waitForPeeringStatusWithRetry path: %s "+
+		"attempt: %d, sleep: %d, timeout: %d", path, attempt, sleep, timeout)
+	response, err := api.sling.New().Path(path).Receive(&data, &failed)
 	if err != nil {
 		return attempt, err
 	} else if attempt*sleep > timeout {
@@ -170,13 +201,14 @@ func (api *API) waitForPeeringStatusWithRetry(path, peeringID string, attempt, s
 		case failed["error_code"] == nil:
 			break
 		case failed["error_code"].(float64) == 40003:
-			log.Printf("[DEBUG] go-api::vpc_peering::waitForPeeringStatusWithRetry %s, attempt: %d, until timeout: %d",
-				failed["message"].(string), attempt, (timeout - (attempt * sleep)))
+			log.Printf("[DEBUG] api::vpc_peering#waitForPeeringStatusWithRetry %s, attempt: %d, until "+
+				"timeout: %d", failed["message"].(string), attempt, (timeout - (attempt * sleep)))
 			attempt++
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.waitForPeeringStatusWithRetry(path, peeringID, attempt, sleep, timeout)
 		}
 	}
 
-	return attempt, fmt.Errorf("accept VPC peering failed, status: %v, message: %v", response.StatusCode, failed)
+	return attempt, fmt.Errorf("accept VPC peering failed, status: %d, message: %s",
+		response.StatusCode, failed)
 }

--- a/api/vpc_peering.go
+++ b/api/vpc_peering.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (api *API) AcceptVpcPeering(instanceID int, peeringID string, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	attempt, err := api.waitForPeeringStatus(instanceID, peeringID, 1, sleep, timeout)
 	log.Printf("[DEBUG] api::vpc_peering#accept attempt: %d, sleep: %d, timeout: %d",
@@ -20,18 +20,18 @@ func (api *API) AcceptVpcPeering(instanceID int, peeringID string, sleep, timeou
 	return api.retryAcceptVpcPeering(path, attempt, sleep, timeout)
 }
 
-func (api *API) ReadVpcInfo(instanceID int) (map[string]interface{}, error) {
+func (api *API) ReadVpcInfo(instanceID int) (map[string]any, error) {
 	path := fmt.Sprintf("/api/instances/%d/vpc-peering/info", instanceID)
 	// Initiale values, 5 attempts and 20 second sleep
 	return api.readVpcInfoWithRetry(path, 5, 20)
 }
 
 func (api *API) ReadVpcPeeringRequest(instanceID int, peeringID string) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/vpc-peering/request/%s", instanceID, peeringID)
 	)
 
@@ -57,11 +57,11 @@ func (api *API) RemoveVpcPeering(instanceID int, peeringID string, sleep, timeou
 }
 
 func (api *API) retryAcceptVpcPeering(path string, attempt, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 	)
 
 	log.Printf("[DEBUG] api::vpc_peering#retryRemoveVpcPeering path: %s, "+
@@ -94,11 +94,11 @@ func (api *API) retryAcceptVpcPeering(path string, attempt, sleep, timeout int) 
 }
 
 func (api *API) readVpcInfoWithRetry(path string, attempts, sleep int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 	)
 
 	log.Printf("[DEBUG] api::vpc_peering#readVpcInfoWithRetry path: %s, "+
@@ -131,7 +131,7 @@ func (api *API) readVpcInfoWithRetry(path string, attempts, sleep int) (
 
 func (api *API) retryRemoveVpcPeering(path string, attempt, sleep, timeout int) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 	)
 
 	log.Printf("[DEBUG] api::vpc_peering#retryRemoveVpcPeering path: %s, "+
@@ -175,8 +175,8 @@ func (api *API) waitForPeeringStatusWithRetry(path, peeringID string, attempt, s
 	timeout int) (int, error) {
 
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 	)
 
 	log.Printf("[DEBUG] api::vpc_peering#waitForPeeringStatusWithRetry path: %s "+

--- a/api/vpc_peering_withvpcid.go
+++ b/api/vpc_peering_withvpcid.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (api *API) AcceptVpcPeeringWithVpcId(vpcID, peeringID string, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	attempt, err := api.waitForPeeringStatusWithVpcID(vpcID, peeringID, 1, sleep, timeout)
 	if err != nil {
@@ -19,18 +19,18 @@ func (api *API) AcceptVpcPeeringWithVpcId(vpcID, peeringID string, sleep, timeou
 	return api.retryAcceptVpcPeering(path, attempt, sleep, timeout)
 }
 
-func (api *API) ReadVpcInfoWithVpcId(vpcID string) (map[string]interface{}, error) {
+func (api *API) ReadVpcInfoWithVpcId(vpcID string) (map[string]any, error) {
 	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/info", vpcID)
 	// Initiale values, 5 attempts and 20 second sleep
 	return api.readVpcInfoWithRetry(path, 5, 20)
 }
 
 func (api *API) ReadVpcPeeringRequestWithVpcId(vpcID, peeringID string) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/vpcs/%s/vpc-peering/request/%s", vpcID, peeringID)
 	)
 

--- a/api/vpc_peering_withvpcid.go
+++ b/api/vpc_peering_withvpcid.go
@@ -8,7 +8,9 @@ import (
 	"time"
 )
 
-func (api *API) AcceptVpcPeeringWithVpcId(vpcID, peeringID string, sleep, timeout int) (map[string]interface{}, error) {
+func (api *API) AcceptVpcPeeringWithVpcId(vpcID, peeringID string, sleep, timeout int) (
+	map[string]interface{}, error) {
+
 	attempt, err := api.waitForPeeringStatusWithVpcID(vpcID, peeringID, 1, sleep, timeout)
 	if err != nil {
 		return nil, err
@@ -23,21 +25,29 @@ func (api *API) ReadVpcInfoWithVpcId(vpcID string) (map[string]interface{}, erro
 	return api.readVpcInfoWithRetry(path, 5, 20)
 }
 
-func (api *API) ReadVpcPeeringRequestWithVpcId(vpcID, peeringID string) (map[string]interface{}, error) {
-	data := make(map[string]interface{})
-	failed := make(map[string]interface{})
-	log.Printf("[DEBUG] go-api::vpc_peering_withvpcid::request vpc id: %v, peering id: %v", vpcID, peeringID)
-	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/request/%s", vpcID, peeringID)
-	response, err := api.sling.New().Get(path).Receive(&data, &failed)
-	log.Printf("[DEBUG] go-api::vpc_peering_withvpcid::request data: %v", data)
+func (api *API) ReadVpcPeeringRequestWithVpcId(vpcID, peeringID string) (
+	map[string]interface{}, error) {
 
+	var (
+		data   map[string]interface{}
+		failed map[string]interface{}
+		path   = fmt.Sprintf("/api/vpcs/%s/vpc-peering/request/%s", vpcID, peeringID)
+	)
+
+	log.Printf("[DEBUG] api::vpc_peering_withvpcid#request path: %s", path)
+	response, err := api.sling.New().Get(path).Receive(&data, &failed)
 	if err != nil {
 		return nil, err
-	} else if response.StatusCode != 200 {
-		return nil, fmt.Errorf("ReadRequest failed, status: %v, message: %s", response.StatusCode, failed)
 	}
 
-	return data, nil
+	switch response.StatusCode {
+	case 200:
+		log.Printf("[DEBUG] api::vpc_peering_withvpcid#request data: %v", data)
+		return data, nil
+	default:
+		return nil, fmt.Errorf("read request failed, status: %d, message: %s",
+			response.StatusCode, failed)
+	}
 }
 
 func (api *API) RemoveVpcPeeringWithVpcId(vpcID, peeringID string, sleep, timeout int) error {
@@ -45,7 +55,9 @@ func (api *API) RemoveVpcPeeringWithVpcId(vpcID, peeringID string, sleep, timeou
 	return api.retryRemoveVpcPeering(path, 1, sleep, timeout)
 }
 
-func (api *API) waitForPeeringStatusWithVpcID(vpcID, peeringID string, attempt, sleep, timeout int) (int, error) {
+func (api *API) waitForPeeringStatusWithVpcID(vpcID, peeringID string, attempt, sleep,
+	timeout int) (int, error) {
+
 	time.Sleep(10 * time.Second)
 	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/status/%s", vpcID, peeringID)
 	return api.waitForPeeringStatusWithRetry(path, peeringID, attempt, sleep, timeout)

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -9,19 +9,19 @@ import (
 )
 
 // CreateWebhook - create a webhook for a vhost and a specific qeueu
-func (api *API) CreateWebhook(instanceID int, params map[string]interface{},
-	sleep, timeout int) (map[string]interface{}, error) {
+func (api *API) CreateWebhook(instanceID int, params map[string]any,
+	sleep, timeout int) (map[string]any, error) {
 
 	return api.createWebhookWithRetry(instanceID, params, 1, sleep, timeout)
 }
 
 // createWebhookWithRetry: create webhook with retry if backend is busy.
-func (api *API) createWebhookWithRetry(instanceID int, params map[string]interface{},
-	attempt, sleep, timeout int) (map[string]interface{}, error) {
+func (api *API) createWebhookWithRetry(instanceID int, params map[string]any,
+	attempt, sleep, timeout int) (map[string]any, error) {
 
 	var (
-		data   = make(map[string]interface{})
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/webhooks", instanceID)
 	)
 
@@ -58,7 +58,7 @@ func (api *API) createWebhookWithRetry(instanceID int, params map[string]interfa
 
 // ReadWebhook - retrieves a specific webhook for an instance
 func (api *API) ReadWebhook(instanceID int, webhookID string, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	path := fmt.Sprintf("/api/instances/%d/webhooks/%s", instanceID, webhookID)
 	return api.readWebhookWithRetry(path, 1, sleep, timeout)
@@ -66,11 +66,11 @@ func (api *API) ReadWebhook(instanceID int, webhookID string, sleep, timeout int
 
 // readWebhookWithRetry: read webhook with retry if backend is busy.
 func (api *API) readWebhookWithRetry(path string, attempt, sleep, timeout int) (
-	map[string]interface{}, error) {
+	map[string]any, error) {
 
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 	)
 
 	log.Printf("[DEBUG] api::webhook#read path: %s", path)
@@ -100,10 +100,10 @@ func (api *API) readWebhookWithRetry(path string, attempt, sleep, timeout int) (
 }
 
 // ListWebhooks - list all webhooks for an instance.
-func (api *API) ListWebhooks(instanceID int) (map[string]interface{}, error) {
+func (api *API) ListWebhooks(instanceID int) (map[string]any, error) {
 	var (
-		data   map[string]interface{}
-		failed map[string]interface{}
+		data   map[string]any
+		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/webhooks", instanceID)
 	)
 
@@ -123,7 +123,7 @@ func (api *API) ListWebhooks(instanceID int) (map[string]interface{}, error) {
 }
 
 // UpdateWebhook - updates a specific webhook for an instance
-func (api *API) UpdateWebhook(instanceID int, webhookID string, params map[string]interface{},
+func (api *API) UpdateWebhook(instanceID int, webhookID string, params map[string]any,
 	sleep, timeout int) error {
 
 	path := fmt.Sprintf("/api/instances/%d/webhooks/%s", instanceID, webhookID)
@@ -131,12 +131,12 @@ func (api *API) UpdateWebhook(instanceID int, webhookID string, params map[strin
 }
 
 // updateWebhookWithRetry: update webhook with retry if backend is busy.
-func (api *API) updateWebhookWithRetry(path string, params map[string]interface{},
+func (api *API) updateWebhookWithRetry(path string, params map[string]any,
 	attempt, sleep, timeout int) error {
 
 	var (
-		data   = make(map[string]interface{})
-		failed map[string]interface{}
+		data   = make(map[string]any)
+		failed map[string]any
 	)
 
 	log.Printf("[DEBUG] api::webhook#update path: %s, params: %v", path, params)
@@ -174,7 +174,7 @@ func (api *API) DeleteWebhook(instanceID int, webhookID string, sleep, timeout i
 // deleteWebhookWithRetry: delete webhook with retry if backend is busy.
 func (api *API) deleteWebhookWithRetry(path string, attempt, sleep, timeout int) error {
 	var (
-		failed map[string]interface{}
+		failed map[string]any
 	)
 
 	log.Printf("[DEBUG] api::webhook#delete path: %s", path)

--- a/cloudamqp/data_source_cloudamqp_account.go
+++ b/cloudamqp/data_source_cloudamqp_account.go
@@ -3,7 +3,7 @@ package cloudamqp
 import (
 	"fmt"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/data_source_cloudamqp_account_vpcs.go
+++ b/cloudamqp/data_source_cloudamqp_account_vpcs.go
@@ -3,7 +3,7 @@ package cloudamqp
 import (
 	"fmt"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/data_source_cloudamqp_alarm.go
+++ b/cloudamqp/data_source_cloudamqp_alarm.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/data_source_cloudamqp_alarm.go
+++ b/cloudamqp/data_source_cloudamqp_alarm.go
@@ -119,7 +119,7 @@ func dataSourceAlarmIDRead(instanceID int, alarmID int, meta interface{}) (map[s
 
 func dataSourceAlarmTypeRead(instanceID int, alarmType string, meta interface{}) (map[string]interface{}, error) {
 	api := meta.(*api.API)
-	alarms, err := api.ReadAlarms(instanceID)
+	alarms, err := api.ListAlarms(instanceID)
 
 	if err != nil {
 		return nil, err

--- a/cloudamqp/data_source_cloudamqp_credentials.go
+++ b/cloudamqp/data_source_cloudamqp_credentials.go
@@ -1,10 +1,10 @@
 package cloudamqp
 
 import (
-	"github.com/84codes/go-api/api"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	"fmt"
+
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceCredentials() *schema.Resource {

--- a/cloudamqp/data_source_cloudamqp_instance.go
+++ b/cloudamqp/data_source_cloudamqp_instance.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/data_source_cloudamqp_nodes.go
+++ b/cloudamqp/data_source_cloudamqp_nodes.go
@@ -68,7 +68,7 @@ func dataSourceNodes() *schema.Resource {
 
 func dataSourceNodesRead(d *schema.ResourceData, meta interface{}) error {
 	api := meta.(*api.API)
-	data, err := api.ReadNodes(d.Get("instance_id").(int))
+	data, err := api.ListNodes(d.Get("instance_id").(int))
 	if err != nil {
 		return err
 	}

--- a/cloudamqp/data_source_cloudamqp_nodes.go
+++ b/cloudamqp/data_source_cloudamqp_nodes.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/data_source_cloudamqp_notification.go
+++ b/cloudamqp/data_source_cloudamqp_notification.go
@@ -86,7 +86,7 @@ func dataSourceNotificationIDRead(instanceID int, alarmID int, meta interface{})
 
 func dataSourceNotificationTypeRead(instanceID int, name string, meta interface{}) (map[string]interface{}, error) {
 	api := meta.(*api.API)
-	recipients, err := api.ReadNotifications(instanceID)
+	recipients, err := api.ListNotifications(instanceID)
 
 	if err != nil {
 		return nil, err

--- a/cloudamqp/data_source_cloudamqp_notification.go
+++ b/cloudamqp/data_source_cloudamqp_notification.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/data_source_cloudamqp_plugins.go
+++ b/cloudamqp/data_source_cloudamqp_plugins.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/data_source_cloudamqp_plugins_community.go
+++ b/cloudamqp/data_source_cloudamqp_plugins_community.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/data_source_cloudamqp_upgradable_versions.go
+++ b/cloudamqp/data_source_cloudamqp_upgradable_versions.go
@@ -3,7 +3,7 @@ package cloudamqp
 import (
 	"strconv"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/data_source_cloudamqp_vpc_gcp_info.go
+++ b/cloudamqp/data_source_cloudamqp_vpc_gcp_info.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/data_source_cloudamqp_vpc_info.go
+++ b/cloudamqp/data_source_cloudamqp_vpc_info.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/provider.go
+++ b/cloudamqp/provider.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/resource_cloudamqp_account_actions.go
+++ b/cloudamqp/resource_cloudamqp_account_actions.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/cloudamqp/resource_cloudamqp_alarm.go
+++ b/cloudamqp/resource_cloudamqp_alarm.go
@@ -98,12 +98,12 @@ func resourceAlarmCreate(d *schema.ResourceData, meta interface{}) error {
 			params[k] = v
 		}
 	}
-	log.Printf("[DEBUG] cloudamqp::resource::alarm::create params: %v", params)
+	log.Printf("[DEBUG] cloudamqp::resource::alarm#create params: %v", params)
 
 	if d.Get("type") == "notice" {
-		log.Printf("[DEBUG] cloudamqp::resource::alarm::create type is 'notice', skipping creation")
-		log.Printf("[DEBUG] cloudamqp::resource::alarm::create type is 'notice', getting existing notice alarm")
-		alarms, err := api.ReadAlarms(d.Get("instance_id").(int))
+		log.Printf("[DEBUG] cloudamqp::resource::alarm#create type is 'notice', skipping creation")
+		log.Printf("[DEBUG] cloudamqp::resource::alarm#create type is 'notice', getting existing notice alarm")
+		alarms, err := api.ListAlarms(d.Get("instance_id").(int))
 
 		if err != nil {
 			return err
@@ -112,8 +112,8 @@ func resourceAlarmCreate(d *schema.ResourceData, meta interface{}) error {
 		for _, alarm := range alarms {
 			if alarm["type"] == "notice" {
 				d.SetId(strconv.FormatFloat(alarm["id"].(float64), 'f', 0, 64))
-				log.Printf("[DEBUG] cloudamqp::resource::alarm::create retrieved existing alarm id: %v", d.Id())
-				log.Printf("[DEBUG] cloudamqp::resource::alarm::create invoking existing alarm update")
+				log.Printf("[DEBUG] cloudamqp::resource::alarm#create retrieved existing alarm id: %v", d.Id())
+				log.Printf("[DEBUG] cloudamqp::resource::alarm#create invoking existing alarm update")
 				return resourceAlarmUpdate(d, meta)
 			}
 		}
@@ -121,14 +121,14 @@ func resourceAlarmCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Couldn't find notice alarm for instance_id %s", d.Get("instance_id"))
 	} else {
 		data, err := api.CreateAlarm(d.Get("instance_id").(int), params)
-		log.Printf("[DEBUG] cloudamqp::resource::alarm::create data: %v", data)
+		log.Printf("[DEBUG] cloudamqp::resource::alarm#create data: %v", data)
 
 		if err != nil {
 			return err
 		}
 		if data["id"] != nil {
 			d.SetId(data["id"].(string))
-			log.Printf("[DEBUG] cloudamqp::resource::alarm::create id set: %v", d.Id())
+			log.Printf("[DEBUG] cloudamqp::resource::alarm#create id set: %v", d.Id())
 		}
 	}
 
@@ -196,7 +196,7 @@ func resourceAlarmDelete(d *schema.ResourceData, meta interface{}) error {
 	params := make(map[string]interface{})
 	params["id"] = d.Id()
 	log.Printf("[DEBUG] cloudamqp::resource::alarm::delete params: %v", params)
-	return api.DeleteAlarm(d.Get("instance_id").(int), params)
+	return api.DeleteAlarm(d.Get("instance_id").(int), d.Id())
 }
 
 func validateAlarmType() schema.SchemaValidateDiagFunc {

--- a/cloudamqp/resource_cloudamqp_alarm.go
+++ b/cloudamqp/resource_cloudamqp_alarm.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/cloudamqp/resource_cloudamqp_aws_eventbridge.go
+++ b/cloudamqp/resource_cloudamqp_aws_eventbridge.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/resource_cloudamqp_custom_domain.go
+++ b/cloudamqp/resource_cloudamqp_custom_domain.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/resource_cloudamqp_extra_disk_size.go
+++ b/cloudamqp/resource_cloudamqp_extra_disk_size.go
@@ -98,7 +98,7 @@ func resourceExtraDiskSizeRead(d *schema.ResourceData, meta interface{}) error {
 		instanceID = d.Get("instance_id").(int)
 	)
 
-	data, err := api.ReadNodes(instanceID)
+	data, err := api.ListNodes(instanceID)
 	if err != nil {
 		return err
 	}

--- a/cloudamqp/resource_cloudamqp_extra_disk_size.go
+++ b/cloudamqp/resource_cloudamqp_extra_disk_size.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/resource_cloudamqp_instance.go
+++ b/cloudamqp/resource_cloudamqp_instance.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/cloudamqp/resource_cloudamqp_integration_log.go
+++ b/cloudamqp/resource_cloudamqp_integration_log.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/cloudamqp/resource_cloudamqp_integration_metric.go
+++ b/cloudamqp/resource_cloudamqp_integration_metric.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/cloudamqp/resource_cloudamqp_node_actions.go
+++ b/cloudamqp/resource_cloudamqp_node_actions.go
@@ -1,7 +1,7 @@
 package cloudamqp
 
 import (
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/cloudamqp/resource_cloudamqp_notification.go
+++ b/cloudamqp/resource_cloudamqp_notification.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/cloudamqp/resource_cloudamqp_plugin.go
+++ b/cloudamqp/resource_cloudamqp_plugin.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/resource_cloudamqp_plugin_community.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/resource_cloudamqp_privatelink_aws.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_aws.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/cloudamqp/resource_cloudamqp_privatelink_azure.go
+++ b/cloudamqp/resource_cloudamqp_privatelink_azure.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/cloudamqp/resource_cloudamqp_rabbitmq_configuration.go
+++ b/cloudamqp/resource_cloudamqp_rabbitmq_configuration.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/cloudamqp/resource_cloudamqp_security_firewall.go
+++ b/cloudamqp/resource_cloudamqp_security_firewall.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/cloudamqp/resource_cloudamqp_upgrade_rabbitmq.go
+++ b/cloudamqp/resource_cloudamqp_upgrade_rabbitmq.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/resource_cloudamqp_vpc.go
+++ b/cloudamqp/resource_cloudamqp_vpc.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/resource_cloudamqp_vpc_connect.go
+++ b/cloudamqp/resource_cloudamqp_vpc_connect.go
@@ -7,8 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/84codes/go-api/api"
-
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/cloudamqp/resource_cloudamqp_vpc_gcp_peering.go
+++ b/cloudamqp/resource_cloudamqp_vpc_gcp_peering.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"log"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/resource_cloudamqp_vpc_peering.go
+++ b/cloudamqp/resource_cloudamqp_vpc_peering.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/cloudamqp/resource_cloudamqp_webhooks.go
+++ b/cloudamqp/resource_cloudamqp_webhooks.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/84codes/go-api/api"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,8 @@ go 1.21
 
 toolchain go1.22.2
 
-require github.com/84codes/go-api v1.16.2
-
 require (
+	github.com/dghubble/sling v1.4.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/tidwall/gjson v1.17.1
 	github.com/tidwall/sjson v1.2.5
@@ -67,5 +66,3 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// replace github.com/84codes/go-api => ../../84codes/go-api

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/84codes/go-api v1.16.2 h1:sRZ7FYLaWTtDQTQ4uUxlhZrJLm6e5w2xRcBwI+rG/g0=
-github.com/84codes/go-api v1.16.2/go.mod h1:pTTFpG2A0THyz22WDxOEYsKzgaU9HIdD0/qTuUwltCE=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.0 h1:nHGfwXmFvJrSR9xu8qL7BkO4DqTHXE9N5vPhgY2I+j0=


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/282 imported https://github.com/84codes/go-api with history

https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/273 makes some changes to the library code, the commits are cherry-picked from that branch

### WHAT is this pull request doing?

- Directly use go-api client library in the provider
- Remove the dependancy to separated go-api client library
- Clean up code and logging.
- More coherent code structure
  - Declare variable within var()
  - Make request
  - Switch statement to handle response

### HOW can this pull request be tested?

- [x] Test with Go-VCR test fixtures and subset of new tests
