### PR TITLE
handle deleted integration read

### DIFF
--- a/api/integration.go
+++ b/api/integration.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -78,11 +77,9 @@ func (api *API) ReadIntegration(ctx context.Context, instanceID int, intType, in
 			}
 		}
 		return convertedData, err
-	case 400:
-		if strings.Compare(failed["error"].(string), "Integration does not exist") == 0 {
-			return nil, nil
-		}
-		fallthrough
+	case 404:
+		tflog.Warn(ctx, "integration not found")
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("failed to read integration, status=%d message=%s ",
 			response.StatusCode, failed)

--- a/api/integration.go
+++ b/api/integration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -77,6 +78,11 @@ func (api *API) ReadIntegration(ctx context.Context, instanceID int, intType, in
 			}
 		}
 		return convertedData, err
+	case 400:
+		if strings.Compare(failed["error"].(string), "Integration does not exist") == 0 {
+			return nil, nil
+		}
+		fallthrough
 	default:
 		return nil, fmt.Errorf("failed to read integration, status=%d message=%s ",
 			response.StatusCode, failed)

--- a/cloudamqp/resource_cloudamqp_integration_log.go
+++ b/cloudamqp/resource_cloudamqp_integration_log.go
@@ -236,6 +236,7 @@ func resourceIntegrationLogRead(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
+	// Handle resource drift and trigger re-creation if resource been deleted outside the provider
 	if data == nil {
 		d.SetId("")
 		return nil

--- a/cloudamqp/resource_cloudamqp_integration_log.go
+++ b/cloudamqp/resource_cloudamqp_integration_log.go
@@ -236,6 +236,11 @@ func resourceIntegrationLogRead(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
+	if data == nil {
+		d.SetId("")
+		return nil
+	}
+
 	for k, v := range data {
 		if k == "type" {
 			d.Set("name", v)

--- a/cloudamqp/resource_cloudamqp_integration_metric.go
+++ b/cloudamqp/resource_cloudamqp_integration_metric.go
@@ -234,6 +234,7 @@ func resourceIntegrationMetricRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
+	// Handle resource drift and trigger re-creation if resource been deleted outside the provider
 	if data == nil {
 		d.SetId("")
 		return nil

--- a/cloudamqp/resource_cloudamqp_integration_metric.go
+++ b/cloudamqp/resource_cloudamqp_integration_metric.go
@@ -234,6 +234,11 @@ func resourceIntegrationMetricRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
+	if data == nil {
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("include_ad_queues", false)
 
 	for k, v := range data {


### PR DESCRIPTION
currently, if a tracked integration is deleted, upon refresh we will get something like

```
╷
│ Error: failed to read integration, status=400 message=map[error:Integration does not exist] 
│ 
│   with cloudamqp_integration_log.datadog[0],
│   on datadog.tf line 1, in resource "cloudamqp_integration_log" "datadog":
│    1: resource "cloudamqp_integration_log" "datadog" {
│ 
╵
╷
│ Error: failed to read integration, status=400 message=map[error:Integration does not exist] 
│ 
│   with cloudamqp_integration_metric.datadog_v2[0],
│   on datadog.tf line 11, in resource "cloudamqp_integration_metric" "datadog_v2":
│   11: resource "cloudamqp_integration_metric" "datadog_v2" {
```

With this fix, it will propose to recreate the missing resource, as expected.