### PR TITLE
Update firewall destroy behavior

### DIFF
--- a/api/security_firewall.go
+++ b/api/security_firewall.go
@@ -194,12 +194,10 @@ func (api *API) deleteFirewallSettingsWithRetry(ctx context.Context, path string
 	timeout int) (int, error) {
 
 	var (
-		params [1]map[string]any
+		params = []map[string]any{}
 		failed map[string]any
 	)
 
-	// Use default firewall rule and update firewall upon delete.
-	params[0] = DefaultFirewallSettings()
 	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
 	if err != nil {
 		return attempt, err
@@ -228,15 +226,4 @@ func (api *API) deleteFirewallSettingsWithRetry(ctx context.Context, path string
 	}
 	return attempt, fmt.Errorf("failed to reset firewall, status=%d message=%s ",
 		response.StatusCode, failed)
-}
-
-func DefaultFirewallSettings() map[string]any {
-	defaultRule := map[string]any{
-		"services": []string{"AMQP", "AMQPS", "STOMP", "STOMPS", "MQTT", "MQTTS", "HTTPS", "STREAM",
-			"STREAM_SSL"},
-		"ports":       []int{},
-		"ip":          "0.0.0.0/0",
-		"description": "Default",
-	}
-	return defaultRule
 }

--- a/docs/resources/security_firewall.md
+++ b/docs/resources/security_firewall.md
@@ -12,9 +12,8 @@ This resource allows you to configure and manage firewall rules for the CloudAMQ
 ~> **WARNING:** Firewall rules applied with this resource will replace any existing firewall rules.
 Make sure all wanted rules are present to not lose them.
 
--> **NOTE:** From [v1.33.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.33.0)
-when destroying this resource the firewall on the servers will also be removed. I.e. the firewall
-will be completely closed.
+-> **NOTE:** From [v1.33.0] when destroying this resource the firewall on the servers will also be
+removed. I.e. the firewall will be completely closed.
 
 Only available for dedicated subscription plans.
 
@@ -166,9 +165,8 @@ Or use Terraform CLI:
 
 ## Destroy the resource
 
-From [v1.33.0](https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.33.0)
-when destroying this resource the firewall on the servers will be removed. I.e. the firewall will be
-completly closed.
+From [v1.33.0] when destroying this resource the firewall on the servers will be removed. I.e. the
+firewall will be completly closed.
 
 Older version will instead update the firewall with a default rule.
 
@@ -245,4 +243,5 @@ The provider from [v1.15.2] will start to warn about using this.
 [v1.15.1]: https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.15.1
 [v1.15.2]: https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.15.2
 [v1.27.0]: https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.27.0
+[v1.33.0]: https://github.com/cloudamqp/terraform-provider-cloudamqp/releases/tag/v1.33.0
 [VPC GPC peering]: ./vpc_gcp_peering#create-vpc-peering-with-additional-firewall-rules


### PR DESCRIPTION
### WHY are these changes introduced?

Previously when destroying the firewall resource, the servers was updated with a
default rule keeping the firewall open.

```hcl
rules {
  ip          = "0.0.0.0/0"
  ports       = []
  services    = ["AMQP", "AMQPS", "STOMP", "STOMPS", "MQTT", "MQTTS",
    "HTTPS", "STREAM", "STREAM_SSL"]
  description = "Default"
}
```

This causes issues for LavinMQ that only support a subset of the pre-defined services.

Reference: https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/328

### WHAT is this pull request doing?

- Updates the servers firewall with no rules, firewall gets closed, when destroying this resource.
- Updates documentation

### HOW can this pull request be tested?

Manual testing that no rules are applied on the servers when the resource is destroyed.
