### PR TITLE
Fix `provider` schema mismatch 

### DIFF
--- a/cloudamqp/provider.go
+++ b/cloudamqp/provider.go
@@ -118,7 +118,8 @@ func Provider(v string, client *http.Client) *schemaSdk.Provider {
 		Schema: map[string]*schemaSdk.Schema{
 			"apikey": {
 				Type:        schemaSdk.TypeString,
-				Required:    true,
+				Required:    false,
+				Optional:    true,
 				DefaultFunc: schemaSdk.EnvDefaultFunc("CLOUDAMQP_APIKEY", nil),
 				Description: "Key used to authentication to the CloudAMQP Customer API",
 			},


### PR DESCRIPTION
https://github.com/cloudamqp/terraform-provider-cloudamqp/commit/000dc57ff5645406e5bf8e48f51ba3e090dc4665 made `apikey` optional:

https://github.com/cloudamqp/terraform-provider-cloudamqp/blob/51afb2cfdd387b04f75206273ba187bff6b566ec/cloudamqp/provider.go#L42-L44

but did not update this part

https://github.com/cloudamqp/terraform-provider-cloudamqp/blob/51afb2cfdd387b04f75206273ba187bff6b566ec/cloudamqp/provider.go#L42-L44

Close https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/347