### PR TITLE
Add enable VPC feature as an account action

### DIFF
--- a/cloudamqp/resource_cloudamqp_account_actions.go
+++ b/cloudamqp/resource_cloudamqp_account_actions.go
@@ -78,7 +78,7 @@ func (r *accountActionsResource) Schema(ctx context.Context, request resource.Sc
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.OneOf("rotate-password", "rotate-apikey"),
+					stringvalidator.OneOf("rotate-password", "rotate-apikey", "enable-vpc"),
 				},
 			},
 		},
@@ -109,6 +109,14 @@ func (r *accountActionsResource) Create(ctx context.Context, request resource.Cr
 			)
 			return
 		}
+	case "enable-vpc":
+		if err := r.client.EnableVPC(ctx, int(plan.InstanceID.ValueInt64())); err != nil {
+			response.Diagnostics.AddError(
+				"Enable VPC Error",
+				fmt.Sprintf("An error occurred while enabling the VPC for instance %d: %s", plan.InstanceID, err),
+			)
+			return
+		}
 	}
 
 	plan.Id = types.StringValue(plan.InstanceID.String())
@@ -125,4 +133,5 @@ func (r *accountActionsResource) Update(ctx context.Context, request resource.Up
 
 func (r *accountActionsResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
 	// This resource does not implement the Delete function
+	response.State.RemoveResource(ctx)
 }

--- a/cloudamqp/resource_cloudamqp_instance.go
+++ b/cloudamqp/resource_cloudamqp_instance.go
@@ -320,7 +320,8 @@ func validateInstanceSchemaAttribute(key string) bool {
 		"vhost",
 		"no_default_alarms",
 		"ready",
-		"backend":
+		"backend",
+		"vpc_id":
 		return true
 	}
 	return false

--- a/docs/resources/account_action.md
+++ b/docs/resources/account_action.md
@@ -11,6 +11,7 @@ This resource allows you to invoke an account action. Current supported actions 
 
 * Rotate password for RabbitMQ/LavinMQ user
 * Rotate API key for the CloudAMQP instance
+* Enable VPC feature
 
 ## Example Usage
 
@@ -30,6 +31,57 @@ resource "cloudamqp_account_action" "rotate-apikey" {
 } 
 ```
 
+```hcl
+resource "cloudamqp_account_actions" "enable_vpc" {
+  instance_id = cloudamqp_instance.instance.id
+  action      = "enable-vpc"
+}
+```
+
+<details>
+ <summary>
+    <b>
+      <i>Manage the enabled VPC</i>
+    </b>
+  </summary>
+
+To add the enable VPC to a managed standalone VPC.
+
+First fetch the VPC identifier <id>
+
+1. Run `terraform refresh` the `vpc_id` will be added to the state for the `cloudamqp_instance.instance` resource.
+2. Retrieve the `vpc_id` form the CloudAMQP HTTP API. Either via [list-instances] or [list-vpcs].
+
+```hcl
+import {
+  to = cloudamqp_vpc.vpc
+  id = <id>
+}
+
+resource "cloudamqp_vpc" "vpc" {
+  name    = "enable-vpc-feature"
+  region  = "amazon-web-services::us-east-1"
+  subnet  = "10.56.72.0/24"
+  tags    = []
+}
+
+resource "cloudamqp_instance" "instance" {
+  name                = "enable-vpc-feature"
+  plan                = "penguin-1"
+  region              = "amazon-web-services::us-east-1"
+  tags                = []
+  vpc_id              = cloudamqp_vpc.vpc.id
+  keep_associated_vpc = true
+}
+
+resource "cloudamqp_account_actions" "enable_vpc" {
+  instance_id = cloudamqp_instance.instance.id
+  action      = "enable-vpc"
+}
+```
+
+</details>
+
 After the action have been invoked, the state need to be refreshed to get the latest changes in
 ***cloudamqp_instance*** or ***data.cloudamqp_instance***. This can be done with
 `terraform refresh`.
@@ -40,7 +92,21 @@ The following arguments are supported:
 
 * `instance_id` - (Required) The CloudAMQP instance ID.
 * `action`      - (Required/ForceNew) The action to be invoked. Allowed actions
-                  `rotate-password`, `rotate-apikey`.
+                  `rotate-password`, `rotate-apikey`, `enable-vpc`.
+
+### Actions
+
+**rotate-password**
+Initiate rotation of the user password on your instance.
+
+**rotate-apikey**
+Initiate rotation of the instance API key used for the CloudAMQP [HTTP API].
+
+**enable-vpc**
+Enables the VPC feature on existing instance not using standalone VPC. Extra cost will be applied:
+https://www.cloudamqp.com/plans.html#xtr
+
+-> NOTE: This action is irreversible, if you want to disable VPC features you will need to delete the instance and create a new one.
 
 ## Dependency
 
@@ -49,3 +115,7 @@ This resource depends on CloudAMQP instance identifier, `cloudamqp_instance.inst
 ## Import
 
 Not possible to import this resource.
+
+[list-instances]: https://docs.cloudamqp.com/#list-instances
+[list-vpcs]: https://docs.cloudamqp.com/#list-vpcs
+[HTTP API]: https://docs.cloudamqp.com/cloudamqp_api.html

--- a/docs/resources/account_action.md
+++ b/docs/resources/account_action.md
@@ -45,9 +45,9 @@ resource "cloudamqp_account_actions" "enable_vpc" {
     </b>
   </summary>
 
-To add the enable VPC to a managed standalone VPC.
+To add the enable VPC as a managed standalone VPC.
 
-First fetch the VPC identifier <id>
+First fetch the VPC identifier <vpc_id> with either
 
 1. Run `terraform refresh` the `vpc_id` will be added to the state for the `cloudamqp_instance.instance` resource.
 2. Retrieve the `vpc_id` form the CloudAMQP HTTP API. Either via [list-instances] or [list-vpcs].
@@ -55,14 +55,13 @@ First fetch the VPC identifier <id>
 ```hcl
 import {
   to = cloudamqp_vpc.vpc
-  id = <id>
+  id = <vpc_id>
 }
 
 resource "cloudamqp_vpc" "vpc" {
   name    = "enable-vpc-feature"
   region  = "amazon-web-services::us-east-1"
   subnet  = "10.56.72.0/24"
-  tags    = []
 }
 
 resource "cloudamqp_instance" "instance" {
@@ -96,17 +95,20 @@ The following arguments are supported:
 
 ### Actions
 
-**rotate-password**
+**rotate-password:**
 Initiate rotation of the user password on your instance.
 
-**rotate-apikey**
+**rotate-apikey:**
 Initiate rotation of the instance API key used for the CloudAMQP [HTTP API].
 
-**enable-vpc**
-Enables the VPC feature on existing instance not using standalone VPC. Extra cost will be applied:
-https://www.cloudamqp.com/plans.html#xtr
+**enable-vpc:**
+Enables the VPC feature on existing instance not using standalone VPC. You can't choose subnet when
+enabling VPC features and it will be set to `10.56.72.0/24`.
 
--> NOTE: This action is irreversible, if you want to disable VPC features you will need to delete the instance and create a new one.
+Extra cost will be applied: [CloudAMQP extra plans]
+
+~> This action is irreversible, if you want to disable VPC features you will need to delete
+the instance and create a new one.
 
 ## Dependency
 
@@ -119,3 +121,4 @@ Not possible to import this resource.
 [list-instances]: https://docs.cloudamqp.com/#list-instances
 [list-vpcs]: https://docs.cloudamqp.com/#list-vpcs
 [HTTP API]: https://docs.cloudamqp.com/cloudamqp_api.html
+[CloudAMQP extra plans]: https://www.cloudamqp.com/plans.html#xtr


### PR DESCRIPTION
### WHY are these changes introduced?

Request to add enable VPC feature for existing instances.

### WHAT is this pull request doing?

- Adds a new account action to enable VPC feature
- Updates documentation

### HOW can this pull request be tested?

Create instance without VPC. Then enable VPC feature through account action.