### PR TITLE
Enable import of VPC peering resource for AWS

### DIFF
--- a/cloudamqp/provider_test.go
+++ b/cloudamqp/provider_test.go
@@ -146,6 +146,10 @@ func cloudamqpResourceTest(t *testing.T, c resource.TestCase) {
 				fmt.Println("SKIP: PUT /api/instances/{id}/config", i.Request.URL, "error:", errStr)
 				i.DiscardOnSave = true
 			}
+		case i.Response.Code == 400 && i.Request.Method == "DELETE" &&
+			regexp.MustCompile(`api/vpcs/\d+/vpc-peering/pcx-[0-9].*$`).MatchString(i.Request.URL):
+			fmt.Println("SKIP: GET /api/vpcs/{id}/security/vpc-peering/request", i.Request.URL)
+			i.DiscardOnSave = true
 		}
 		return nil
 	}

--- a/cloudamqp/resource_cloudamqp_vpc_peering.go
+++ b/cloudamqp/resource_cloudamqp_vpc_peering.go
@@ -3,6 +3,7 @@ package cloudamqp
 import (
 	"errors"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
@@ -16,6 +17,9 @@ func resourceVpcPeering() *schema.Resource {
 		Read:   resourceVpcPeeringRead,
 		Update: resourceVpcPeeringAccept,
 		Delete: resourceVpcPeeringDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"instance_id": {
 				Type:        schema.TypeInt,
@@ -54,60 +58,114 @@ func resourceVpcPeering() *schema.Resource {
 }
 
 func resourceVpcPeeringAccept(d *schema.ResourceData, meta interface{}) error {
-	api := meta.(*api.API)
-	err := errors.New("")
-	if d.Get("instance_id") == 0 && d.Get("vpc_id") == nil {
+	var (
+		api        = meta.(*api.API)
+		err        = errors.New("")
+		instanceID = d.Get("instance_id").(int)
+		vpcID      = d.Get("vpc_id").(string)
+		peeringID  = d.Get("peering_id").(string)
+		sleep      = d.Get("sleep").(int)
+		timeout    = d.Get("timeout").(int)
+	)
+
+	log.Printf("[DEBUG] cloudamqp::resource::vpc_aws_peering#accept instance_id: %d, vpc_id: %s, "+
+		"peering_id: %s", instanceID, vpcID, peeringID)
+
+	if instanceID == 0 && vpcID == "" {
 		return errors.New("you need to specify either instance_id or vpc_id")
-	} else if d.Get("instance_id") != 0 {
-		_, err = api.AcceptVpcPeering(d.Get("instance_id").(int), d.Get("peering_id").(string),
-			d.Get("sleep").(int), d.Get("timeout").(int))
-	} else if d.Get("vpc_id") != nil {
-		_, err = api.AcceptVpcPeeringWithVpcId(d.Get("vpc_id").(string), d.Get("peering_id").(string),
-			d.Get("sleep").(int), d.Get("timeout").(int))
+	} else if instanceID != 0 {
+		_, err = api.AcceptVpcPeering(instanceID, peeringID, sleep, timeout)
+	} else if vpcID != "" {
+		_, err = api.AcceptVpcPeeringWithVpcId(vpcID, peeringID, sleep, timeout)
 	}
 
 	if err != nil {
 		return err
-	}
-	if d.Get("peering_id") != nil {
-		d.SetId(d.Get("peering_id").(string))
 	}
 
 	return resourceVpcPeeringRead(d, meta)
 }
 
 func resourceVpcPeeringRead(d *schema.ResourceData, meta interface{}) error {
+	var (
+		api        = meta.(*api.API)
+		instanceID = d.Get("instance_id").(int)
+		vpcID      = d.Get("vpc_id").(string)
+		peeringID  = d.Get("peering_id").(string)
+		data       map[string]interface{}
+		err        = errors.New("")
+	)
+
+	// Check to determine if the resource should be imported.
 	if strings.Contains(d.Id(), ",") {
-		s := strings.Split(d.Id(), ",")
-		d.SetId(s[0])
-		if s[1] != "" {
-			instanceID, _ := strconv.Atoi(s[1])
-			d.Set("instance_id", instanceID)
-		} else if s[2] != "" {
-			vpcID, _ := strconv.Atoi(s[2])
-			d.Set("vpc_id", vpcID)
-		}
-	}
-	if d.Get("instance_id").(int) == 0 && d.Get("vpc_id").(string) == "" {
-		return errors.New("missing instance identifier: {resource_id},{instance_id}")
+		log.Printf("[DEBUG] cloudamqp::resource::vpc_aws_peering#read import detected")
+		return resourceVpcPeeringImport(d, meta)
 	}
 
-	api := meta.(*api.API)
-	err := errors.New("")
-	data := make(map[string]interface{})
-	if d.Get("instance_id") == 0 && d.Get("vpc_id") == nil {
+	if instanceID == 0 && vpcID == "" {
 		return errors.New("you need to specify either instance_id or vpc_id")
-	} else if d.Get("instance_id") != 0 {
-		data, err = api.ReadVpcPeeringRequest(d.Get("instance_id").(int), d.Get("peering_id").(string))
+	} else if instanceID != 0 {
+		data, err = api.ReadVpcPeeringRequest(instanceID, peeringID)
 	} else if d.Get("vpc_id") != nil {
-		data, err = api.ReadVpcPeeringRequestWithVpcId(d.Get("vpc_id").(string), d.Get("peering_id").(string))
+		data, err = api.ReadVpcPeeringRequestWithVpcId(vpcID, peeringID)
 	}
 
 	if err != nil {
 		return err
 	}
+
 	for k, v := range data {
-		if k == "status" {
+		switch k {
+		case "vpc_peering_connection_id":
+			d.SetId(v.(string))
+		case "status":
+			status := v.(map[string]interface{})
+			if err = d.Set(k, status["code"]); err != nil {
+				return fmt.Errorf("error setting status for resource %s: %s", d.Id(), err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceVpcPeeringImport(d *schema.ResourceData, meta interface{}) error {
+	var (
+		api  = meta.(*api.API)
+		data map[string]interface{}
+		err  = errors.New("")
+	)
+
+	// Set default values to arguments
+	d.Set("sleep", 60)
+	d.Set("timeout", 3600)
+
+	log.Printf("[DEBUG] cloudamqp::resource::vpc_aws_peering#import id: %v", d.Id())
+	importValues := strings.Split(d.Id(), ",")
+	if len(importValues) < 3 {
+		return errors.New("wrong number of import argument, need all three <type>,<id>,<peering_id>")
+	}
+	peeringID := importValues[2]
+	d.Set("peering_id", peeringID)
+	if importValues[0] == "instance" {
+		instanceID, _ := strconv.Atoi(importValues[1])
+		d.Set("instance_id", instanceID)
+		data, err = api.ReadVpcPeeringRequest(instanceID, peeringID)
+	} else if importValues[0] == "vpc" {
+		vpcID := importValues[1]
+		d.Set("vpc_id", vpcID)
+		data, err = api.ReadVpcPeeringRequestWithVpcId(vpcID, peeringID)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	for k, v := range data {
+		switch k {
+		case "vpc_peering_connection_id":
+			d.SetId(v.(string))
+		case "status":
 			status := v.(map[string]interface{})
 			if err = d.Set(k, status["code"]); err != nil {
 				return fmt.Errorf("error setting status for resource %s: %s", d.Id(), err)
@@ -119,15 +177,22 @@ func resourceVpcPeeringRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceVpcPeeringDelete(d *schema.ResourceData, meta interface{}) error {
-	api := meta.(*api.API)
-	if d.Get("instance_id") == 0 && d.Get("vpc_id") == nil {
+	var (
+		api        = meta.(*api.API)
+		instanceID = d.Get("instance_id").(int)
+		vpcID      = d.Get("vpc_id").(string)
+		peeringID  = d.Get("peering_id").(string)
+		sleep      = d.Get("sleep").(int)
+		timeout    = d.Get("timeout").(int)
+	)
+
+	if instanceID == 0 && vpcID == "" {
 		return errors.New("you need to specify either instance_id or vpc_id")
-	} else if d.Get("instance_id") != 0 {
-		return api.RemoveVpcPeering(d.Get("instance_id").(int), d.Get("peering_id").(string),
-			d.Get("sleep").(int), d.Get("timeout").(int))
-	} else if d.Get("vpc_id") != nil {
-		return api.RemoveVpcPeeringWithVpcId(d.Get("vpc_id").(string), d.Get("peering_id").(string),
-			d.Get("sleep").(int), d.Get("timeout").(int))
+	} else if instanceID != 0 {
+		return api.RemoveVpcPeering(instanceID, peeringID, sleep, timeout)
+	} else if vpcID != "" {
+		return api.RemoveVpcPeeringWithVpcId(vpcID, peeringID, sleep, timeout)
 	}
-	return errors.New("")
+
+	return nil
 }

--- a/cloudamqp/resource_cloudamqp_vpc_peering_test.go
+++ b/cloudamqp/resource_cloudamqp_vpc_peering_test.go
@@ -1,0 +1,78 @@
+package cloudamqp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cloudamqp/terraform-provider-cloudamqp/cloudamqp/vcr-testing/configuration"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// TestAccVpcPeering_Basic: Accept VPC peering and import.
+func TestAccVpcPeering_Basic(t *testing.T) {
+	var (
+		fileNames              = []string{"vpc_peering"}
+		vpcPeeringResourceName = "cloudamqp_vpc_peering.accepter"
+
+		params = map[string]string{
+			"VpcID":     "186",
+			"PeeringID": "pcx-03ebf8d9ceac304d7",
+		}
+	)
+
+	cloudamqpResourceTest(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		ProviderFactories:         testAccProviderFactory,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			// {
+			// 	ResourceName:            vpcResourceName,
+			// 	ImportStateId:           vpcID,
+			// 	ImportState:             true,
+			// 	ImportStateVerify:       true,
+			// 	ImportStateVerifyIgnore: []string{},
+			// },
+			// {
+			// 	ResourceName:            instanceResourceName,
+			// 	ImportStateId:           instanceID,
+			// 	ImportState:             true,
+			// 	ImportStateVerify:       true,
+			// 	ImportStateVerifyIgnore: []string{},
+			// },
+			// {
+			// 	Config: configuration.GetTemplatedConfig(t, fileNames, params),
+			// 	Check: resource.ComposeAggregateTestCheckFunc(
+			// 		resource.TestCheckResourceAttr(vpcResourceName, "name", params["VpcName"]),
+			// 		resource.TestCheckResourceAttr(vpcResourceName, "id", vpcID),
+			// 		resource.TestCheckResourceAttr(vpcResourceName, "subnet", params["VpcSubnet"]),
+			// 		resource.TestCheckResourceAttr(vpcResourceName, "region", params["VpcRegion"]),
+			// 		resource.TestCheckResourceAttr(instanceResourceName, "name", params["InstanceName"]),
+			// 		resource.TestCheckResourceAttr(instanceResourceName, "name", params["InstanceName"]),
+			// 		resource.TestCheckResourceAttr(instanceResourceName, "name", params["InstanceName"]),
+			// 	),
+			// },
+			// {
+			// 	ResourceName:            vpcPeeringResourceName,
+			// 	ImportStateIdFunc:       testAccImportVpcPeeringStateIdFunc("vpc", vpcResourceName, peeringID),
+			// 	ImportState:             true,
+			// 	ImportStateVerify:       true,
+			// 	ImportStateVerifyIgnore: []string{},
+			// },
+			{
+				Config: configuration.GetTemplatedConfig(t, fileNames, params),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(vpcPeeringResourceName, "vpc_id", params["VpcID"]),
+					resource.TestCheckResourceAttr(vpcPeeringResourceName, "peering_id", params["PeeringID"]),
+					resource.TestCheckResourceAttr(vpcPeeringResourceName, "status", "active"),
+				),
+			},
+			{
+				ResourceName:            vpcPeeringResourceName,
+				ImportStateId:           fmt.Sprintf("%s,%s,%s", "vpc", params["VpcID"], params["PeeringID"]),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}

--- a/cloudamqp/resource_cloudamqp_vpc_peering_test.go
+++ b/cloudamqp/resource_cloudamqp_vpc_peering_test.go
@@ -25,39 +25,6 @@ func TestAccVpcPeering_Basic(t *testing.T) {
 		ProviderFactories:         testAccProviderFactory,
 		PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
-			// {
-			// 	ResourceName:            vpcResourceName,
-			// 	ImportStateId:           vpcID,
-			// 	ImportState:             true,
-			// 	ImportStateVerify:       true,
-			// 	ImportStateVerifyIgnore: []string{},
-			// },
-			// {
-			// 	ResourceName:            instanceResourceName,
-			// 	ImportStateId:           instanceID,
-			// 	ImportState:             true,
-			// 	ImportStateVerify:       true,
-			// 	ImportStateVerifyIgnore: []string{},
-			// },
-			// {
-			// 	Config: configuration.GetTemplatedConfig(t, fileNames, params),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		resource.TestCheckResourceAttr(vpcResourceName, "name", params["VpcName"]),
-			// 		resource.TestCheckResourceAttr(vpcResourceName, "id", vpcID),
-			// 		resource.TestCheckResourceAttr(vpcResourceName, "subnet", params["VpcSubnet"]),
-			// 		resource.TestCheckResourceAttr(vpcResourceName, "region", params["VpcRegion"]),
-			// 		resource.TestCheckResourceAttr(instanceResourceName, "name", params["InstanceName"]),
-			// 		resource.TestCheckResourceAttr(instanceResourceName, "name", params["InstanceName"]),
-			// 		resource.TestCheckResourceAttr(instanceResourceName, "name", params["InstanceName"]),
-			// 	),
-			// },
-			// {
-			// 	ResourceName:            vpcPeeringResourceName,
-			// 	ImportStateIdFunc:       testAccImportVpcPeeringStateIdFunc("vpc", vpcResourceName, peeringID),
-			// 	ImportState:             true,
-			// 	ImportStateVerify:       true,
-			// 	ImportStateVerifyIgnore: []string{},
-			// },
 			{
 				Config: configuration.GetTemplatedConfig(t, fileNames, params),
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/docs/resources/vpc_peering.md
+++ b/docs/resources/vpc_peering.md
@@ -250,7 +250,37 @@ This resource depends on CloudAMQP managed VPC identifier, `cloudamqp_vpc.vpc.id
 
 ## Import
 
+*Before v1.33.0*
 Not possible to import this resource.
+
+*From v1.33.0*
+`cloudamqp_vpc_peering` can be imported while using the CloudAMQP managed VPC identifier or
+instance identifier, together with the *peering_id*.
+
+```hcl
+terraform import cloudamqp_vpc_peering.<resource_name> <resource-type>,<resource-identifier>,<peering_id>
+```
+
+### Resource type
+
+To use the CloudAMQP managed VPC identifier set the resource type to *vpc*.
+
+```hcl
+terraform import cloudamqp_vpc_peering.vpc_accept_peering vpc,<vpc_id>,<peering_id>
+```
+
+To use the Cloudamqp instance identifier set the resource type to *instance*.
+
+```hcl
+terraform import cloudamqp_vpc_peering.vpc_accept_peering instance,<instance_id>,<peering_id>
+```
+
+### Peering Identifier
+
+This can be found as *peering connection id* in your AWS VPC dashboard/Peering connections, for the correct VPC peering.
+
+Also available as the identifier for *aws_vpc_peering_connection* [resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection) or
+[data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_peering_connection).
 
 ## Create VPC Peering with additional firewall rules
 

--- a/test/configurations/vpc_peering.txt
+++ b/test/configurations/vpc_peering.txt
@@ -1,0 +1,4 @@
+resource "cloudamqp_vpc_peering" "accepter" {
+  vpc_id     = {{.VpcID}}
+  peering_id = "{{.PeeringID}}"
+}

--- a/test/fixtures/vcr/TestAccVpcPeering_Basic.yaml
+++ b/test/fixtures/vcr/TestAccVpcPeering_Basic.yaml
@@ -1,0 +1,305 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: localhost:9393
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - REDACTED
+            User-Agent:
+                - terraform-provider-cloudamqp_v1.0
+        url: http://localhost:9393/api/vpcs/186/vpc-peering/status/pcx-03ebf8d9ceac304d7
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 31
+        uncompressed: false
+        body: '{"status":"pending-acceptance"}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "31"
+            Content-Type:
+                - application/json
+            Nel:
+                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+            Report-To:
+                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
+            Set-Cookie:
+                - REDACTED
+            X-Content-Type-Options:
+                - nosniff
+            X-Request-Id:
+                - 56ccd00b-02b4-4963-be30-f7fc5a09dd7f
+        status: 200 OK
+        code: 200
+        duration: 1.69384039s
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: localhost:9393
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - REDACTED
+            User-Agent:
+                - terraform-provider-cloudamqp_v1.0
+        url: http://localhost:9393/api/vpcs/186/vpc-peering/request/pcx-03ebf8d9ceac304d7
+        method: PUT
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 80
+        uncompressed: false
+        body: '{"success":true,"ports":[5672,5671,15672,5552,5551],"subnets":["10.56.73.0/24"]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "80"
+            Content-Type:
+                - application/json
+            Nel:
+                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+            Report-To:
+                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
+            Set-Cookie:
+                - REDACTED
+            X-Content-Type-Options:
+                - nosniff
+            X-Request-Id:
+                - 78c2ac30-9cb0-464f-929e-ec60341f093b
+        status: 200 OK
+        code: 200
+        duration: 4.672059702s
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: localhost:9393
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - REDACTED
+            User-Agent:
+                - terraform-provider-cloudamqp_v1.0
+        url: http://localhost:9393/api/vpcs/186/vpc-peering/request/pcx-03ebf8d9ceac304d7
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 938
+        uncompressed: false
+        body: '{"accepter_vpc_info":{"cidr_block":"10.56.72.0/24","cidr_block_set":[{"cidr_block":"10.56.72.0/24"}],"owner_id":"100855782518","peering_options":{"allow_dns_resolution_from_remote_vpc":true,"allow_egress_from_local_classic_link_to_remote_vpc":false,"allow_egress_from_local_vpc_to_remote_classic_link":false},"vpc_id":"vpc-067c4977b5f0796db","region":"us-east-1"},"requester_vpc_info":{"cidr_block":"10.56.73.0/24","cidr_block_set":[{"cidr_block":"10.56.73.0/24"}],"owner_id":"100855782518","peering_options":{"allow_dns_resolution_from_remote_vpc":false,"allow_egress_from_local_classic_link_to_remote_vpc":false,"allow_egress_from_local_vpc_to_remote_classic_link":false},"vpc_id":"vpc-0d43c74850fed41a0","region":"us-east-1"},"status":{"code":"active","message":"Active"},"tags":[{"key":"Name","value":"Terrform Peering"}],"vpc_peering_connection_id":"pcx-03ebf8d9ceac304d7","routes":[{"destination":"10.56.73.0/24","state":"active"}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Nel:
+                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+            Report-To:
+                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
+            Set-Cookie:
+                - REDACTED
+            X-Content-Type-Options:
+                - nosniff
+            X-Request-Id:
+                - a8e1a1d7-1913-4beb-b8f3-6b1e2ca53989
+        status: 200 OK
+        code: 200
+        duration: 1.465121334s
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: localhost:9393
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - REDACTED
+            User-Agent:
+                - terraform-provider-cloudamqp_v1.0
+        url: http://localhost:9393/api/vpcs/186/vpc-peering/request/pcx-03ebf8d9ceac304d7
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 938
+        uncompressed: false
+        body: '{"accepter_vpc_info":{"cidr_block":"10.56.72.0/24","cidr_block_set":[{"cidr_block":"10.56.72.0/24"}],"owner_id":"100855782518","peering_options":{"allow_dns_resolution_from_remote_vpc":true,"allow_egress_from_local_classic_link_to_remote_vpc":false,"allow_egress_from_local_vpc_to_remote_classic_link":false},"vpc_id":"vpc-067c4977b5f0796db","region":"us-east-1"},"requester_vpc_info":{"cidr_block":"10.56.73.0/24","cidr_block_set":[{"cidr_block":"10.56.73.0/24"}],"owner_id":"100855782518","peering_options":{"allow_dns_resolution_from_remote_vpc":false,"allow_egress_from_local_classic_link_to_remote_vpc":false,"allow_egress_from_local_vpc_to_remote_classic_link":false},"vpc_id":"vpc-0d43c74850fed41a0","region":"us-east-1"},"status":{"code":"active","message":"Active"},"tags":[{"key":"Name","value":"Terrform Peering"}],"vpc_peering_connection_id":"pcx-03ebf8d9ceac304d7","routes":[{"destination":"10.56.73.0/24","state":"active"}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Nel:
+                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+            Report-To:
+                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
+            Set-Cookie:
+                - REDACTED
+            X-Content-Type-Options:
+                - nosniff
+            X-Request-Id:
+                - b57c9213-73cc-47db-bfa1-358da059164e
+        status: 200 OK
+        code: 200
+        duration: 893.618981ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: localhost:9393
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - REDACTED
+            User-Agent:
+                - terraform-provider-cloudamqp_v1.0
+        url: http://localhost:9393/api/vpcs/186/vpc-peering/request/pcx-03ebf8d9ceac304d7
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 938
+        uncompressed: false
+        body: '{"accepter_vpc_info":{"cidr_block":"10.56.72.0/24","cidr_block_set":[{"cidr_block":"10.56.72.0/24"}],"owner_id":"100855782518","peering_options":{"allow_dns_resolution_from_remote_vpc":true,"allow_egress_from_local_classic_link_to_remote_vpc":false,"allow_egress_from_local_vpc_to_remote_classic_link":false},"vpc_id":"vpc-067c4977b5f0796db","region":"us-east-1"},"requester_vpc_info":{"cidr_block":"10.56.73.0/24","cidr_block_set":[{"cidr_block":"10.56.73.0/24"}],"owner_id":"100855782518","peering_options":{"allow_dns_resolution_from_remote_vpc":false,"allow_egress_from_local_classic_link_to_remote_vpc":false,"allow_egress_from_local_vpc_to_remote_classic_link":false},"vpc_id":"vpc-0d43c74850fed41a0","region":"us-east-1"},"status":{"code":"active","message":"Active"},"tags":[{"key":"Name","value":"Terrform Peering"}],"vpc_peering_connection_id":"pcx-03ebf8d9ceac304d7","routes":[{"destination":"10.56.73.0/24","state":"active"}]}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "938"
+            Content-Type:
+                - application/json
+            Nel:
+                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+            Report-To:
+                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
+            Set-Cookie:
+                - REDACTED
+            X-Content-Type-Options:
+                - nosniff
+            X-Request-Id:
+                - 460e42de-7657-4753-a439-018f3d536a4f
+        status: 200 OK
+        code: 200
+        duration: 866.872421ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: localhost:9393
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - REDACTED
+            User-Agent:
+                - terraform-provider-cloudamqp_v1.0
+        url: http://localhost:9393/api/vpcs/186/vpc-peering/pcx-03ebf8d9ceac304d7
+        method: DELETE
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Cache-Control:
+                - no-cache
+            Nel:
+                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+            Report-To:
+                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
+            Set-Cookie:
+                - REDACTED
+            X-Content-Type-Options:
+                - nosniff
+            X-Request-Id:
+                - d8622b2d-48ad-4103-8099-05363956686e
+        status: 204 No Content
+        code: 204
+        duration: 1.997313282s


### PR DESCRIPTION
### WHY are these changes introduced?

The resource `cloudamqp_vpc_peering` lacks import functionality. This got requested way back in: https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/158.
We found a way to enable this for GCP https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/308, take a similar approach for AWS. 

### WHAT is this pull request doing?

- Adds import functionality to the `cloudamqp_vpc_peering` resource
- Updates documentation
- Adds Go VCR test for accept and import

### HOW can this pull request be tested?

Run VCR test for accepting the peering and importing the resource.
Limited from the complete flow to not mix in the AWS provider in the test.