### PR TITLE
add cloudamqp_notifications data source

### DIFF
--- a/cloudamqp/data_source_cloudamqp_notifications.go
+++ b/cloudamqp/data_source_cloudamqp_notifications.go
@@ -1,0 +1,102 @@
+package cloudamqp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceNotifications() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNotificationsRead,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "Instance identifier",
+			},
+			"recipients": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of notification recipients",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"recipient_id": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Recipient identifier",
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Type of the notification",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Notification endpoint, where to send the notifcation",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Display name of the recipient",
+						},
+						"options": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Description: "Key-value pair options parameters",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceNotificationsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var (
+		instanceID = d.Get("instance_id").(int)
+		data       []map[string]any
+		err        error
+	)
+
+	api := meta.(*api.API)
+	data, err = api.ListNotifications(ctx, instanceID)
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(fmt.Sprintf("%v.notifications", instanceID))
+
+	recipients := make([]map[string]any, len(data))
+	for k, v := range data {
+		recipients[k] = readNotification(v)
+	}
+
+	if err = d.Set("recipients", recipients); err != nil {
+		return diag.Errorf("error setting recipients for resource %s: %s", d.Id(), err)
+	}
+	return diag.Diagnostics{}
+}
+
+func readNotification(data map[string]any) map[string]any {
+	notification := make(map[string]any)
+	for k, v := range data {
+		if k == "id" {
+			notification["recipient_id"] = int(v.(float64))
+		} else if validateRecipientAttribute(k) {
+			notification[k] = v
+		}
+	}
+	return notification
+}

--- a/cloudamqp/provider.go
+++ b/cloudamqp/provider.go
@@ -45,6 +45,7 @@ func Provider(v string, client *http.Client) *schema.Provider {
 			"cloudamqp_instance":            dataSourceInstance(),
 			"cloudamqp_nodes":               dataSourceNodes(),
 			"cloudamqp_notification":        dataSourceNotification(),
+			"cloudamqp_notifications":       dataSourceNotifications(),
 			"cloudamqp_plugins_community":   dataSourcePluginsCommunity(),
 			"cloudamqp_plugins":             dataSourcePlugins(),
 			"cloudamqp_upgradable_versions": dataSourceUpgradableVersions(),


### PR DESCRIPTION
Hi!

Adding another datasource (cloudamqp_notifications) to fetch all notification recipients assigned to an instance

```terraform
data "cloudamqp_notifications" "notifications" {
  instance_id = cloudamqp_instance.instance.id
}

output "recipients" {
  value = data.cloudamqp_notifications.notifications.recipients
}
```

cheers!