### PR TITLE
Migrate cloudamqp_webhook towards Terraform plugin framework

### DIFF
--- a/api/models/integrations/webhook.go
+++ b/api/models/integrations/webhook.go
@@ -1,0 +1,25 @@
+package integrations
+
+type WebhookCreateRequest struct {
+	Concurrency int64  `json:"concurrency"`
+	WebhookURI  string `json:"webhook_uri"`
+	Vhost       string `json:"vhost"`
+	Queue       string `json:"queue"`
+}
+
+type WebhookUpdateRequest struct {
+	WebhookID   int64  `json:"webhook_id"`
+	Concurrency int64  `json:"concurrency"`
+	WebhookURI  string `json:"webhook_uri"`
+	Vhost       string `json:"vhost"`
+	Queue       string `json:"queue"`
+}
+
+type WebhookResponse struct {
+	ID          int64  `json:"id"`
+	Concurrency int64  `json:"concurrency"`
+	WebhookURI  string `json:"webhook_uri"`
+	Vhost       string `json:"vhost"`
+	Queue       string `json:"queue"`
+	LastStatus  string `json:"last_status,omitempty"`
+}

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -4,212 +4,91 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
+	model "github.com/cloudamqp/terraform-provider-cloudamqp/api/models/integrations"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// CreateWebhook - create a webhook for a vhost and a specific qeueu
-func (api *API) CreateWebhook(ctx context.Context, instanceID int, params map[string]any,
-	sleep, timeout int) (map[string]any, error) {
-
-	path := fmt.Sprintf("/api/instances/%d/webhooks", instanceID)
-	tflog.Debug(ctx, fmt.Sprintf("method=POST path=%s sleep=%d timeout=%d ", path, sleep, timeout),
-		params)
-	return api.createWebhookWithRetry(ctx, path, params, 1, sleep, timeout)
-}
-
-// createWebhookWithRetry: create webhook with retry if backend is busy.
-func (api *API) createWebhookWithRetry(ctx context.Context, path string, params map[string]any,
-	attempt, sleep, timeout int) (map[string]any, error) {
+// CreateWebhook - create a webhook for a vhost and a specific queue
+func (api *API) CreateWebhook(ctx context.Context, instanceID int64, params model.WebhookCreateRequest, sleep time.Duration) (
+	string, error) {
 
 	var (
-		data   map[string]any
-		failed map[string]any
+		data model.WebhookResponse
+		path = fmt.Sprintf("/api/instances/%d/webhooks", instanceID)
 	)
 
-	response, err := api.sling.New().Post(path).BodyJSON(params).Receive(&data, &failed)
+	tflog.Debug(ctx, fmt.Sprintf("method=POST path=%s params=%v ", path, params))
+	err := api.callWithRetry(ctx, api.sling.New().Post(path).BodyJSON(params), retryRequest{
+		functionName: "CreateWebhook",
+		resourceName: "Webhook",
+		attempt:      1,
+		sleep:        sleep,
+		data:         &data,
+		failed:       nil,
+	})
 	if err != nil {
-		return nil, err
-	} else if attempt*sleep > timeout {
-		return nil, fmt.Errorf("timeout reached after %d seconds, while creating webhook", timeout)
+		return "", err
 	}
 
-	switch response.StatusCode {
-	case 201:
-		tflog.Debug(ctx, "response data", data)
-		if v, ok := data["id"]; ok {
-			data["id"] = strconv.FormatFloat(v.(float64), 'f', 0, 64)
-		} else {
-			return nil, fmt.Errorf("invalid identifier=%v", data["id"])
-		}
-		return data, nil
-	case 400:
-		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			tflog.Debug(ctx, fmt.Sprintf("timeout talking to backend, will try again, attempt=%d "+
-				"until_timeout=%d ", attempt, (timeout-(attempt*sleep))))
-			attempt++
-			time.Sleep(time.Duration(sleep) * time.Second)
-			return api.createWebhookWithRetry(ctx, path, params, attempt, sleep, timeout)
-		}
-	}
-
-	return nil, fmt.Errorf("failed to create webhook, status=%d message=%s ",
-		response.StatusCode, failed)
+	id := strconv.FormatInt(data.ID, 10)
+	return id, nil
 }
 
 // ReadWebhook - retrieves a specific webhook for an instance
