### PR TITLE
LavinMQ supports MQTT and MQTTS

### DIFF
--- a/docs/resources/security_firewall.md
+++ b/docs/resources/security_firewall.md
@@ -122,6 +122,8 @@ Pre-defined services for LavinMQ:
 | AMQP         | 5672  |
 | AMQPS        | 5671  |
 | HTTPS        | 443   |
+| MQTT         | 1883  |
+| MQTTS        | 8883  |
 
 ## Attributes Reference
 


### PR DESCRIPTION
This is the case since [Feb 24, 2025](https://github.com/84codes/account-console/pull/720).