### PR TITLE
Migrate cloudamqp_vpc towards Terraform plugin framework

### DIFF
--- a/api/account.go
+++ b/api/account.go
@@ -43,7 +43,14 @@ func (api *API) ListVpcs(ctx context.Context) ([]model.VpcResponse, error) {
 	)
 
 	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s ", path))
-	err := CallWithRetry(ctx, api.sling.New().Get(path), "VPC", 1, 10*time.Second, &data, &failed)
+	err := api.callWithRetry(ctx, api.sling.New().Get(path), retryRequest{
+		functionName: "ListVpcs",
+		resourceName: "VPC",
+		attempt:      1,
+		sleep:        10 * time.Second,
+		data:         &data,
+		failed:       &failed,
+	})
 	if err != nil {
 		return []model.VpcResponse{}, fmt.Errorf("failed to read VPC: %w", err)
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -30,12 +30,13 @@ func New(baseUrl, apiKey string, useragent string, client *http.Client) *API {
 }
 
 type retryRequest struct {
-	functionName string
-	resourceName string
-	attempt      int
-	sleep        time.Duration
-	data         any
-	failed       *map[string]any
+	functionName    string
+	resourceName    string
+	attempt         int
+	sleep           time.Duration
+	data            any
+	failed          *map[string]any
+	customRetryCode int
 }
 
 func (api *API) callWithRetry(ctx context.Context, sling *sling.Sling, request retryRequest) error {
@@ -52,6 +53,11 @@ func (api *API) callWithRetry(ctx context.Context, sling *sling.Sling, request r
 		request.attempt, response.StatusCode))
 
 	switch response.StatusCode {
+	case request.customRetryCode:
+		if _, ok := ctx.Deadline(); !ok {
+			return fmt.Errorf("context has no deadline")
+		}
+		tflog.Debug(ctx, fmt.Sprintf("custom retry logic, will try again, attempt=%d", request.attempt))
 	case 200, 201, 204:
 		return nil
 	case 400, 409:

--- a/api/models/network/vpc.go
+++ b/api/models/network/vpc.go
@@ -1,0 +1,17 @@
+package network
+
+type VpcRequest struct {
+	Name   string   `json:"name"`
+	Region string   `json:"region"`
+	Subnet string   `json:"subnet"`
+	Tags   []string `json:"tags"`
+}
+
+type VpcResponse struct {
+	ID      int      `json:"id"`
+	Name    string   `json:"name"`
+	Region  string   `json:"region"`
+	Subnet  string   `json:"subnet"`
+	Tags    []string `json:"tags"`
+	VpcName string   `json:"vpc_name"`
+}

--- a/api/vpc.go
+++ b/api/vpc.go
@@ -3,164 +3,86 @@ package api
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
+	model "github.com/cloudamqp/terraform-provider-cloudamqp/api/models/network"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func (api *API) waitUntilVpcReady(ctx context.Context, vpcID string) error {
+func (api *API) CreateVPC(ctx context.Context, params model.VpcRequest) (model.VpcResponse, error) {
 	var (
-		data   map[string]any
-		failed map[string]any
-		path   = fmt.Sprintf("api/vpcs/%s/vpc-peering/info", vpcID)
-	)
-
-	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s wait until ready", path))
-	for {
-		response, err := api.sling.New().Get(path).Receive(&data, &failed)
-		if err != nil {
-			return err
-		}
-
-		switch response.StatusCode {
-		case 200:
-			return nil
-		case 400:
-			tflog.Warn(ctx, fmt.Sprintf("wait until ready, status=%d message=%s ",
-				response.StatusCode, failed))
-		default:
-			return fmt.Errorf("failed to wait until ready, status=%d message=%s ",
-				response.StatusCode, failed)
-		}
-		time.Sleep(10 * time.Second)
-	}
-}
-
-func (api *API) readVpcName(ctx context.Context, vpcID string) (map[string]any, error) {
-	var (
-		data   map[string]any
-		failed map[string]any
-		path   = fmt.Sprintf("api/vpcs/%s/vpc-peering/info", vpcID)
-	)
-
-	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s ", path))
-	response, err := api.sling.New().Get(path).Receive(&data, &failed)
-	if err != nil {
-		return nil, err
-	}
-
-	switch response.StatusCode {
-	case 200:
-		tflog.Debug(ctx, "response data", data)
-		return data, nil
-	default:
-		return nil, fmt.Errorf("failed to read VPC name, status)%d message=%s ",
-			response.StatusCode, failed)
-	}
-}
-
-func (api *API) CreateVpcInstance(ctx context.Context, params map[string]any) (map[string]any, error) {
-	var (
-		data   map[string]any
+		data   model.VpcResponse
 		failed map[string]any
 		path   = "/api/vpcs"
 	)
 
-	tflog.Debug(ctx, fmt.Sprintf("method=POST path=%s ", path), params)
-	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
+	tflog.Debug(ctx, fmt.Sprintf("method=POST path=%s params=%v", path, params))
+	err := CallWithRetry(ctx, api.sling.New().Post(path).BodyJSON(params), "VPC", 1, 10*time.Second, &data, &failed)
 	if err != nil {
-		return nil, err
+		return model.VpcResponse{}, err
 	}
 
-	switch response.StatusCode {
-	case 200:
-		tflog.Debug(ctx, "response data", data)
-		if id, ok := data["id"]; ok {
-			data["id"] = strconv.FormatFloat(id.(float64), 'f', 0, 64)
-		} else {
-			return nil, fmt.Errorf("invalid identifier=%v ", data["id"])
-		}
-		api.waitUntilVpcReady(ctx, data["id"].(string))
-		return data, nil
-	default:
-		return nil, fmt.Errorf("failed to create VPC, status=%d message=%s ",
-			response.StatusCode, failed)
+	name, err := api.readVpcName(ctx, data.ID)
+	if err != nil {
+		return model.VpcResponse{}, fmt.Errorf("failed to read VPC name: %w", err)
 	}
+	data.VpcName = name
+	return data, nil
 }
 
-func (api *API) ReadVpcInstance(ctx context.Context, vpcID string) (map[string]any, error) {
+func (api *API) ReadVPC(ctx context.Context, vpcID int) (model.VpcResponse, error) {
 	var (
-		data   map[string]any
+		data   model.VpcResponse
 		failed map[string]any
-		path   = fmt.Sprintf("/api/vpcs/%s", vpcID)
+		path   = fmt.Sprintf("/api/vpcs/%d", vpcID)
 	)
 
 	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s ", path))
-	response, err := api.sling.New().Path(path).Receive(&data, &failed)
+	err := CallWithRetry(ctx, api.sling.New().Get(path), "VPC", 1, 10*time.Second, &data, &failed)
 	if err != nil {
-		return nil, err
+		return model.VpcResponse{}, fmt.Errorf("failed to read VPC: %w", err)
 	}
 
-	switch response.StatusCode {
-	case 200:
-		tflog.Debug(ctx, "response data", data)
-		data_temp, _ := api.readVpcName(ctx, vpcID)
-		data["vpc_name"] = data_temp["name"]
-		return data, nil
-	case 410:
-		tflog.Warn(ctx, "the VPC has been deleted")
-		return nil, nil
-	default:
-		return nil, fmt.Errorf("failed to read VPC, status=%d message=%s ",
-			response.StatusCode, failed)
+	name, err := api.readVpcName(ctx, data.ID)
+	if err != nil {
+		return model.VpcResponse{}, fmt.Errorf("failed to read VPC name: %w", err)
 	}
+	data.VpcName = name
+	return data, nil
 }
 
-func (api *API) UpdateVpcInstance(ctx context.Context, vpcID string, params map[string]any) error {
+func (api *API) readVpcName(ctx context.Context, vpcID int) (string, error) {
+	var (
+		data   map[string]any
+		failed map[string]any
+		path   = fmt.Sprintf("api/vpcs/%d/vpc-peering/info", vpcID)
+	)
+
+	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s ", path))
+	err := CallWithRetry(ctx, api.sling.New().Get(path), "VPC", 1, 10*time.Second, &data, &failed)
+	if err != nil {
+		return "", err
+	}
+
+	return data["name"].(string), nil
+}
+
+func (api *API) UpdateVPC(ctx context.Context, vpcID string, params model.VpcRequest) error {
 	var (
 		failed map[string]any
 		path   = fmt.Sprintf("api/vpcs/%s", vpcID)
 	)
 
-	tflog.Debug(ctx, fmt.Sprintf("method=PUT path=%s ", path), params)
-	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
-	if err != nil {
-		return err
-	}
-
-	switch response.StatusCode {
-	case 200:
-		return nil
-	case 410:
-		tflog.Warn(ctx, "the VPC has been deleted")
-		return nil
-	default:
-		return fmt.Errorf("failed to update VPC, status=%d message=%s ",
-			response.StatusCode, failed)
-	}
+	tflog.Debug(ctx, fmt.Sprintf("method=PUT path=%s params=%v ", path, params))
+	return CallWithRetry(ctx, api.sling.New().Put(path).BodyJSON(params), "VPC", 1, 10*time.Second, nil, &failed)
 }
 
-func (api *API) DeleteVpcInstance(ctx context.Context, vpcID string) error {
+func (api *API) DeleteVPC(ctx context.Context, vpcID string) error {
 	var (
 		failed map[string]any
 		path   = fmt.Sprintf("api/vpcs/%s", vpcID)
 	)
 
 	tflog.Debug(ctx, fmt.Sprintf("method=DELETE path=%s ", path))
-	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
-	if err != nil {
-		return err
-	}
-
-	switch response.StatusCode {
-	case 204:
-		return nil
-	case 410:
-		tflog.Warn(ctx, "the VPC has been deleted")
-		return nil
-	default:
-		return fmt.Errorf("failed to delete VPC, status=%d message=%s ",
-			response.StatusCode, failed)
-	}
+	return CallWithRetry(ctx, api.sling.New().Delete(path), "VPC", 1, 10*time.Second, nil, &failed)
 }

--- a/api/vpc.go
+++ b/api/vpc.go
@@ -17,9 +17,21 @@ func (api *API) CreateVPC(ctx context.Context, params model.VpcRequest) (model.V
 	)
 
 	tflog.Debug(ctx, fmt.Sprintf("method=POST path=%s params=%v", path, params))
-	err := CallWithRetry(ctx, api.sling.New().Post(path).BodyJSON(params), "VPC", 1, 10*time.Second, &data, &failed)
+	err := api.callWithRetry(ctx, api.sling.New().Post(path).BodyJSON(params), retryRequest{
+		functionName: "CreateVPC",
+		resourceName: "VPC",
+		attempt:      1,
+		sleep:        5 * time.Second,
+		data:         &data,
+		failed:       &failed,
+	})
 	if err != nil {
 		return model.VpcResponse{}, err
+	}
+
+	err = api.pollForVpcReady(ctx, data.ID)
+	if err != nil {
+		return model.VpcResponse{}, fmt.Errorf("failed to poll for VPC readiness: %w", err)
 	}
 
 	name, err := api.readVpcName(ctx, data.ID)
@@ -38,7 +50,14 @@ func (api *API) ReadVPC(ctx context.Context, vpcID int) (model.VpcResponse, erro
 	)
 
 	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s ", path))
-	err := CallWithRetry(ctx, api.sling.New().Get(path), "VPC", 1, 10*time.Second, &data, &failed)
+	err := api.callWithRetry(ctx, api.sling.New().Get(path), retryRequest{
+		functionName: "ReadVPC",
+		resourceName: "VPC",
+		attempt:      1,
+		sleep:        5 * time.Second,
+		data:         &data,
+		failed:       &failed,
+	})
 	if err != nil {
 		return model.VpcResponse{}, fmt.Errorf("failed to read VPC: %w", err)
 	}
@@ -51,38 +70,83 @@ func (api *API) ReadVPC(ctx context.Context, vpcID int) (model.VpcResponse, erro
 	return data, nil
 }
 
+func (api *API) UpdateVPC(ctx context.Context, vpcID int, params model.VpcRequest) error {
+	var (
+		failed map[string]any
+		path   = fmt.Sprintf("/api/vpcs/%d", vpcID)
+	)
+
+	tflog.Debug(ctx, fmt.Sprintf("method=PUT path=%s params=%v ", path, params))
+	return api.callWithRetry(ctx, api.sling.New().Put(path).BodyJSON(params), retryRequest{
+		functionName: "UpdateVPC",
+		resourceName: "VPC",
+		attempt:      1,
+		sleep:        5 * time.Second,
+		data:         nil,
+		failed:       &failed,
+	})
+}
+
+func (api *API) DeleteVPC(ctx context.Context, vpcID int) error {
+	var (
+		failed map[string]any
+		path   = fmt.Sprintf("/api/vpcs/%d", vpcID)
+	)
+
+	tflog.Debug(ctx, fmt.Sprintf("method=DELETE path=%s ", path))
+	return api.callWithRetry(ctx, api.sling.New().Delete(path), retryRequest{
+		functionName: "DeleteVPC",
+		resourceName: "VPC",
+		attempt:      1,
+		sleep:        5 * time.Second,
+		data:         nil,
+		failed:       &failed,
+	})
+}
+
+func (api *API) pollForVpcReady(ctx context.Context, vpcID int) error {
+	var (
+		failed map[string]any
+		path   = fmt.Sprintf("/api/vpcs/%d/vpc-peering/info", vpcID)
+	)
+
+	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s ", path))
+	// CustomRetryCode set to 400, to poll for VPC readiness (200)
+	return api.callWithRetry(ctx, api.sling.New().Get(path), retryRequest{
+		functionName:    "PollForVpcReady",
+		resourceName:    "VPC",
+		attempt:         1,
+		sleep:           5 * time.Second,
+		data:            nil,
+		failed:          &failed,
+		customRetryCode: 400,
+	})
+}
+
+// readVpcName - retrieves external cloud provider VPC name
 func (api *API) readVpcName(ctx context.Context, vpcID int) (string, error) {
 	var (
 		data   map[string]any
 		failed map[string]any
-		path   = fmt.Sprintf("api/vpcs/%d/vpc-peering/info", vpcID)
+		path   = fmt.Sprintf("/api/vpcs/%d/vpc-peering/info", vpcID)
 	)
 
 	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s ", path))
-	err := CallWithRetry(ctx, api.sling.New().Get(path), "VPC", 1, 10*time.Second, &data, &failed)
+	err := api.callWithRetry(ctx, api.sling.New().Get(path), retryRequest{
+		functionName: "ReadVpcName",
+		resourceName: "VPC",
+		attempt:      1,
+		sleep:        5 * time.Second,
+		data:         &data,
+		failed:       &failed,
+	})
 	if err != nil {
 		return "", err
 	}
 
-	return data["name"].(string), nil
-}
-
-func (api *API) UpdateVPC(ctx context.Context, vpcID string, params model.VpcRequest) error {
-	var (
-		failed map[string]any
-		path   = fmt.Sprintf("api/vpcs/%s", vpcID)
-	)
-
-	tflog.Debug(ctx, fmt.Sprintf("method=PUT path=%s params=%v ", path, params))
-	return CallWithRetry(ctx, api.sling.New().Put(path).BodyJSON(params), "VPC", 1, 10*time.Second, nil, &failed)
-}
-
-func (api *API) DeleteVPC(ctx context.Context, vpcID string) error {
-	var (
-		failed map[string]any
-		path   = fmt.Sprintf("api/vpcs/%s", vpcID)
-	)
-
-	tflog.Debug(ctx, fmt.Sprintf("method=DELETE path=%s ", path))
-	return CallWithRetry(ctx, api.sling.New().Delete(path), "VPC", 1, 10*time.Second, nil, &failed)
+	name, ok := data["name"].(string)
+	if !ok {
+		return "", fmt.Errorf("missing or invalid 'name' in VPC peering info: %v", data)
+	}
+	return name, nil
 }

--- a/cloudamqp/provider.go
+++ b/cloudamqp/provider.go
@@ -104,6 +104,7 @@ func (p *cloudamqpProvider) Resources(_ context.Context) []func() resource.Resou
 		NewAccountActionsResource,
 		NewAwsEventBridgeResource,
 		NewRabbitMqConfigurationResource,
+		NewVpcResource,
 	}
 }
 
@@ -172,7 +173,6 @@ func Provider(v string, client *http.Client) *schemaSdk.Provider {
 			"cloudamqp_vpc_connect":        resourceVpcConnect(),
 			"cloudamqp_vpc_gcp_peering":    resourceVpcGcpPeering(),
 			"cloudamqp_vpc_peering":        resourceVpcPeering(),
-			"cloudamqp_vpc":                resourceVpc(),
 			"cloudamqp_webhook":            resourceWebhook(),
 		},
 		ConfigureContextFunc: configureClient(client),

--- a/cloudamqp/resource_cloudamqp_vpc.go
+++ b/cloudamqp/resource_cloudamqp_vpc.go
@@ -165,7 +165,12 @@ func (r *vpcResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
-	id, _ := strconv.Atoi(state.ID.ValueString())
+	id, err := strconv.Atoi(state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid ID", fmt.Sprintf("Could not convert ID to integer: %s", err))
+		return
+	}
+
 	data, err := r.client.ReadVPC(timeoutCtx, id)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -206,11 +211,17 @@ func (r *vpcResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	data.Tags = make([]string, 0)
 	plan.Tags.ElementsAs(timeoutCtx, &data.Tags, false)
 
-	err := r.client.UpdateVPC(timeoutCtx, plan.ID.ValueString(), data)
+	id, err := strconv.Atoi(state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid ID", fmt.Sprintf("Could not convert ID to integer: %s", err))
+		return
+	}
+
+	err = r.client.UpdateVPC(timeoutCtx, id, data)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to Update VPC instance",
-			fmt.Sprintf("Could not update VPC instance with ID %s: %s", plan.ID.ValueString(), err),
+			fmt.Sprintf("Could not update VPC instance with ID %d: %s", id, err),
 		)
 		return
 	}
@@ -231,11 +242,17 @@ func (r *vpcResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
-	err := r.client.DeleteVPC(timeoutCtx, state.ID.ValueString())
+	id, err := strconv.Atoi(state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid ID", fmt.Sprintf("Could not convert ID to integer: %s", err))
+		return
+	}
+
+	err = r.client.DeleteVPC(timeoutCtx, id)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to Delete VPC Instance",
-			fmt.Sprintf("Could not delete VPC instance with ID %s: %s", state.ID.ValueString(), err),
+			fmt.Sprintf("Could not delete VPC instance with ID %d: %s", id, err),
 		)
 		return
 	}

--- a/cloudamqp/resource_cloudamqp_vpc.go
+++ b/cloudamqp/resource_cloudamqp_vpc.go
@@ -256,4 +256,5 @@ func (r *vpcResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		)
 		return
 	}
+	resp.State.RemoveResource(ctx)
 }

--- a/cloudamqp/resource_cloudamqp_vpc.go
+++ b/cloudamqp/resource_cloudamqp_vpc.go
@@ -234,11 +234,6 @@ func (r *vpcResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		)
 		return
 	}
-
-	// resp.State.RemoveResource(ctx)
-	// if resp.Diagnostics.HasError() {
-	// 	return
-	// }
 }
 
 func populateVpcStateModel(ctx context.Context, state *vpcResourceModel, data *model.VpcResponse) {
@@ -248,21 +243,3 @@ func populateVpcStateModel(ctx context.Context, state *vpcResourceModel, data *m
 	state.Tags, _ = types.ListValueFrom(ctx, types.StringType, data.Tags)
 	state.VpcName = types.StringValue(data.VpcName)
 }
-
-// func populateVpcRequestModel(ctx context.Context, request *model.VpcRequest, config, plan *vpcResourceModel) {
-// 	if config.Name != plan.Name {
-// 		request.Name = config.Name.ValueString()
-// 	}
-// 	if config.Region != plan.Region {
-// 		request.Region = config.Region.ValueString()
-// 	}
-// 	if config.Subnet != plan.Subnet {
-// 		request.Subnet = config.Subnet.ValueString()
-// 	}
-// 	if len(config.Tags.Elements()) != len(plan.Tags.Elements()) {
-// 		request.Tags = make([]string, 0, len(config.Tags.Elements()))
-// 		config.Tags.ElementsAs(ctx, &request.Tags, false)
-// 	} else {
-// 		request.Tags = make([]string, 0)
-// 	}
-// }

--- a/cloudamqp/resource_cloudamqp_vpc.go
+++ b/cloudamqp/resource_cloudamqp_vpc.go
@@ -175,7 +175,12 @@ func (r *vpcResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
-	populateVpcStateModel(ctx, &state, &data)
+	state.Name = types.StringValue(data.Name)
+	state.Region = types.StringValue(data.Region)
+	state.Subnet = types.StringValue(data.Subnet)
+	state.Tags, _ = types.ListValueFrom(ctx, types.StringType, data.Tags)
+	state.VpcName = types.StringValue(data.VpcName)
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -234,12 +239,4 @@ func (r *vpcResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		)
 		return
 	}
-}
-
-func populateVpcStateModel(ctx context.Context, state *vpcResourceModel, data *model.VpcResponse) {
-	state.Name = types.StringValue(data.Name)
-	state.Region = types.StringValue(data.Region)
-	state.Subnet = types.StringValue(data.Subnet)
-	state.Tags, _ = types.ListValueFrom(ctx, types.StringType, data.Tags)
-	state.VpcName = types.StringValue(data.VpcName)
 }

--- a/cloudamqp/resource_cloudamqp_vpc.go
+++ b/cloudamqp/resource_cloudamqp_vpc.go
@@ -3,137 +3,266 @@ package cloudamqp
 import (
 	"context"
 	"fmt"
-	"net"
+	"strconv"
+	"time"
 
 	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	model "github.com/cloudamqp/terraform-provider-cloudamqp/api/models/network"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/cloudamqp/utils/validators"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func resourceVpc() *schema.Resource {
-	return &schema.Resource{
-		CreateContext: resourceVpcCreate,
-		ReadContext:   resourceVpcRead,
-		UpdateContext: resourceVpcUpdate,
-		DeleteContext: resourceVpcDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:        schema.TypeString,
+var (
+	_ resource.Resource                = &vpcResource{}
+	_ resource.ResourceWithConfigure   = &vpcResource{}
+	_ resource.ResourceWithImportState = &vpcResource{}
+)
+
+type vpcResource struct {
+	client *api.API
+}
+
+func NewVpcResource() resource.Resource {
+	return &vpcResource{}
+}
+
+type vpcResourceModel struct {
+	ID      types.String `tfsdk:"id"`
+	Name    types.String `tfsdk:"name"`
+	Region  types.String `tfsdk:"region"`
+	Subnet  types.String `tfsdk:"subnet"`
+	Tags    types.List   `tfsdk:"tags"`
+	VpcName types.String `tfsdk:"vpc_name"`
+}
+
+func (r *vpcResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "cloudamqp_vpc"
+}
+
+func (r *vpcResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Resource ID of the VPC instance",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
 				Required:    true,
 				Description: "Name of the VPC instance",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
-			"region": {
-				Type:        schema.TypeString,
+			"region": schema.StringAttribute{
 				Required:    true,
-				ForceNew:    true,
-				Description: "The hosted region for the standalone VPC instance",
-			},
-			"subnet": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: func(val any, key string) (warns []string, errs []error) {
-					v := val.(string)
-					_, _, err := net.ParseCIDR(v)
-					if err != nil {
-						errs = append(errs, fmt.Errorf("subnet: %v", err))
-					}
-					return
+				Description: "Region where the VPC is located",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
 				},
-				Description: "The VPC subnet",
 			},
-			"tags": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
+			"subnet": schema.StringAttribute{
+				Required:    true,
+				Description: "The VPC subnet in CIDR notation (e.g., 10.56.72.0/24)",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
 				},
-				Description: "Tag the VPC instance with optional tags",
+				Validators: []validator.String{
+					validators.CidrValidator{},
+				},
 			},
-			"vpc_name": {
-				Type:        schema.TypeString,
+			"tags": schema.ListAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: "Optional tags to associate with the VPC instance",
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"vpc_name": schema.StringAttribute{
 				Computed:    true,
 				Description: "VPC name given when hosted at the cloud provider",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}
 }
 
-func resourceVpcCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	api := meta.(*api.API)
-	keys := []string{"name", "region", "subnet", "tags"}
-	params := make(map[string]any)
-	for _, k := range keys {
-		if v := d.Get(k); v != nil && v != "" {
-			params[k] = v
-		}
+func (r *vpcResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*api.API)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider Data Type",
+			fmt.Sprintf("Expected *api.API, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+func (r *vpcResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *vpcResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan vpcResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	data, err := api.CreateVpcInstance(ctx, params)
+	tags := make([]string, 0)
+	plan.Tags.ElementsAs(ctx, &tags, false)
+
+	vpc := model.VpcRequest{
+		Name:   plan.Name.ValueString(),
+		Region: plan.Region.ValueString(),
+		Subnet: plan.Subnet.ValueString(),
+		Tags:   tags,
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	data, err := r.client.CreateVPC(timeoutCtx, vpc)
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError(
+			"Failed to Create VPC Instance",
+			fmt.Sprintf("Could not create VPC instance: %s", err),
+		)
+		return
 	}
 
-	d.SetId(data["id"].(string))
-	return resourceVpcRead(ctx, d, meta)
+	plan.ID = types.StringValue(strconv.Itoa(data.ID))
+	plan.VpcName = types.StringValue(data.VpcName)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
-func resourceVpcRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	api := meta.(*api.API)
-	data, err := api.ReadVpcInstance(ctx, d.Id())
+func (r *vpcResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state vpcResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	id, _ := strconv.Atoi(state.ID.ValueString())
+	data, err := r.client.ReadVPC(timeoutCtx, id)
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError(
+			"Failed to Read VPC Instance",
+			fmt.Sprintf("Could not read VPC instance with ID %d: %s", id, err),
+		)
+		return
 	}
 
-	for k, v := range data {
-		if validateVpcSchemaAttribute(k) {
-			err = d.Set(k, v)
-			if err != nil {
-				return diag.Errorf("error setting %s for resource %s: %s", k, d.Id(), err)
-			}
-		}
+	populateVpcStateModel(ctx, &state, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-
-	return diag.Diagnostics{}
 }
 
-func resourceVpcUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	api := meta.(*api.API)
-	keys := []string{"name", "tags"}
-	params := make(map[string]any)
-	for _, k := range keys {
-		if v := d.Get(k); v != nil {
-			params[k] = d.Get(k)
-		}
+func (r *vpcResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var (
+		plan  vpcResourceModel
+		state vpcResourceModel
+	)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if err := api.UpdateVpcInstance(ctx, d.Id(), params); err != nil {
-		return diag.FromErr(err)
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	var data model.VpcRequest
+	data.Name = plan.Name.ValueString()
+	data.Tags = make([]string, 0)
+	plan.Tags.ElementsAs(timeoutCtx, &data.Tags, false)
+
+	err := r.client.UpdateVPC(timeoutCtx, plan.ID.ValueString(), data)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to Update VPC instance",
+			fmt.Sprintf("Could not update VPC instance with ID %s: %s", plan.ID.ValueString(), err),
+		)
+		return
 	}
 
-	return resourceVpcRead(ctx, d, meta)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
-func resourceVpcDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	api := meta.(*api.API)
-	if err := api.DeleteVpcInstance(ctx, d.Id()); err != nil {
-		return diag.FromErr(err)
+func (r *vpcResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state vpcResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	return diag.Diagnostics{}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	err := r.client.DeleteVPC(timeoutCtx, state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to Delete VPC Instance",
+			fmt.Sprintf("Could not delete VPC instance with ID %s: %s", state.ID.ValueString(), err),
+		)
+		return
+	}
+
+	// resp.State.RemoveResource(ctx)
+	// if resp.Diagnostics.HasError() {
+	// 	return
+	// }
 }
 
-func validateVpcSchemaAttribute(key string) bool {
-	switch key {
-	case "name",
-		"region",
-		"subnet",
-		"tags",
-		"vpc_name":
-		return true
-	}
-	return false
+func populateVpcStateModel(ctx context.Context, state *vpcResourceModel, data *model.VpcResponse) {
+	state.Name = types.StringValue(data.Name)
+	state.Region = types.StringValue(data.Region)
+	state.Subnet = types.StringValue(data.Subnet)
+	state.Tags, _ = types.ListValueFrom(ctx, types.StringType, data.Tags)
+	state.VpcName = types.StringValue(data.VpcName)
 }
+
+// func populateVpcRequestModel(ctx context.Context, request *model.VpcRequest, config, plan *vpcResourceModel) {
+// 	if config.Name != plan.Name {
+// 		request.Name = config.Name.ValueString()
+// 	}
+// 	if config.Region != plan.Region {
+// 		request.Region = config.Region.ValueString()
+// 	}
+// 	if config.Subnet != plan.Subnet {
+// 		request.Subnet = config.Subnet.ValueString()
+// 	}
+// 	if len(config.Tags.Elements()) != len(plan.Tags.Elements()) {
+// 		request.Tags = make([]string, 0, len(config.Tags.Elements()))
+// 		config.Tags.ElementsAs(ctx, &request.Tags, false)
+// 	} else {
+// 		request.Tags = make([]string, 0)
+// 	}
+// }

--- a/cloudamqp/resource_cloudamqp_vpc_test.go
+++ b/cloudamqp/resource_cloudamqp_vpc_test.go
@@ -44,13 +44,13 @@ func TestAccVpc_Basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            vpcResourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ResourceName:      vpcResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
-				Config: configuration.GetTemplatedConfig(t, fileNames, paramsUpdated),
+				ExpectNonEmptyPlan: true,
+				Config:             configuration.GetTemplatedConfig(t, fileNames, paramsUpdated),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(vpcResourceName, "name", paramsUpdated["VpcName"]),
 					resource.TestCheckResourceAttr(vpcResourceName, "region", paramsUpdated["VpcRegion"]),

--- a/cloudamqp/utils/validators/cidr_validator.go
+++ b/cloudamqp/utils/validators/cidr_validator.go
@@ -1,0 +1,27 @@
+package validators
+
+import (
+	"context"
+	"net"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+type CidrValidator struct{}
+
+func (v CidrValidator) Description(ctx context.Context) string {
+	return "Must be a valid CIDR (e.g., 10.0.0.0/16)"
+}
+func (v CidrValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v CidrValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if _, _, err := net.ParseCIDR(req.ConfigValue.ValueString()); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid CIDR",
+			"Value must be a valid CIDR notation (e.g., 10.0.0.0/16)",
+		)
+	}
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Part of Terraform plugin framework migration #281.

### WHAT is this pull request doing?

- Adds API model for request/response for the VPC
- Update client code:
  - Utilizes the generic retry method
  - Adding customRetryCode to override when to retry the request
- Migrates `cloudamqp_vpc` resource
- Comment about not being able to use `schema.ListNestedAttribute` with protocol version 5

### HOW can this pull request be tested?

VCR-test coverage and made manual testing during development.