### PR TITLE
Add availability zone information to nodes

### DIFF
--- a/cloudamqp/data_source_cloudamqp_nodes.go
+++ b/cloudamqp/data_source_cloudamqp_nodes.go
@@ -59,6 +59,10 @@ func dataSourceNodes() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"availability_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -108,7 +112,8 @@ func validateNodesSchemaAttribute(key string) bool {
 		"configured",
 		"rmq_version",
 		"disk_size",
-		"additional_disk_size":
+		"additional_disk_size",
+		"availability_zone":
 		return true
 	}
 	return false

--- a/docs/data-sources/nodes.md
+++ b/docs/data-sources/nodes.md
@@ -41,6 +41,7 @@ The `nodes` block consist of
 * `configured`            - Is the node configured?
 * `disk_size`             - Subscription plan disk size
 * `additional_disk_size`  - Additional added disk size
+* `availability_zone`     - Availability zone the node is hosted in.
 
 ***Note:*** *Total disk size = disk_size + additional_disk_size*
 


### PR DESCRIPTION
### WHY are these changes introduced?

Request https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/288 to add availability zone information to all nodes.

### WHAT is this pull request doing?

Add availability zone information to nodes data source.

### HOW can this pull request be tested?

Manual checked 1-3 nodes changes for AWS (including Google and Azure). AZ id updated automatically for the data source when subscription plan changed. 