-func (api *API) ReadWebhook(ctx context.Context, instanceID int, webhookID string, sleep,
-	timeout int) (map[string]any, error) {
-
-	path := fmt.Sprintf("/api/instances/%d/webhooks/%s", instanceID, webhookID)
-	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s sleep=%s timeout=%s ", path, sleep, timeout))
-	return api.readWebhookWithRetry(ctx, path, 1, sleep, timeout)
-}
-
-// readWebhookWithRetry: read webhook with retry if backend is busy.
-func (api *API) readWebhookWithRetry(ctx context.Context, path string, attempt, sleep, timeout int) (
-	map[string]any, error) {
+func (api *API) ReadWebhook(ctx context.Context, instanceID int64, webhookID string, sleep time.Duration) (
+	model.WebhookResponse, error) {
 
 	var (
-		data   map[string]any
-		failed map[string]any
-	)
-
-	response, err := api.sling.New().Get(path).Receive(&data, &failed)
-	if err != nil {
-		return nil, err
-	} else if attempt*sleep > timeout {
-		return nil, fmt.Errorf("timeout reached after %d seconds, while reading webhook information",
-			timeout)
-	}
-
-	switch response.StatusCode {
-	case 200:
-		tflog.Debug(ctx, "response data", data)
-		return data, nil
-	case 400:
-		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			tflog.Debug(ctx, fmt.Sprintf("timeout talking to backend, will try again, attempt=%d "+
-				"until_timeout=%d ", attempt, (timeout-(attempt*sleep))))
-			attempt++
-			time.Sleep(time.Duration(sleep) * time.Second)
-			return api.readWebhookWithRetry(ctx, path, attempt, sleep, timeout)
-		}
-	case 404:
-		tflog.Warn(ctx, "webhook not found")
-		return nil, nil
-	}
-
-	return nil, fmt.Errorf("failed to read webhook information, status=%d message=%s ",
-		response.StatusCode, failed)
-}
-
-// ListWebhooks - list all webhooks for an instance.
-func (api *API) ListWebhooks(ctx context.Context, instanceID int) (map[string]any, error) {
-	var (
-		data   map[string]any
-		failed map[string]any
-		path   = fmt.Sprintf("/api/instances/%d/webhooks", instanceID)
+		data model.WebhookResponse
+		path = fmt.Sprintf("/api/instances/%d/webhooks/%s", instanceID, webhookID)
 	)
 
 	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s ", path))
-	response, err := api.sling.New().Path(path).Receive(&data, &failed)
+	err := api.callWithRetry(ctx, api.sling.New().Get(path), retryRequest{
+		functionName: "ReadWebhook",
+		resourceName: "Webhook",
+		attempt:      1,
+		sleep:        sleep,
+		data:         &data,
+		failed:       nil,
+	})
 	if err != nil {
-		return nil, err
+		return model.WebhookResponse{}, err
 	}
 
-	switch response.StatusCode {
-	case 200:
-		return data, nil
-	default:
-		return nil, fmt.Errorf("failed to list webhooks, status=%d message=%s ",
-			response.StatusCode, failed)
-	}
+	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s data=%v ", path, data))
+
+	return data, nil
 }
 
 // UpdateWebhook - updates a specific webhook for an instance
