### PR TITLE
Documentation: Update extra disk information for Azure

### DIFF
--- a/docs/resources/extra_disk_size.md
+++ b/docs/resources/extra_disk_size.md
@@ -13,20 +13,24 @@ This resource allows you to resize the disk with additional storage capacity.
 
 ***From v1.25.0***: Google Compute Engine (GCE) and Azure available.
 
-Introducing a new optional argument called `allow_downtime`.  Leaving it out or set it to false will proceed to try and resize the disk without downtime, available for *AWS* and *GCE*.
-While *Azure* only support swapping the disk, and this argument needs to be set to *true*.
+Introducing a new optional argument called `allow_downtime`. Leaving it out or set it to false will
+proceed to try and resize the disk without downtime, available for *AWS*, *GCE* and *Azure*.
 
 `allow_downtime` also makes it possible to circumvent the time rate limit or shrinking the disk.
 
-| Cloud Platform        | allow_downtime=false | allow_downtime=true           |
-|-----------------------|----------------------|-------------------------------|
-| amazon-web-services   | Expand current disk* | Try to expand, otherwise swap |
-| google-compute-engine | Expand current disk* | Try to expand, otherwise swap |
-| azure-arm             | Not supported        | Swap disk to new size         |
+| Cloud Platform        | allow_downtime=false | allow_downtime=true           | Possible to resize |
+|-----------------------|----------------------|-------------------------------|--------------------|
+| amazon-web-services   | Expand current disk* | Try to expand, otherwise swap | Every 6 hour       |
+| google-compute-engine | Expand current disk* | Try to expand, otherwise swap | Every 4 hour       |
+| azure-arm             | Expand current disk* | Expand current disk           | No time rate limit |
 
 *Preferable method to use.
 
-~> **WARNING:** Due to restrictions from cloud providers, it's only possible to resize the disk every 8 hours. Unless the `allow_downtime=true` is set, then the disk will be swapped for a new.
+-> **Note:** Due to restrictions from cloud providers, it's only possible to resize the disk after
+the rate time limit. See `Possible to resize` column above for the different cloud platforms.
+
+-> **Note:** Shrinking the disk will always need to swap the old disk to a new one and require
+`allow_downtime` set to *true*.
 
 Pricing is available at [cloudamqp.com](https://www.cloudamqp.com/) and only available for dedicated subscription plans.
 
@@ -149,7 +153,7 @@ data "cloudamqp_nodes" "nodes" {
 <details>
   <summary>
     <b>
-      <i>Azure extra disk size with downtime</i>
+      <i>Azure extra disk size without downtime</i>
     </b>
   </summary>
 
@@ -170,7 +174,6 @@ resource "cloudamqp_instance" "instance" {
 resource "cloudamqp_extra_disk_size" "resize_disk" {
   instance_id = cloudamqp_instance.instance.id
   extra_disk_size = 25
-  allow_downtime = true
 }
 
 # Optional, refresh nodes info after disk resize by adding dependency
@@ -189,11 +192,15 @@ data "cloudamqp_nodes" "nodes" {
 
 Any changes to the arguments will destroy and recreate this resource.
 
-* `instance_id`       - (ForceNew/Required) The CloudAMQP instance ID.
-* `extra_disk_size`   - (ForceNew/Required) Extra disk size in GB. Supported values: 0, 25, 50, 100, 250, 500, 1000, 2000
-* `allow_downtime`    - (Optional) When resizing the disk, allow cluster downtime if necessary. Default set to false. Required when hosting in *Azure*.
-* `sleep`       - (Optional) Configurable sleep time in seconds between retries for resizing the disk. Default set to 30 seconds.
-* `timeout`     - (Optional) Configurable timeout time in seconds for resizing the disk. Default set to 1800 seconds.
+* `instance_id`     - (ForceNew/Required) The CloudAMQP instance ID.
+* `extra_disk_size` - (ForceNew/Required) Extra disk size in GB. Supported values: 0, 25, 50, 100,
+                        250, 500, 1000, 2000
+* `allow_downtime`  - (Optional) When resizing the disk, allow cluster downtime if necessary.
+                      Default set to false. Required when hosting in *Azure*.
+* `sleep`           - (Optional) Configurable sleep time in seconds between retries for resizing the
+                      disk. Default set to 30 seconds.
+* `timeout`         - (Optional) Configurable timeout time in seconds for resizing the disk. Default
+                      set to 1800 seconds.
 
 ***Note:*** `allow_downtime`, `sleep`, `timeout` only available from v1.25.0.
 

--- a/docs/resources/extra_disk_size.md
+++ b/docs/resources/extra_disk_size.md
@@ -196,7 +196,7 @@ Any changes to the arguments will destroy and recreate this resource.
 * `extra_disk_size` - (ForceNew/Required) Extra disk size in GB. Supported values: 0, 25, 50, 100,
                         250, 500, 1000, 2000
 * `allow_downtime`  - (Optional) When resizing the disk, allow cluster downtime if necessary.
-                      Default set to false. Required when hosting in *Azure*.
+                      Default set to false.
 * `sleep`           - (Optional) Configurable sleep time in seconds between retries for resizing the
                       disk. Default set to 30 seconds.
 * `timeout`         - (Optional) Configurable timeout time in seconds for resizing the disk. Default


### PR DESCRIPTION
### WHY are these changes introduced?

We use new underlying disks in Azure that allow resize while expanding disk. No longer
the  need to use `allow_downtime` when adding extra disk

### WHAT is this pull request doing?

- Updates documentation for `cloudamqp_extra_disk` resource

### HOW can this pull request be tested?

Use extra disk resource together with `cloudamqp_instance.instance` while hosting it in
Azure to get the results.

For documentation, see [extra_disk_size.md](https://github.com/cloudamqp/terraform-provider-cloudamqp/blob/docs/resize-disk-update/docs/resources/extra_disk_size.md). 
Note: GitHub don't render info boxes (blue, yellow, red) correctly.

md-file can also be copied into [registry.terraform.io docs preview](https://registry.terraform.io/tools/doc-preview).
Note: preview don't rendered tables correctly.
