### PR TITLE
Fix: Handle deleted resource drift

### DIFF
--- a/api/alarms.go
+++ b/api/alarms.go
@@ -59,7 +59,7 @@ func (api *API) ReadAlarm(ctx context.Context, instanceID int, alarmID string) (
 		tflog.Debug(ctx, "response data", data)
 		return data, err
 	case 404:
-		tflog.Debug(ctx, "alarm not found")
+		tflog.Warn(ctx, "alarm not found")
 		return nil, nil
 	default:
 		return nil,

--- a/api/alarms.go
+++ b/api/alarms.go
@@ -58,6 +58,9 @@ func (api *API) ReadAlarm(ctx context.Context, instanceID int, alarmID string) (
 	case 200:
 		tflog.Debug(ctx, "response data", data)
 		return data, err
+	case 404:
+		tflog.Debug(ctx, "alarm not found")
+		return nil, nil
 	default:
 		return nil,
 			fmt.Errorf("failed to read alarm, status=%d message=%s ", response.StatusCode, failed)

--- a/api/aws_eventbridge.go
+++ b/api/aws_eventbridge.go
@@ -57,6 +57,9 @@ func (api *API) ReadAwsEventBridge(ctx context.Context, instanceID int, eventbri
 	case 200:
 		tflog.Debug(ctx, "response data", data)
 		return data, nil
+	case 404:
+		tflog.Warn(ctx, "AWS EventBridge not found")
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("failed to read AWS EventBridge, status=%d message=%s ",
 			response.StatusCode, failed)

--- a/api/instance.go
+++ b/api/instance.go
@@ -167,6 +167,9 @@ func (api *API) ReadInstance(ctx context.Context, instanceID string) (map[string
 	case 200:
 		tflog.Debug(sensitiveCtx, "response data", data)
 		return data, nil
+	case 404:
+		tflog.Warn(ctx, "instance not found")
+		return nil, nil
 	case 410:
 		tflog.Warn(ctx, "instance has been deleted")
 		return nil, nil

--- a/api/notifications.go
+++ b/api/notifications.go
@@ -58,7 +58,7 @@ func (api *API) ReadNotification(ctx context.Context, instanceID int, recipientI
 		tflog.Debug(ctx, "response data", data)
 		return data, nil
 	case 404:
-		tflog.Debug(ctx, "notification not found")
+		tflog.Warn(ctx, "notification not found")
 		return nil, nil
 	default:
 		return nil, fmt.Errorf("failed to read notification, status=%d message=%s ",

--- a/api/notifications.go
+++ b/api/notifications.go
@@ -57,6 +57,9 @@ func (api *API) ReadNotification(ctx context.Context, instanceID int, recipientI
 	case 200:
 		tflog.Debug(ctx, "response data", data)
 		return data, nil
+	case 404:
+		tflog.Debug(ctx, "notification not found")
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("failed to read notification, status=%d message=%s ",
 			response.StatusCode, failed)

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -98,7 +98,7 @@ func (api *API) readWebhookWithRetry(ctx context.Context, path string, attempt, 
 			return api.readWebhookWithRetry(ctx, path, attempt, sleep, timeout)
 		}
 	case 404:
-		tflog.Debug(ctx, "webhook not found")
+		tflog.Warn(ctx, "webhook not found")
 		return nil, nil
 	}
 

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -97,6 +97,9 @@ func (api *API) readWebhookWithRetry(ctx context.Context, path string, attempt, 
 			time.Sleep(time.Duration(sleep) * time.Second)
 			return api.readWebhookWithRetry(ctx, path, attempt, sleep, timeout)
 		}
+	case 404:
+		tflog.Debug(ctx, "webhook not found")
+		return nil, nil
 	}
 
 	return nil, fmt.Errorf("failed to read webhook information, status=%d message=%s ",

--- a/cloudamqp/resource_cloudamqp_alarm.go
+++ b/cloudamqp/resource_cloudamqp_alarm.go
@@ -149,7 +149,7 @@ func resourceAlarmRead(ctx context.Context, d *schema.ResourceData, meta any) di
 		return diag.FromErr(err)
 	}
 
-	// Handle resource drift, if resource is deleted
+	// Handle resource drift and trigger re-creation if resource been deleted outside the provider
 	if data == nil {
 		d.SetId("")
 		return nil

--- a/cloudamqp/resource_cloudamqp_alarm.go
+++ b/cloudamqp/resource_cloudamqp_alarm.go
@@ -149,6 +149,12 @@ func resourceAlarmRead(ctx context.Context, d *schema.ResourceData, meta any) di
 		return diag.FromErr(err)
 	}
 
+	// Handle resource drift, if resource is deleted
+	if data == nil {
+		d.SetId("")
+		return nil
+	}
+
 	for k, v := range data {
 		if validateAlarmSchemaAttribute(k) {
 			if err = d.Set(k, v); err != nil {

--- a/cloudamqp/resource_cloudamqp_aws_eventbridge.go
+++ b/cloudamqp/resource_cloudamqp_aws_eventbridge.go
@@ -215,6 +215,12 @@ func (r *awsEventBridgeResource) Read(ctx context.Context, request resource.Read
 		return
 	}
 
+	// Handle deleted resource drift, trigger re-creation
+	if data == nil {
+		response.State.RemoveResource(ctx)
+		return
+	}
+
 	state.AwsAccountId = types.StringValue(data["aws_account_id"].(string))
 	state.AwsRegion = types.StringValue(data["aws_region"].(string))
 	state.Vhost = types.StringValue(data["vhost"].(string))

--- a/cloudamqp/resource_cloudamqp_aws_eventbridge.go
+++ b/cloudamqp/resource_cloudamqp_aws_eventbridge.go
@@ -215,7 +215,7 @@ func (r *awsEventBridgeResource) Read(ctx context.Context, request resource.Read
 		return
 	}
 
-	// Handle deleted resource drift, trigger re-creation
+	// Handle resource drift and trigger re-creation if resource been deleted outside the provider
 	if data == nil {
 		response.State.RemoveResource(ctx)
 		return

--- a/cloudamqp/resource_cloudamqp_instance.go
+++ b/cloudamqp/resource_cloudamqp_instance.go
@@ -221,11 +221,11 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	api := meta.(*api.API)
 	data, err := api.ReadInstance(ctx, d.Id())
-
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
+	// Handle resource drift and trigger re-creation if resource been deleted outside the provider
 	if data == nil {
 		d.SetId("")
 		return nil

--- a/cloudamqp/resource_cloudamqp_instance.go
+++ b/cloudamqp/resource_cloudamqp_instance.go
@@ -226,6 +226,11 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.FromErr(err)
 	}
 
+	if data == nil {
+		d.SetId("")
+		return nil
+	}
+
 	for k, v := range data {
 		if validateInstanceSchemaAttribute(k) {
 			if k == "vpc" {

--- a/cloudamqp/resource_cloudamqp_notification.go
+++ b/cloudamqp/resource_cloudamqp_notification.go
@@ -141,7 +141,7 @@ func resourceNotificationRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
-	// Handle resource drift, if resource is deleted
+	// Handle resource drift and trigger re-creation if resource been deleted outside the provider
 	if data == nil {
 		d.SetId("")
 		return nil

--- a/cloudamqp/resource_cloudamqp_notification.go
+++ b/cloudamqp/resource_cloudamqp_notification.go
@@ -141,6 +141,12 @@ func resourceNotificationRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
+	// Handle resource drift, if resource is deleted
+	if data == nil {
+		d.SetId("")
+		return nil
+	}
+
 	for k, v := range data {
 		if !validateRecipientAttribute(k) {
 			continue

--- a/cloudamqp/resource_cloudamqp_webhooks.go
+++ b/cloudamqp/resource_cloudamqp_webhooks.go
@@ -116,6 +116,7 @@ func resourceWebhookRead(ctx context.Context, d *schema.ResourceData, meta any) 
 		return diag.FromErr(err)
 	}
 
+	// Handle resource drift and trigger re-creation if resource been deleted outside the provider
 	if data == nil {
 		d.SetId("")
 		return nil

--- a/cloudamqp/resource_cloudamqp_webhooks.go
+++ b/cloudamqp/resource_cloudamqp_webhooks.go
@@ -116,6 +116,11 @@ func resourceWebhookRead(ctx context.Context, d *schema.ResourceData, meta any) 
 		return diag.FromErr(err)
 	}
 
+	if data == nil {
+		d.SetId("")
+		return nil
+	}
+
 	for k, v := range data {
 		if validateWebhookSchemaAttribute(k) {
 			err = d.Set(k, v)


### PR DESCRIPTION
### WHY are these changes introduced?

Notified about faulty resource drift if underlying resource been deleted.
https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/359

Current behavior will make the provider stop with error message. Instead
of trigger re-creation of the resource.

Reference from Terraform tutorials:
https://developer.hashicorp.com/terraform/tutorials/state/resource-drift#introduce-drift

Issue: https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/360

### WHAT is this pull request doing?

- NOP in client library when response contains HTTP status code 404 for given resource.
- Reset the resource identifier during read phase to trigger re-creation of the resource.

### HOW was this pull request be tested?

Created each resource and removed them from UI. Re-run to trigger re-creation.