-func (api *API) UpdateWebhook(ctx context.Context, instanceID int, webhookID string,
-	params map[string]any, sleep, timeout int) error {
+func (api *API) UpdateWebhook(ctx context.Context, instanceID int64, webhookID string,
+	params model.WebhookUpdateRequest, sleep time.Duration) error {
 
 	path := fmt.Sprintf("/api/instances/%d/webhooks/%s", instanceID, webhookID)
-	tflog.Debug(ctx, fmt.Sprintf("method=PUT path=%s sleep=%d timeout=%d ", path, sleep, timeout),
-		params)
-	return api.updateWebhookWithRetry(ctx, path, params, 1, sleep, timeout)
-}
-
-// updateWebhookWithRetry: update webhook with retry if backend is busy.
-func (api *API) updateWebhookWithRetry(ctx context.Context, path string, params map[string]any,
-	attempt, sleep, timeout int) error {
-
-	var (
-		data   = make(map[string]any)
-		failed map[string]any
-	)
-
-	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(&data, &failed)
-	if err != nil {
-		return err
-	} else if attempt*sleep > timeout {
-		return fmt.Errorf("timeout reached after %d seconds, while updating webhook", timeout)
-	}
-
-	switch response.StatusCode {
-	case 201:
-		tflog.Debug(ctx, "response data", data)
-		return nil
-	case 400:
-		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			tflog.Debug(ctx, fmt.Sprintf("timeout talking to backend, will try again, attempt=%d "+
-				"until_timeout=%d ", attempt, (timeout-(attempt*sleep))))
-			attempt++
-			time.Sleep(time.Duration(sleep) * time.Second)
-			return api.updateWebhookWithRetry(ctx, path, params, attempt, sleep, timeout)
-		}
-	}
-
-	return fmt.Errorf("failed to update webhook, status=%d message=%s ",
-		response.StatusCode, failed)
+	tflog.Debug(ctx, fmt.Sprintf("method=PUT path=%s params=%v ", path, params))
+	return api.callWithRetry(ctx, api.sling.New().Put(path).BodyJSON(params), retryRequest{
+		functionName: "UpdateWebhook",
+		resourceName: "Webhook",
+		attempt:      1,
+		sleep:        sleep,
+		data:         nil,
+		failed:       nil,
+	})
 }
 
 // DeleteWebhook - removes a specific webhook for an instance
-func (api *API) DeleteWebhook(ctx context.Context, instanceID int, webhookID string, sleep,
-	timeout int) error {
-
+func (api *API) DeleteWebhook(ctx context.Context, instanceID int64, webhookID string, sleep time.Duration) error {
 	path := fmt.Sprintf("/api/instances/%d/webhooks/%s", instanceID, webhookID)
-	tflog.Debug(ctx, fmt.Sprintf("method=DELETE path=%s sleep=%d timeout=%d ", path, sleep, timeout))
-	return api.deleteWebhookWithRetry(ctx, path, 1, sleep, timeout)
-}
-
-// deleteWebhookWithRetry: delete webhook with retry if backend is busy.
-func (api *API) deleteWebhookWithRetry(ctx context.Context, path string, attempt, sleep,
-	timeout int) error {
-
-	var (
-		failed map[string]any
-	)
-
-	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
-	if err != nil {
-		return err
-	} else if attempt*sleep > timeout {
-		return fmt.Errorf("imeout reached after %d seconds, while deleting webhook", timeout)
-	}
-
-	switch response.StatusCode {
-	case 204:
-		return nil
-	case 400:
-		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			tflog.Debug(ctx, fmt.Sprintf("timeout talking to backend, will try again, attempt=%d "+
-				"until_timeout=%d ", attempt, (timeout-(attempt*sleep))))
-			attempt++
-			time.Sleep(time.Duration(sleep) * time.Second)
-			return api.deleteWebhookWithRetry(ctx, path, attempt, sleep, timeout)
-		}
-	}
-
-	return fmt.Errorf("failed to delete webhook, status=%d message=%s ",
-		response.StatusCode, failed)
+	tflog.Debug(ctx, fmt.Sprintf("method=DELETE path=%s ", path))
+	return api.callWithRetry(ctx, api.sling.New().Delete(path), retryRequest{
+		functionName: "DeleteWebhook",
+		resourceName: "Webhook",
+		attempt:      1,
+		sleep:        sleep,
+		data:         nil,
+		failed:       nil,
+	})
 }

--- a/cloudamqp/provider.go
+++ b/cloudamqp/provider.go
@@ -105,6 +105,7 @@ func (p *cloudamqpProvider) Resources(_ context.Context) []func() resource.Resou
 		NewAwsEventBridgeResource,
 		NewRabbitMqConfigurationResource,
 		NewVpcResource,
