### PR TITLE
Remove default subscription plan from VCR testing configuration

### DIFF
--- a/cloudamqp/resource_cloudamqp_alarm_test.go
+++ b/cloudamqp/resource_cloudamqp_alarm_test.go
@@ -23,6 +23,7 @@ func TestAccAlarm_Basic(t *testing.T) {
 		params = map[string]string{
 			"InstanceName":   "TestAccAlarm_Basic",
 			"InstanceID":     fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":   "bunny-1",
 			"RecipientName":  "test",
 			"RecipientType":  "email",
 			"RecipientValue": "test@example.com",
@@ -41,6 +42,7 @@ func TestAccAlarm_Basic(t *testing.T) {
 		paramsUpdated    = map[string]string{
 			"InstanceName":             "TestAccAlarm_Basic",
 			"InstanceID":               fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":             "bunny-1",
 			"RecipientName":            "test",
 			"RecipientType":            "email",
 			"RecipientValue":           "test@example.com",

--- a/cloudamqp/resource_cloudamqp_aws_eventbridge_test.go
+++ b/cloudamqp/resource_cloudamqp_aws_eventbridge_test.go
@@ -18,6 +18,7 @@ func TestAccIntegrationAwsEventbridge_Basic(t *testing.T) {
 		params = map[string]string{
 			"InstanceName":            "TestAccIntegrationAwsEventbridge_Basic",
 			"InstanceID":              fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":            "bunny-1",
 			"AwsEventbridgeVhost":     "myvhost",
 			"AwsEventbridgeQueue":     "myqueue",
 			"AwsEventbridgeAccountID": "012345678910",

--- a/cloudamqp/resource_cloudamqp_extra_disk_size_test.go
+++ b/cloudamqp/resource_cloudamqp_extra_disk_size_test.go
@@ -18,6 +18,7 @@ func TestAccExtraDiskSize_AWS_Basic(t *testing.T) {
 		params = map[string]string{
 			"InstanceName":   "TestAccExtraDiskSize_AWS_Basic",
 			"InstanceID":     fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":   "bunny-1",
 			"InstanceRegion": "amazon-web-services::us-east-1",
 			"ExtraDiskSize":  "25",
 			"AllowDowntime":  "false",
@@ -51,6 +52,7 @@ func TestAccExtraDiskSize_GCE_Basic(t *testing.T) {
 		params = map[string]string{
 			"InstanceName":   "TestAccExtraDiskSize_GCE_Basic",
 			"InstanceID":     fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":   "bunny-1",
 			"InstanceRegion": "google-compute-engine::us-east1",
 			"ExtraDiskSize":  "25",
 			"AllowDowntime":  "false",
@@ -84,6 +86,7 @@ func TestAccExtraDiskSize_Azure_Basic(t *testing.T) {
 		params = map[string]string{
 			"InstanceName":   "TestAccExtraDiskSize_Azure_Basic",
 			"InstanceID":     fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":   "bunny-1",
 			"InstanceRegion": "azure-arm::eastus",
 			"ExtraDiskSize":  "25",
 			"AllowDowntime":  "true",

--- a/cloudamqp/resource_cloudamqp_instance_test.go
+++ b/cloudamqp/resource_cloudamqp_instance_test.go
@@ -22,12 +22,14 @@ func TestAccInstance_Basic(t *testing.T) {
 			"InstanceName": "TestAccInstance_Basic-before",
 			"InstanceTags": converter.CommaStringArray([]string{"terraform"}),
 			"InstanceID":   fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan": "bunny-1",
 		}
 
 		paramsUpdated = map[string]string{
 			"InstanceName": "TestAccInstance_Basic-after",
 			"InstanceTags": converter.CommaStringArray([]string{"terraform", "acceptance-test"}),
 			"InstanceID":   fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan": "bunny-1",
 		}
 	)
 

--- a/cloudamqp/resource_cloudamqp_integration_log_test.go
+++ b/cloudamqp/resource_cloudamqp_integration_log_test.go
@@ -27,6 +27,7 @@ func TestAccIntegrationLog_Basic(t *testing.T) {
 		params = map[string]string{
 			"InstanceName":              "TestAccIntegrationLog_Basic",
 			"InstanceID":                fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":              "bunny-1",
 			"InstanceHost":              fmt.Sprintf("%s.host", instanceResourceName),
 			"AzmTentantId":              "71e89a32-14f3-4458-b136-7395bb6d1969", // Randomized token
 			"AzmApplicationId":          "3e303e72-4024-494c-b5f6-f5ffbe8139de", // Randomized token

--- a/cloudamqp/resource_cloudamqp_integration_metric_test.go
+++ b/cloudamqp/resource_cloudamqp_integration_metric_test.go
@@ -22,6 +22,7 @@ func TestAccIntegrationMetric_Basic(t *testing.T) {
 		params = map[string]string{
 			"InstanceName":              "TestAccIntegrationMetric_Basic",
 			"InstanceID":                fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":              "bunny-1",
 			"CloudwatchAccessKeyId":     os.Getenv("CLOUDWATCH_ACCESS_KEY_ID"),
 			"CloudwatchSecretAccessKey": os.Getenv("CLOUDWATCH_SECRET_ACCESS_KEY"),
 			"CloudwatchRegion":          "us-east-1",

--- a/cloudamqp/resource_cloudamqp_notification_test.go
+++ b/cloudamqp/resource_cloudamqp_notification_test.go
@@ -18,6 +18,7 @@ func TestAccNotification_Basic(t *testing.T) {
 		params = map[string]string{
 			"InstanceName":   "TestAccNotification_Basic",
 			"InstanceID":     fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":   "bunny-1",
 			"RecipientType":  "email",
 			"RecipientValue": "notification@example.com",
 			"RecipientName":  "notification",
@@ -26,6 +27,7 @@ func TestAccNotification_Basic(t *testing.T) {
 		paramsUpdated = map[string]string{
 			"InstanceName":   "TestAccNotification_Basic",
 			"InstanceID":     fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":   "bunny-1",
 			"RecipientType":  "email",
 			"RecipientValue": "test@example.com",
 			"RecipientName":  "test",

--- a/cloudamqp/resource_cloudamqp_plugin_community_test.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community_test.go
@@ -21,6 +21,7 @@ func TestAccPluginCommunity_Basic(t *testing.T) {
 		params = map[string]string{
 			"InstanceName":           "TestAccPluginCommunity_Basic",
 			"InstanceID":             fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":           "bunny-1",
 			"PluginCommunityName":    "rabbitmq_delayed_message_exchange",
 			"PluginCommunityEnabled": "true",
 			"PluginCommunitySleep":   "1",
@@ -29,6 +30,7 @@ func TestAccPluginCommunity_Basic(t *testing.T) {
 		paramsUpdated = map[string]string{
 			"InstanceName":           "TestAccPluginCommunity_Basic",
 			"InstanceID":             fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":           "bunny-1",
 			"PluginCommunityName":    "rabbitmq_delayed_message_exchange",
 			"PluginCommunityEnabled": "false",
 			"PluginCommunitySleep":   "1",

--- a/cloudamqp/resource_cloudamqp_plugin_test.go
+++ b/cloudamqp/resource_cloudamqp_plugin_test.go
@@ -21,6 +21,7 @@ func TestAccPlugin_Basic(t *testing.T) {
 		params = map[string]string{
 			"InstanceName":  "TestAccPlugin_Basic",
 			"InstanceID":    fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":  "bunny-1",
 			"PluginName":    "rabbitmq_mqtt",
 			"PluginEnabled": "true",
 			"PluginSleep":   "1",
@@ -29,6 +30,7 @@ func TestAccPlugin_Basic(t *testing.T) {
 		paramsUpdated = map[string]string{
 			"InstanceName":  "TestAccPlugin_Basic",
 			"InstanceID":    fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":  "bunny-1",
 			"PluginName":    "rabbitmq_mqtt",
 			"PluginEnabled": "false",
 			"PluginSleep":   "1",

--- a/cloudamqp/resource_cloudamqp_rabbitmq_configuration_test.go
+++ b/cloudamqp/resource_cloudamqp_rabbitmq_configuration_test.go
@@ -18,6 +18,7 @@ func TestAccRabbitMqConfiguration_Basic(t *testing.T) {
 		params = map[string]string{
 			"InstanceName":    "TestAccRabbitMqConfiguration_Basic",
 			"InstanceID":      fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":    "bunny-1",
 			"ChannelMax":      "100",
 			"ConnectionMax":   "100",
 			"ConsumerTimeout": "720000",
@@ -60,6 +61,7 @@ func TestAccRabbitMqConfiguration_LogExhangeLevel(t *testing.T) {
 		params = map[string]string{
 			"InstanceName":     "TestAccRabbitMqConfiguration_Basic",
 			"InstanceID":       fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":     "bunny-1",
 			"LogExchangeLevel": "info",
 			"NodeName":         fmt.Sprintf("%s.nodes[0].name", dataSourceNodesName),
 			"NodeAction":       "restart",

--- a/cloudamqp/resource_cloudamqp_security_firewall_test.go
+++ b/cloudamqp/resource_cloudamqp_security_firewall_test.go
@@ -24,12 +24,14 @@ func TestAccFirewall_Basic(t *testing.T) {
 			"VpcName":      "TestAccFirewall_Basic",
 			"InstanceName": "TestAccFirewall_Basic",
 			"InstanceID":   fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan": "bunny-1",
 		}
 
 		paramsUpdated = map[string]string{
 			"VpcName":             "TestAccFirewall_Basic",
 			"InstanceName":        "TestAccFirewall_Basic",
 			"InstanceID":          fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":        "bunny-1",
 			"FirewallIP":          "10.56.72.0/24",
 			"FirewallDescription": "VPC Subnet",
 			"FirewallServices":    converter.CommaStringArray([]string{"AMQPS"}),

--- a/cloudamqp/resource_cloudamqp_upgrade_rabbitmq_test.go
+++ b/cloudamqp/resource_cloudamqp_upgrade_rabbitmq_test.go
@@ -23,6 +23,7 @@ func TestAccUpgradeRabbitMQ_Latest(t *testing.T) {
 			"InstanceName":       "TestAccUpgradeRabbitMQ_Latest",
 			"InstanceTags":       converter.CommaStringArray([]string{"terraform"}),
 			"InstanceID":         fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":       "bunny-1",
 			"InstanceRmqVersion": "3.12.2",
 		}
 
@@ -32,6 +33,7 @@ func TestAccUpgradeRabbitMQ_Latest(t *testing.T) {
 			"InstanceName":                  "TestAccUpgradeRabbitMQ_Latest",
 			"InstanceTags":                  converter.CommaStringArray([]string{"terraform"}),
 			"InstanceID":                    fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":                  "bunny-1",
 			"UpgradeRabbitMQCurrentVersion": "3.12.2",
 			"UpgradeRabbitMQNewVersion":     "3.12.13",
 		}
@@ -40,6 +42,7 @@ func TestAccUpgradeRabbitMQ_Latest(t *testing.T) {
 			"InstanceName":                  "TestAccUpgradeRabbitMQ_Latest",
 			"InstanceTags":                  converter.CommaStringArray([]string{"terraform"}),
 			"InstanceID":                    fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":                  "bunny-1",
 			"UpgradeRabbitMQCurrentVersion": "3.12.13",
 			"UpgradeRabbitMQNewVersion":     "3.13.2",
 		}
@@ -49,6 +52,7 @@ func TestAccUpgradeRabbitMQ_Latest(t *testing.T) {
 			"InstanceName": "TestAccUpgradeRabbitMQ_Latest",
 			"InstanceTags": converter.CommaStringArray([]string{"terraform"}),
 			"InstanceID":   fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan": "bunny-1",
 		}
 	)
 
@@ -115,6 +119,7 @@ func TestAccUpgradeRabbitMQ_Specific(t *testing.T) {
 			"InstanceName":       "TestAccUpgradeRabbitMQ_Latest",
 			"InstanceTags":       converter.CommaStringArray([]string{"terraform"}),
 			"InstanceID":         fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":       "bunny-1",
 			"InstanceRmqVersion": "3.12.2",
 		}
 
@@ -124,6 +129,7 @@ func TestAccUpgradeRabbitMQ_Specific(t *testing.T) {
 			"InstanceName":              "TestAccUpgradeRabbitMQ_Latest",
 			"InstanceTags":              converter.CommaStringArray([]string{"terraform"}),
 			"InstanceID":                fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":              "bunny-1",
 			"UpgradeRabbitMQNewVersion": "3.12.13",
 		}
 
@@ -131,6 +137,7 @@ func TestAccUpgradeRabbitMQ_Specific(t *testing.T) {
 			"InstanceName":              "TestAccUpgradeRabbitMQ_Latest",
 			"InstanceTags":              converter.CommaStringArray([]string{"terraform"}),
 			"InstanceID":                fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":              "bunny-1",
 			"UpgradeRabbitMQNewVersion": "3.13.2",
 		}
 
@@ -138,6 +145,7 @@ func TestAccUpgradeRabbitMQ_Specific(t *testing.T) {
 		paramsCheck           = map[string]string{
 			"InstanceName": "TestAccUpgradeRabbitMQ_Latest",
 			"InstanceTags": converter.CommaStringArray([]string{"terraform"}),
+			"InstancePlan": "bunny-1",
 			"InstanceID":   fmt.Sprintf("%s.id", instanceResourceName),
 		}
 	)

--- a/cloudamqp/resource_cloudamqp_vpc_connect_test.go
+++ b/cloudamqp/resource_cloudamqp_vpc_connect_test.go
@@ -24,6 +24,7 @@ func TestAccVpcConnect_AWS_Basic(t *testing.T) {
 			"InstanceName":   "TestAccVpcConnect_AWS_Basic",
 			"InstanceRegion": "amazon-web-services::us-east-1",
 			"InstanceID":     fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":   "bunny-1",
 			"VpcConnectAllowedPrincipals": converter.CommaStringArray([]string{
 				"arn:aws:iam::123456789012:root"}),
 		}
@@ -90,6 +91,7 @@ func TestAccVpcConnect_Azure_Basic(t *testing.T) {
 			"InstanceName":   "TestAccVpcConnect_Azure_Basic",
 			"InstanceRegion": "azure-arm::eastus",
 			"InstanceID":     fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":   "bunny-1",
 			"VpcConnectApprovedSubscriptions": converter.CommaStringArray([]string{
 				"56fab608-c846-4770-a493-e77f52c1ce41"}),
 		}
@@ -133,6 +135,7 @@ func TestAccVpcConnect_GCP_Basic(t *testing.T) {
 			"InstanceName":   "TestAccVpcConnect_GCP_Basic",
 			"InstanceRegion": "google-compute-engine::us-west1",
 			"InstanceID":     fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":   "bunny-1",
 			"VpcConnectAllowedProjects": converter.CommaStringArray([]string{
 				"playground-84codes"}),
 		}

--- a/cloudamqp/resource_cloudamqp_webhook_test.go
+++ b/cloudamqp/resource_cloudamqp_webhook_test.go
@@ -18,6 +18,7 @@ func TestAccWebhook_Basic(t *testing.T) {
 		params = map[string]string{
 			"InstanceName":       "TestAccWebhook_Basic",
 			"InstanceID":         fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":       "bunny-1",
 			"WebhookVhost":       fmt.Sprintf("%s.vhost", instanceResourceName),
 			"WebhookQueue":       "myqueue",
 			"WebhookURI":         "https://example.com/webhook?key=secret",
@@ -27,6 +28,7 @@ func TestAccWebhook_Basic(t *testing.T) {
 		paramsUpdated = map[string]string{
 			"InstanceName":       "TestAccWebhook_Basic",
 			"InstanceID":         fmt.Sprintf("%s.id", instanceResourceName),
+			"InstancePlan":       "bunny-1",
 			"WebhookVhost":       fmt.Sprintf("%s.vhost", instanceResourceName),
 			"WebhookQueue":       "myqueue_02",
 			"WebhookURI":         "https://example.com/webhook?key=secret",

--- a/test/configurations/instance.txt
+++ b/test/configurations/instance.txt
@@ -1,6 +1,6 @@
 resource "cloudamqp_instance" "instance" {
 	name   = "{{or .InstanceName `TestAccInstance`}}"
-	plan   = "{{or .InstancePlan `bunny-1`}}"
+	plan   = "{{.InstancePlan}}"
 	region = "{{or .InstanceRegion `amazon-web-services::us-east-1`}}"
 	tags   = {{or .InstanceTags `["terraform"]`}}
 }

--- a/test/configurations/instance_with_version.txt
+++ b/test/configurations/instance_with_version.txt
@@ -1,6 +1,6 @@
 resource "cloudamqp_instance" "instance" {
 	name   = "{{or .InstanceName `TestAccInstance`}}"
-	plan   = "{{or .InstancePlan `bunny-1`}}"
+	plan   = "{{.InstancePlan}}"
 	region = "{{or .InstanceRegion `amazon-web-services::us-east-1`}}"
 	tags   = {{or .InstanceTags `["terraform"]`}}
 	rmq_version = "{{.InstanceRmqVersion}}"


### PR DESCRIPTION
### WHY are these changes introduced?

To use the same instance resource VCR test configuration for both backends. This force each configuration to include the subscription plan to be used.

### WHAT is this pull request doing?

Remove the default subscription plan from `instance*.txt` configuration.
Add the subscription plan to all tests.

### HOW can this pull request be tested?

Run VCR tests.