### PR TITLE
Add cloudamqp_alarms datasource

### DIFF
--- a/cloudamqp/data_source_cloudamqp_alarms.go
+++ b/cloudamqp/data_source_cloudamqp_alarms.go
@@ -1,0 +1,149 @@
+package cloudamqp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAlarms() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAlarmsRead,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "Instance identifier",
+			},
+			"type": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Type of the alarm",
+				ValidateDiagFunc: validateAlarmType(),
+			},
+			"alarms": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of alarms",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"alarm_id": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Alarm identifier",
+						},
+						"type": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Description:      "Type of the alarm",
+							ValidateDiagFunc: validateAlarmType(),
+						},
+						"enabled": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Enable or disable an alarm",
+						},
+						"reminder_interval": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The reminder interval (in seconds) to resend the alarm if not resolved. Set to 0 for no reminders",
+						},
+						"value_threshold": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "What value to trigger the alarm for",
+						},
+						"value_calculation": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Disk value threshold calculation. Fixed or percentage of disk space remaining",
+						},
+						"time_threshold": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "For how long (in seconds) the value_threshold should be active before trigger alarm",
+						},
+						"vhost_regex": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Regex for which vhost the queues are in",
+						},
+						"queue_regex": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Regex for which queues to check",
+						},
+						"message_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Message types (total, unacked, ready) of the queue to trigger the alarm",
+						},
+						"recipients": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeInt,
+							},
+							Description: "Identifiers for recipients to be notified.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlarmsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var (
+		data       []map[string]any
+		instanceID = d.Get("instance_id").(int)
+		err        error
+	)
+
+	api := meta.(*api.API)
+	data, err = api.ListAlarms(ctx, instanceID)
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.Get("type") != "" {
+		d.SetId(fmt.Sprintf("%v.%v.alarms", instanceID, d.Get("type")))
+		filteredAlarms := make([]map[string]any, 0)
+		for _, alarm := range data {
+			if alarm["type"] == d.Get("type") {
+				filteredAlarms = append(filteredAlarms, alarm)
+			}
+		}
+		data = filteredAlarms
+	} else {
+		d.SetId(fmt.Sprintf("%v.alarms", instanceID))
+	}
+
+	alarms := make([]map[string]any, len(data))
+	for k, v := range data {
+		alarms[k] = readAlarm(v)
+	}
+
+	if err = d.Set("alarms", alarms); err != nil {
+		return diag.Errorf("error setting alarms for resource %s: %s", d.Id(), err)
+	}
+
+	return diag.Diagnostics{}
+}
+
+func readAlarm(data map[string]any) map[string]any {
+	alarm := make(map[string]any)
+	for k, v := range data {
+		if validateAlarmSchemaAttribute(k) {
+			alarm[k] = v
+		}
+	}
+	return alarm
+}

--- a/cloudamqp/data_source_cloudamqp_alarms.go
+++ b/cloudamqp/data_source_cloudamqp_alarms.go
@@ -141,7 +141,9 @@ func dataSourceAlarmsRead(ctx context.Context, d *schema.ResourceData, meta any)
 func readAlarm(data map[string]any) map[string]any {
 	alarm := make(map[string]any)
 	for k, v := range data {
-		if validateAlarmSchemaAttribute(k) {
+		if k == "id" {
+			alarm["alarm_id"] = int(v.(float64))
+		} else if validateAlarmSchemaAttribute(k) {
 			alarm[k] = v
 		}
 	}

--- a/cloudamqp/provider.go
+++ b/cloudamqp/provider.go
@@ -40,6 +40,7 @@ func Provider(v string, client *http.Client) *schema.Provider {
 			"cloudamqp_account_vpcs":        dataSourceAccountVpcs(),
 			"cloudamqp_account":             dataSourceAccount(),
 			"cloudamqp_alarm":               dataSourceAlarm(),
+			"cloudamqp_alarms":              dataSourceAlarms(),
 			"cloudamqp_credentials":         dataSourceCredentials(),
 			"cloudamqp_instance":            dataSourceInstance(),
 			"cloudamqp_nodes":               dataSourceNodes(),

--- a/docs/data-sources/alarms.md
+++ b/docs/data-sources/alarms.md
@@ -1,0 +1,61 @@
+---
+layout: "cloudamqp"
+page_title: "CloudAMQP: data source cloudamqp_alarms"
+description: |-
+  Get a list of pre-defined or created alarms.
+---
+
+# cloudamqp_alarms
+
+Use this data source to retrieve a list of default or created alarms.
+
+## Example Usage
+
+```hcl
+data "cloudamqp_alarms" "queue_alarms" {
+  instance_id = cloudamqp_instance.instance.id
+  type        = "queue"
+}
+```
+
+## Argument Reference
+
+* `instance_id` - (Required) The CloudAMQP instance identifier.
+* `type`        - (Optional) The alarm type to filter for. Supported
+                  [alarm types](#alarm-types).
+
+## Attributes Reference
+
+All attributes reference are computed
+
+*`alarms`               - List of alarms (see [below for nested schema](#nestedatt--alarms))
+
+<a id="nestedatt--alarms"></a>
+
+### Nested Schema for `alarms`
+
+* `alarm_id`            - The alarm identifier.
+* `type`                - The type of the alarm.
+* `enabled`             - Enable/disable status of the alarm.
+* `value_threshold`     - The value threshold that triggers the alarm.
+* `reminder_interval`   - The reminder interval (in seconds) to resend the alarm if not resolved.
+                          Set to 0 for no reminders.
+* `time_threshold`      - The time interval (in seconds) the `value_threshold` should be active
+                          before trigger an alarm.
+* `queue_regex`         - Regular expression for which queue to check.
+* `vhost_regex`         - Regular expression for which vhost to check
+* `recipients`          - Identifier for recipient to be notified.
+* `message_type`        - Message type `(total, unacked, ready)` used by queue alarm type.
+
+Specific attribute for `disk` alarm
+
+* `value_calculation`   - Disk value threshold calculation, `(fixed, percentage)` of disk space
+                          remaining.
+
+## Dependency
+
+This data source depends on CloudAMQP instance identifier, `cloudamqp_instance.instance.id`.
+
+## Alarm Types
+
+`cpu, memory, disk, queue, connection, flow, consumer, netsplit, server_unreachable, notice`


### PR DESCRIPTION
Hello!

Adding a new datasource (`cloudamqp_alarms`) to fetch all (or filtered down for a specifc type) alarms for an cloudamqp_alarm` datasource.

```terraform
data "cloudamqp_alarms" "queue_alarms" {
  instance_id = cloudamqp_instance.instance.id
  type        = "queue"
}

output "queue_alarms" {
  value = data.cloudamqp_alarms.queue_alarms.alarms
}
```

Thanks, happy to address any feedback!