+		NewWebhookResource,
 	}
 }
 
@@ -173,7 +174,6 @@ func Provider(v string, client *http.Client) *schemaSdk.Provider {
 			"cloudamqp_vpc_connect":        resourceVpcConnect(),
 			"cloudamqp_vpc_gcp_peering":    resourceVpcGcpPeering(),
 			"cloudamqp_vpc_peering":        resourceVpcPeering(),
-			"cloudamqp_webhook":            resourceWebhook(),
 		},
 		ConfigureContextFunc: configureClient(client),
 	}

--- a/cloudamqp/resource_cloudamqp_webhooks.go
+++ b/cloudamqp/resource_cloudamqp_webhooks.go
@@ -5,180 +5,302 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
+	model "github.com/cloudamqp/terraform-provider-cloudamqp/api/models/integrations"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func resourceWebhook() *schema.Resource {
-	return &schema.Resource{
-		CreateContext: resourceWebhookCreate,
-		ReadContext:   resourceWebhookRead,
-		UpdateContext: resourceWebhookUpdate,
-		DeleteContext: resourceWebhookDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Schema: map[string]*schema.Schema{
-			"instance_id": {
-				Type:        schema.TypeInt,
-				Required:    true,
-				ForceNew:    true,
-				Description: "Instance identifier",
+var (
+	_ resource.Resource                = &webhookResource{}
+	_ resource.ResourceWithConfigure   = &webhookResource{}
+	_ resource.ResourceWithImportState = &webhookResource{}
+)
+
+type webhookResource struct {
+	client *api.API
+}
+
+func NewWebhookResource() resource.Resource {
+	return &webhookResource{}
+}
+
+type webhookResourceModel struct {
+	ID          types.String `tfsdk:"id"`
+	InstanceID  types.Int64  `tfsdk:"instance_id"`
+	Vhost       types.String `tfsdk:"vhost"`
+	Queue       types.String `tfsdk:"queue"`
+	WebhookURI  types.String `tfsdk:"webhook_uri"`
+	Concurrency types.Int64  `tfsdk:"concurrency"`
+	Sleep       types.Int64  `tfsdk:"sleep"`
+	Timeout     types.Int64  `tfsdk:"timeout"`
+}
+
+func (r *webhookResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "cloudamqp_webhook"
+}
+
+func (r *webhookResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Resource ID of the webhook",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
-			"vhost": {
-				Type:        schema.TypeString,
+			"instance_id": schema.Int64Attribute{
+				Required:    true,
+				Description: "Instance identifier",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
+			},
+			"vhost": schema.StringAttribute{
 				Required:    true,
 				Description: "The name of the virtual host",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
-			"queue": {
-				Type:        schema.TypeString,
+			"queue": schema.StringAttribute{
 				Required:    true,
 				Description: "The queue that should be forwarded, must be a durable queue!",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
-			"webhook_uri": {
-				Type:        schema.TypeString,
+			"webhook_uri": schema.StringAttribute{
 				Required:    true,
 				Description: "A POST request will be made for each message in the queue to this endpoint",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
-			"concurrency": {
-				Type:        schema.TypeInt,
+			"concurrency": schema.Int64Attribute{
 				Required:    true,
 				Description: "How many times the request will be made if previous call fails",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
-			"sleep": {
-				Type:        schema.TypeInt,
+			"sleep": schema.Int64Attribute{
 				Optional:    true,
-				Default:     10,
+				Computed:    true,
 				Description: "Configurable sleep time in seconds between retries for webhook",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
-			"timeout": {
-				Type:        schema.TypeInt,
+			"timeout": schema.Int64Attribute{
 				Optional:    true,
-				Default:     1800,
+				Computed:    true,
 				Description: "Configurable timeout time in seconds for webhook",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}
 }
 
-func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	var (
-		api        = meta.(*api.API)
-		keys       = []string{"vhost", "queue", "webhook_uri", "concurrency"}
-		params     = make(map[string]any)
-		instanceID = d.Get("instance_id").(int)
-		sleep      = d.Get("sleep").(int)
-		timeout    = d.Get("timeout").(int)
-	)
+func (r *webhookResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*api.API)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider Data Type",
+			fmt.Sprintf("Expected *api.API, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
 
-	for _, k := range keys {
-		if v := d.Get(k); v != nil {
-			params[k] = v
-		}
+func (r *webhookResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *webhookResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan webhookResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	data, err := api.CreateWebhook(ctx, instanceID, params, sleep, timeout)
+	sleep, timeout := r.extractSleepAndTimeout(&plan)
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	instanceID := plan.InstanceID.ValueInt64()
+
+	request := model.WebhookCreateRequest{
+		WebhookURI:  plan.WebhookURI.ValueString(),
+		Vhost:       plan.Vhost.ValueString(),
+		Queue:       plan.Queue.ValueString(),
+		Concurrency: plan.Concurrency.ValueInt64(),
+	}
+
+	id, err := r.client.CreateWebhook(timeoutCtx, instanceID, request, sleep)
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError(
+			"Failed to Create Webhook",
+			fmt.Sprintf("Could not create webhook: %s", err),
+		)
+		return
 	}
 
-	d.SetId(data["id"].(string))
-	return diag.Diagnostics{}
+	plan.ID = types.StringValue(id)
+	plan.Sleep = types.Int64Value(int64(sleep.Seconds()))
+	plan.Timeout = types.Int64Value(int64(timeout.Seconds()))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
-func resourceWebhookRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	var (
-		api        = meta.(*api.API)
-		instanceID = d.Get("instance_id").(int)
-		sleep      = d.Get("sleep").(int)
-		timeout    = d.Get("timeout").(int)
-	)
-
-	if strings.Contains(d.Id(), ",") {
-		tflog.Info(ctx, fmt.Sprintf("import of resource with identifier: %s", d.Id()))
-		s := strings.Split(d.Id(), ",")
-		d.SetId(s[0])
-		instanceID, _ = strconv.Atoi(s[1])
-		d.Set("instance_id", instanceID)
-		// Set default values for optional arguments
-		d.Set("sleep", 10)
-		d.Set("timeout", 1800)
-	}
-	if d.Get("instance_id").(int) == 0 {
-		return diag.Errorf("missing instance identifier: {resource_id},{instance_id}")
+func (r *webhookResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state webhookResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	data, err := api.ReadWebhook(ctx, instanceID, d.Id(), sleep, timeout)
+	// Import resource with identifier {resource_id},{instance_id}
+	if strings.Contains(state.ID.ValueString(), ",") {
+		s := strings.Split(state.ID.ValueString(), ",")
+		state.ID = types.StringValue(s[0])
+		instanceID, _ := strconv.Atoi(s[1])
+		state.InstanceID = types.Int64Value(int64(instanceID))
+		tflog.Info(ctx, fmt.Sprintf("Importing webhook with ID: %s for instanceID: %d", state.ID.ValueString(), instanceID))
+	}
+	if state.InstanceID.ValueInt64() == 0 {
+		resp.Diagnostics.AddError("Missing instance identifier {resource_id},{instance_id}", "")
+		return
+	}
+
+	sleep, timeout := r.extractSleepAndTimeout(&state)
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	id := state.ID.ValueString()
+	instanceID := state.InstanceID.ValueInt64()
+
+	data, err := r.client.ReadWebhook(timeoutCtx, instanceID, id, sleep)
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError(
+			"Failed to Read Webhook",
+			fmt.Sprintf("Could not read webhook with ID %s: %s", id, err),
+		)
+		return
 	}
 
-	// Handle resource drift and trigger re-creation if resource been deleted outside the provider
-	if data == nil {
-		d.SetId("")
-		return nil
+	state.ID = types.StringValue(strconv.FormatInt(data.ID, 10))
+	state.Concurrency = types.Int64Value(data.Concurrency)
+	state.Queue = types.StringValue(data.Queue)
+	state.Vhost = types.StringValue(data.Vhost)
+	state.WebhookURI = types.StringValue(data.WebhookURI)
+	state.Sleep = types.Int64Value(int64(sleep.Seconds()))
+	state.Timeout = types.Int64Value(int64(timeout.Seconds()))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-
-	for k, v := range data {
-		if validateWebhookSchemaAttribute(k) {
-			err = d.Set(k, v)
-
-			if err != nil {
-				return diag.Errorf("error setting %s for resource %s: %s", k, d.Id(), err)
-			}
-		}
-	}
-
-	return nil
 }
 
-func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	var (
-		api        = meta.(*api.API)
-		keys       = []string{"vhost", "queue", "webhook_uri", "concurrency"}
-		params     = make(map[string]any)
-		instanceID = d.Get("instance_id").(int)
-		sleep      = d.Get("sleep").(int)
-		timeout    = d.Get("timeout").(int)
-	)
-
-	for _, k := range keys {
-		if v := d.Get(k); v != nil {
-			params[k] = v
-		}
+func (r *webhookResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan webhookResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	params["webhook_id"] = d.Id()
-	if err := api.UpdateWebhook(ctx, instanceID, d.Id(), params, sleep, timeout); err != nil {
-		return diag.FromErr(err)
+	sleep, timeout := r.extractSleepAndTimeout(&plan)
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	id := plan.ID.ValueString()
+	instanceID := plan.InstanceID.ValueInt64()
+	webhookID, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to Convert Webhook ID",
+			fmt.Sprintf("Could not convert webhook ID %s to int: %s", id, err),
+		)
+		return
 	}
-	return diag.Diagnostics{}
+
+	request := model.WebhookUpdateRequest{
+		WebhookID:   webhookID,
+		WebhookURI:  plan.WebhookURI.ValueString(),
+		Vhost:       plan.Vhost.ValueString(),
+		Queue:       plan.Queue.ValueString(),
+		Concurrency: plan.Concurrency.ValueInt64(),
+	}
+
+	err = r.client.UpdateWebhook(timeoutCtx, instanceID, id, request, sleep)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to Update Webhook",
+			fmt.Sprintf("Could not update webhook with ID %s: %s", id, err),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
-func resourceWebhookDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	var (
-		api        = meta.(*api.API)
-		instanceID = d.Get("instance_id").(int)
-		sleep      = d.Get("sleep").(int)
-		timeout    = d.Get("timeout").(int)
-	)
-
-	if err := api.DeleteWebhook(ctx, instanceID, d.Id(), sleep, timeout); err != nil {
-		return diag.FromErr(err)
+func (r *webhookResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state webhookResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	return diag.Diagnostics{}
+
+	sleep, timeout := r.extractSleepAndTimeout(&state)
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	id := state.ID.ValueString()
+	instanceID := state.InstanceID.ValueInt64()
+
+	err := r.client.DeleteWebhook(timeoutCtx, instanceID, id, sleep)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to Delete Webhook",
+			fmt.Sprintf("Could not delete webhook with ID %s: %s", id, err),
+		)
+		return
+	}
+	resp.State.RemoveResource(ctx)
 }
 
-func validateWebhookSchemaAttribute(key string) bool {
-	switch key {
-	case "vhost",
-		"queue",
-		"webhook_uri",
-		"concurrency":
-		return true
+func (r *webhookResource) extractSleepAndTimeout(plan *webhookResourceModel) (time.Duration, time.Duration) {
+	sleep := time.Duration(plan.Sleep.ValueInt64()) * time.Second
+	timeout := time.Duration(plan.Timeout.ValueInt64()) * time.Second
+
+	// Default values
+	if sleep == 0 {
+		sleep = time.Duration(10) * time.Second
 	}
-	return false
+	if timeout == 0 {
+		timeout = time.Duration(1800) * time.Second
+	}
+
+	return sleep, timeout
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Part of Terraform plugin framework migration #281.

### WHAT is this pull request doing?

- Adds API model for request/response for the Webhook integration
- Updates client code:
  - Utilizes the generic retry method
- Migrates `cloudamqp_webhook` resource

### HOW can this pull request be tested?

VCR-test coverage and made manual testing during development.