### PR TITLE
Update instance.md

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -396,3 +396,4 @@ resource "cloudamqp_instance" "bunny_instance" {
 [Managed VPC]: ../guides/info_managed_vpc#dedicated-instance-and-vpc_subnet
 [plans]: ../guides/info_plan.md
 [**RabbitMQ**]: https://www.rabbitmq.com
+[instance regions]: ../guides/info_region.md


### PR DESCRIPTION
There's a missing link in the [cloudamqp_instance](https://registry.terraform.io/providers/cloudamqp/cloudamqp/latest/docs/resources/instance) doc page.