### PR TITLE
Update handling of default values for Rabbitmq configuration resource

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -44,10 +44,7 @@ func (api *API) callWithRetry(ctx context.Context, sling *sling.Sling, request r
 		return ctx.Err()
 	}
 
-	response, err := sling.Receive(request.data, request.failed)
-	if err != nil {
-		return err
-	}
+	response, _ := sling.Receive(request.data, request.failed)
 
 	tflog.Info(ctx, fmt.Sprintf("callWithRetry function=%s attempt=%d status=%d", request.functionName,
 		request.attempt, response.StatusCode))

--- a/api/models/instance/configuration/rabbitmq.go
+++ b/api/models/instance/configuration/rabbitmq.go
@@ -13,13 +13,13 @@ type RabbitMqConfigRequest struct {
 	VmMemoryHighWatermark    *float64              `json:"rabbit.vm_memory_high_watermark,omitempty"`
 	QueueIndexEmbedMsgsBelow *int64                `json:"rabbit.queue_index_embed_msgs_below,omitempty"`
 	MaxMessageSize           *int64                `json:"rabbit.max_message_size,omitempty"`
-	LogExchangeLevel         *string               `json:"rabbit.log.exchange.level,omitempty"`
-	ClusterPartitionHandling *string               `json:"rabbit.cluster_partition_handling,omitempty"`
+	LogExchangeLevel         string                `json:"rabbit.log.exchange.level,omitempty"`
+	ClusterPartitionHandling string                `json:"rabbit.cluster_partition_handling,omitempty"`
 }
 
 type RabbitMqConfigResponse struct {
 	Heartbeat                int64                `json:"rabbit.heartbeat"`
-	ConnectionMax            ConnectionMaxValue   `json:"rabbit.connection_max"`
+	ConnectionMax            *ConnectionMaxValue  `json:"rabbit.connection_max,omitempty"`
 	ChannelMax               int64                `json:"rabbit.channel_max"`
 	ConsumerTimeout          ConsumerTimeoutValue `json:"rabbit.consumer_timeout"`
 	VmMemoryHighWatermark    float64              `json:"rabbit.vm_memory_high_watermark"`

--- a/api/rabbitmq_configuration.go
+++ b/api/rabbitmq_configuration.go
@@ -3,109 +3,54 @@ package api
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	model "github.com/cloudamqp/terraform-provider-cloudamqp/api/models/instance/configuration"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func (api *API) ReadRabbitMqConfiguration(ctx context.Context, instanceID, sleep, timeout int) (
-	*model.RabbitMqConfigResponse, error) {
-
-	path := fmt.Sprintf("/api/instances/%d/config", instanceID)
-	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s sleep=%d timeout=%d ", path, sleep, timeout))
-	return api.readRabbitMqConfigurationWithRetry(ctx, path, 1, sleep, timeout)
-}
-
-func (api *API) readRabbitMqConfigurationWithRetry(ctx context.Context, path string, attempt, sleep,
-	timeout int) (*model.RabbitMqConfigResponse, error) {
+// ReadRabbitMqConfiguration - retrieves the RabbitMQ configuration for an instance
+func (api *API) ReadRabbitMqConfiguration(ctx context.Context, instanceID, sleep int) (*model.RabbitMqConfigResponse, error) {
 
 	var (
 		data   model.RabbitMqConfigResponse
 		failed map[string]any
+		path   = fmt.Sprintf("/api/instances/%d/config", instanceID)
 	)
 
-	response, err := api.sling.New().Get(path).Receive(&data, &failed)
+	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s ", path))
+	err := api.callWithRetry(ctx, api.sling.New().Get(path), retryRequest{
+		functionName: "ReadRabbitMqConfiguration",
+		resourceName: "RabbitMQConfiguration",
+		attempt:      1,
+		sleep:        time.Duration(sleep) * time.Second,
+		data:         &data,
+		failed:       &failed,
+	})
 	if err != nil {
 		return nil, err
-	} else if attempt*sleep > timeout {
-		return nil,
-			fmt.Errorf("timeout reached after %d seconds, while reading RabbitMQ", timeout)
 	}
 
-	switch response.StatusCode {
-	case 200:
-		tflog.Debug(ctx, fmt.Sprintf("response data: %v", data))
-		return &data, nil
-	case 404:
-		tflog.Warn(ctx, "RabbitMQ configuration not found")
-		return nil, nil
-	case 400:
-		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			tflog.Debug(ctx, fmt.Sprintf("timeout talking to backend, will try again, "+
-				"attempt=%d until_timeout=%d ", attempt, (timeout-(attempt*sleep))))
-			attempt++
-			time.Sleep(time.Duration(sleep) * time.Second)
-			return api.readRabbitMqConfigurationWithRetry(ctx, path, attempt, sleep, timeout)
-		}
-	case 503:
-		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			tflog.Debug(ctx, fmt.Sprintf("timeout talking to backend, will try again, "+
-				"attempt=%d until_timeout=%d ", attempt, (timeout-(attempt*sleep))))
-			attempt++
-			time.Sleep(time.Duration(sleep) * time.Second)
-			return api.readRabbitMqConfigurationWithRetry(ctx, path, attempt, sleep, timeout)
-		}
-	}
-	return nil,
-		fmt.Errorf("failed to read RabbitMQ configuration, status=%d message=%s ", response.StatusCode, failed)
+	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s data=%v ", path, data))
+	return &data, nil
 }
 
+// UpdateRabbitMqConfiguration - updates the RabbitMQ configuration for an instance
 func (api *API) UpdateRabbitMqConfiguration(ctx context.Context, instanceID int,
-	params model.RabbitMqConfigRequest, sleep, timeout int) error {
+	params model.RabbitMqConfigRequest, sleep int) error {
 
-	path := fmt.Sprintf("api/instances/%d/config", instanceID)
-	tflog.Debug(ctx, fmt.Sprintf("method=PUT path=%s sleep=%d timeout=%d params=%v", path, sleep,
-		timeout, params))
-	return api.updateRabbitMqConfigurationWithRetry(ctx, path, params, 1, sleep, timeout)
-}
+	var (
+		failed map[string]any
+		path   = fmt.Sprintf("/api/instances/%d/config", instanceID)
+	)
 
-func (api *API) updateRabbitMqConfigurationWithRetry(ctx context.Context, path string,
-	params model.RabbitMqConfigRequest, attempt, sleep, timeout int) error {
-
-	failed := make(map[string]any)
-	response, err := api.sling.New().Put(path).BodyJSON(params).Receive(nil, &failed)
-	if err != nil {
-		return err
-	} else if attempt*sleep > timeout {
-		return fmt.Errorf("timeout reached after %d seconds, while updating RabbitMQ", timeout)
-	}
-
-	switch response.StatusCode {
-	case 200:
-		return nil
-	case 400:
-		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			tflog.Debug(ctx, fmt.Sprintf("timeout talking to backend, will try again, "+
-				"attempt=%d until_timeout=%d ", attempt, (timeout-(attempt*sleep))))
-			attempt++
-			time.Sleep(time.Duration(sleep) * time.Second)
-			return api.updateRabbitMqConfigurationWithRetry(ctx, path, params, attempt, sleep, timeout)
-		}
-	case 503:
-		if strings.Compare(failed["error"].(string), "Timeout talking to backend") == 0 {
-			tflog.Debug(ctx, fmt.Sprintf("timeout talking to backend, will try again, "+
-				"attempt=%d until_timeout=%d ", attempt, (timeout-(attempt*sleep))))
-			attempt++
-			time.Sleep(time.Duration(sleep) * time.Second)
-			return api.updateRabbitMqConfigurationWithRetry(ctx, path, params, attempt, sleep, timeout)
-		}
-	}
-	return fmt.Errorf("failed to upgrade RabbitMQ configuration, status=%d message=%s ",
-		response.StatusCode, failed)
-}
-
-func (api *API) DeleteRabbitMqConfiguration() error {
-	return nil
+	tflog.Debug(ctx, fmt.Sprintf("method=PUT path=%s params=%v ", path, params))
+	return api.callWithRetry(ctx, api.sling.New().Put(path).BodyJSON(params), retryRequest{
+		functionName: "UpdateRabbitMqConfiguration",
+		resourceName: "RabbitMQConfiguration",
+		attempt:      1,
+		sleep:        time.Duration(sleep) * time.Second,
+		data:         nil,
+		failed:       &failed,
+	})
 }

--- a/cloudamqp/resource_cloudamqp_rabbitmq_configuration.go
+++ b/cloudamqp/resource_cloudamqp_rabbitmq_configuration.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -93,7 +92,6 @@ func (r *rabbitMqConfigurationResource) Schema(ctx context.Context, req resource
 			"connection_max": schema.Int64Attribute{
 				Optional:    true,
 				Computed:    true,
-				Default:     int64default.StaticInt64(-1),
 				Description: "Set the maximum permissible number of connections, -1 means infinity.",
 				Validators: []validator.Int64{
 					int64validator.AtLeast(-1),
@@ -191,18 +189,12 @@ func (r *rabbitMqConfigurationResource) Schema(ctx context.Context, req resource
 				Default:     int64default.StaticInt64(60),
 				Computed:    true,
 				Description: "Configurable sleep time in seconds between retries for RabbitMQ configuration",
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.UseStateForUnknown(),
-				},
 			},
 			"timeout": schema.Int64Attribute{
 				Optional:    true,
 				Default:     int64default.StaticInt64(3600),
 				Computed:    true,
 				Description: "Configurable timeout time in seconds for RabbitMQ configuration",
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.UseStateForUnknown(),
-				},
 			},
 		},
 	}
@@ -233,45 +225,8 @@ func (r *rabbitMqConfigurationResource) Create(ctx context.Context, req resource
 	instanceID := int(plan.InstanceID.ValueInt64())
 	sleep := int(plan.Sleep.ValueInt64())
 	timeout := int(plan.Timeout.ValueInt64())
+	data := r.populateCreateRequest(&plan)
 
-	data := model.RabbitMqConfigRequest{}
-	if !plan.Heartbeat.IsUnknown() {
-		data.Heartbeat = utils.Pointer(plan.Heartbeat.ValueInt64())
-	}
-	if !plan.ConnectionMax.IsUnknown() {
-		if plan.ConnectionMax.ValueInt64() == -1 {
-			data.ConnectionMax = &model.ConnectionMaxValue{IsInfinity: true}
-		} else {
-			data.ConnectionMax = &model.ConnectionMaxValue{IsInfinity: false, Value: plan.ConnectionMax.ValueInt64()}
-		}
-	}
-	if !plan.ChannelMax.IsUnknown() {
-		data.ChannelMax = utils.Pointer(plan.ChannelMax.ValueInt64())
-	}
-	if !plan.ConsumerTimeout.IsUnknown() {
-		if plan.ConsumerTimeout.ValueInt64() == -1 {
-			data.ConsumerTimeout = &model.ConsumerTimeoutValue{IsEnabled: false}
-		} else {
-			data.ConsumerTimeout = &model.ConsumerTimeoutValue{IsEnabled: true, Value: plan.ConsumerTimeout.ValueInt64()}
-		}
-	}
-	if !plan.VmMemoryHighWatermark.IsUnknown() {
-		data.VmMemoryHighWatermark = utils.Pointer(plan.VmMemoryHighWatermark.ValueFloat64())
-	}
-	if !plan.QueueIndexEmbedMsgsBelow.IsUnknown() {
-		data.QueueIndexEmbedMsgsBelow = utils.Pointer(plan.QueueIndexEmbedMsgsBelow.ValueInt64())
-	}
-	if !plan.MaxMessageSize.IsUnknown() {
-		data.MaxMessageSize = utils.Pointer(plan.MaxMessageSize.ValueInt64())
-	}
-	if !plan.LogExchangeLevel.IsUnknown() {
-		data.LogExchangeLevel = utils.Pointer(plan.LogExchangeLevel.ValueString())
-	}
-	if !plan.ClusterPartitionHandling.IsUnknown() {
-		data.ClusterPartitionHandling = utils.Pointer(plan.ClusterPartitionHandling.ValueString())
-	}
-
-	tflog.Debug(ctx, fmt.Sprintf("Creating RabbitMQ configuration for instance ID %d with data: %v", instanceID, data))
 	err := r.client.UpdateRabbitMqConfiguration(ctx, instanceID, data, sleep, timeout)
 	if err != nil {
 		resp.Diagnostics.AddError("API Error", fmt.Sprintf("Failed to create RabbitMQ configuration: %s", err.Error()))
@@ -289,8 +244,7 @@ func (r *rabbitMqConfigurationResource) Create(ctx context.Context, req resource
 		return
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Read RabbitMQ configuration data: %v", dataResp))
-	populateRabbitMqConfigModel(&plan, dataResp, instanceID, sleep, timeout)
+	r.populateRabbitMqConfigModel(&plan, dataResp, instanceID, sleep, timeout)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -303,7 +257,14 @@ func (r *rabbitMqConfigurationResource) Read(ctx context.Context, req resource.R
 
 	instanceID := int(state.InstanceID.ValueInt64())
 	sleep := int(state.Sleep.ValueInt64())
+	if sleep == 0 {
+		sleep = 60 // fallback default
+	}
+
 	timeout := int(state.Timeout.ValueInt64())
+	if timeout == 0 {
+		timeout = 3600 // fallback default
+	}
 
 	data, err := r.client.ReadRabbitMqConfiguration(ctx, instanceID, sleep, timeout)
 	if err != nil {
@@ -317,15 +278,15 @@ func (r *rabbitMqConfigurationResource) Read(ctx context.Context, req resource.R
 		return
 	}
 
-	tflog.Info(ctx, fmt.Sprintf("Read RabbitMQ configuration data: %v", data))
-
-	populateRabbitMqConfigModel(&state, data, instanceID, sleep, timeout)
+	r.populateRabbitMqConfigModel(&state, data, instanceID, sleep, timeout)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 func (r *rabbitMqConfigurationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan rabbitMqConfigurationResourceModel
+	var state rabbitMqConfigurationResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -333,43 +294,7 @@ func (r *rabbitMqConfigurationResource) Update(ctx context.Context, req resource
 	instanceID := int(plan.InstanceID.ValueInt64())
 	sleep := int(plan.Sleep.ValueInt64())
 	timeout := int(plan.Timeout.ValueInt64())
-
-	data := model.RabbitMqConfigRequest{}
-	if !plan.Heartbeat.IsNull() {
-		data.Heartbeat = utils.Pointer(plan.Heartbeat.ValueInt64())
-	}
-	if !plan.ConnectionMax.IsNull() {
-		if plan.ConnectionMax.ValueInt64() == -1 {
-			data.ConnectionMax = &model.ConnectionMaxValue{IsInfinity: true}
-		} else {
-			data.ConnectionMax = &model.ConnectionMaxValue{IsInfinity: false, Value: plan.ConnectionMax.ValueInt64()}
-		}
-	}
-	if !plan.ChannelMax.IsNull() {
-		data.ChannelMax = utils.Pointer(plan.ChannelMax.ValueInt64())
-	}
-	if !plan.ConsumerTimeout.IsNull() {
-		if plan.ConsumerTimeout.ValueInt64() == -1 {
-			data.ConsumerTimeout = &model.ConsumerTimeoutValue{IsEnabled: false}
-		} else {
-			data.ConsumerTimeout = &model.ConsumerTimeoutValue{IsEnabled: true, Value: plan.ConsumerTimeout.ValueInt64()}
-		}
-	}
-	if !plan.VmMemoryHighWatermark.IsNull() {
-		data.VmMemoryHighWatermark = utils.Pointer(plan.VmMemoryHighWatermark.ValueFloat64())
-	}
-	if !plan.QueueIndexEmbedMsgsBelow.IsNull() {
-		data.QueueIndexEmbedMsgsBelow = utils.Pointer(plan.QueueIndexEmbedMsgsBelow.ValueInt64())
-	}
-	if !plan.MaxMessageSize.IsNull() {
-		data.MaxMessageSize = utils.Pointer(plan.MaxMessageSize.ValueInt64())
-	}
-	if !plan.LogExchangeLevel.IsNull() {
-		data.LogExchangeLevel = utils.Pointer(plan.LogExchangeLevel.ValueString())
-	}
-	if !plan.ClusterPartitionHandling.IsNull() {
-		data.ClusterPartitionHandling = utils.Pointer(plan.ClusterPartitionHandling.ValueString())
-	}
+	data := r.populateUpdateRequest(&plan)
 
 	err := r.client.UpdateRabbitMqConfiguration(ctx, instanceID, data, sleep, timeout)
 	if err != nil {
@@ -388,17 +313,17 @@ func (r *rabbitMqConfigurationResource) Update(ctx context.Context, req resource
 		return
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Read RabbitMQ configuration data: %v", dataResp))
-	populateRabbitMqConfigModel(&plan, dataResp, instanceID, sleep, timeout)
+	r.populateRabbitMqConfigModel(&plan, dataResp, instanceID, sleep, timeout)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *rabbitMqConfigurationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	// No-op: configuration is not deleted from the server only removed from the state.
+	resp.State.RemoveResource(ctx)
 }
 
 func (r *rabbitMqConfigurationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	id := req.ID // This is a string
+	id := req.ID
 	instanceID, err := strconv.ParseInt(id, 10, 64)
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid import ID", fmt.Sprintf("Expected numeric instance_id, got: %q", id))
@@ -408,31 +333,140 @@ func (r *rabbitMqConfigurationResource) ImportState(ctx context.Context, req res
 	resp.State.SetAttribute(ctx, path.Root("instance_id"), instanceID)
 }
 
-// Helper to populate the resource model from the API response
-func populateRabbitMqConfigModel(model *rabbitMqConfigurationResourceModel, data *model.RabbitMqConfigResponse, instanceID, sleep, timeout int) {
-	model.ID = types.StringValue(strconv.Itoa(instanceID))
-	model.InstanceID = types.Int64Value(int64(instanceID))
-	model.Sleep = types.Int64Value(int64(sleep))
-	model.Timeout = types.Int64Value(int64(timeout))
-	model.Heartbeat = types.Int64Value(data.Heartbeat)
-	if data.ConnectionMax.IsInfinity {
-		model.ConnectionMax = types.Int64Value(-1)
+// Handle data conversion from API response to resource model
+func (r *rabbitMqConfigurationResource) populateRabbitMqConfigModel(resourceModel *rabbitMqConfigurationResourceModel,
+	data *model.RabbitMqConfigResponse, instanceID, sleep, timeout int) {
+
+	resourceModel.ID = types.StringValue(strconv.Itoa(instanceID))
+	resourceModel.InstanceID = types.Int64Value(int64(instanceID))
+	resourceModel.Sleep = types.Int64Value(int64(sleep))
+	resourceModel.Timeout = types.Int64Value(int64(timeout))
+	resourceModel.Heartbeat = types.Int64Value(data.Heartbeat)
+	resourceModel.ChannelMax = types.Int64Value(data.ChannelMax)
+	resourceModel.MaxMessageSize = types.Int64Value(data.MaxMessageSize)
+	resourceModel.LogExchangeLevel = types.StringValue(data.LogExchangeLevel)
+	resourceModel.ClusterPartitionHandling = types.StringValue(data.ClusterPartitionHandling)
+	resourceModel.VmMemoryHighWatermark = types.Float64Value(data.VmMemoryHighWatermark)
+
+	if data.ConnectionMax == nil {
+		resourceModel.ConnectionMax = types.Int64Value(-1) // Default value when not set
+	} else if data.ConnectionMax.IsInfinity {
+		resourceModel.ConnectionMax = types.Int64Value(-1)
 	} else {
-		model.ConnectionMax = types.Int64Value(data.ConnectionMax.Value)
+		resourceModel.ConnectionMax = types.Int64Value(data.ConnectionMax.Value)
 	}
-	model.ChannelMax = types.Int64Value(data.ChannelMax)
+
 	if !data.ConsumerTimeout.IsEnabled {
-		model.ConsumerTimeout = types.Int64Value(-1)
+		resourceModel.ConsumerTimeout = types.Int64Value(-1)
 	} else {
-		model.ConsumerTimeout = types.Int64Value(data.ConsumerTimeout.Value)
+		resourceModel.ConsumerTimeout = types.Int64Value(data.ConsumerTimeout.Value)
 	}
-	model.VmMemoryHighWatermark = types.Float64Value(data.VmMemoryHighWatermark)
+
 	if data.QueueIndexEmbedMsgsBelow == nil {
-		model.QueueIndexEmbedMsgsBelow = types.Int64Null()
+		resourceModel.QueueIndexEmbedMsgsBelow = types.Int64Value(4096) // Default value when not set
 	} else {
-		model.QueueIndexEmbedMsgsBelow = types.Int64Value(*data.QueueIndexEmbedMsgsBelow)
+		resourceModel.QueueIndexEmbedMsgsBelow = types.Int64Value(*data.QueueIndexEmbedMsgsBelow)
 	}
-	model.MaxMessageSize = types.Int64Value(data.MaxMessageSize)
-	model.LogExchangeLevel = types.StringValue(data.LogExchangeLevel)
-	model.ClusterPartitionHandling = types.StringValue(data.ClusterPartitionHandling)
+}
+
+// Handle data conversion from resource model to create API request
+func (r *rabbitMqConfigurationResource) populateCreateRequest(plan *rabbitMqConfigurationResourceModel) model.RabbitMqConfigRequest {
+	data := model.RabbitMqConfigRequest{}
+
+	if !plan.Heartbeat.IsUnknown() {
+		data.Heartbeat = utils.Pointer(plan.Heartbeat.ValueInt64())
+	}
+
+	if !plan.ConnectionMax.IsUnknown() {
+		if plan.ConnectionMax.ValueInt64() == -1 {
+			data.ConnectionMax = utils.Pointer(model.ConnectionMaxValue{IsInfinity: true})
+		} else {
+			data.ConnectionMax = utils.Pointer(model.ConnectionMaxValue{IsInfinity: false, Value: plan.ConnectionMax.ValueInt64()})
+		}
+	}
+
+	if !plan.ChannelMax.IsUnknown() {
+		data.ChannelMax = utils.Pointer(plan.ChannelMax.ValueInt64())
+	}
+
+	if !plan.ConsumerTimeout.IsUnknown() {
+		if plan.ConsumerTimeout.ValueInt64() == -1 {
+			data.ConsumerTimeout = utils.Pointer(model.ConsumerTimeoutValue{IsEnabled: false})
+		} else {
+			data.ConsumerTimeout = utils.Pointer(model.ConsumerTimeoutValue{IsEnabled: true, Value: plan.ConsumerTimeout.ValueInt64()})
+		}
+	}
+
+	if !plan.VmMemoryHighWatermark.IsUnknown() {
+		data.VmMemoryHighWatermark = utils.Pointer(plan.VmMemoryHighWatermark.ValueFloat64())
+	}
+
+	if !plan.QueueIndexEmbedMsgsBelow.IsUnknown() {
+		data.QueueIndexEmbedMsgsBelow = utils.Pointer(plan.QueueIndexEmbedMsgsBelow.ValueInt64())
+	}
+
+	if !plan.MaxMessageSize.IsUnknown() {
+		data.MaxMessageSize = utils.Pointer(plan.MaxMessageSize.ValueInt64())
+	}
+
+	if !plan.LogExchangeLevel.IsUnknown() {
+		data.LogExchangeLevel = plan.LogExchangeLevel.ValueString()
+	}
+
+	if !plan.ClusterPartitionHandling.IsUnknown() {
+		data.ClusterPartitionHandling = plan.ClusterPartitionHandling.ValueString()
+	}
+
+	return data
+}
+
+// Handle data conversion from resource model to update API request
+func (r *rabbitMqConfigurationResource) populateUpdateRequest(plan *rabbitMqConfigurationResourceModel) model.RabbitMqConfigRequest {
+	data := model.RabbitMqConfigRequest{}
+
+	if !plan.Heartbeat.IsNull() {
+		data.Heartbeat = utils.Pointer(plan.Heartbeat.ValueInt64())
+	}
+
+	if !plan.ConnectionMax.IsNull() {
+		if plan.ConnectionMax.ValueInt64() == -1 {
+			data.ConnectionMax = utils.Pointer(model.ConnectionMaxValue{IsInfinity: true})
+		} else {
+			data.ConnectionMax = utils.Pointer(model.ConnectionMaxValue{IsInfinity: false, Value: plan.ConnectionMax.ValueInt64()})
+		}
+	}
+
+	if !plan.ChannelMax.IsNull() {
+		data.ChannelMax = utils.Pointer(plan.ChannelMax.ValueInt64())
+	}
+
+	if !plan.ConsumerTimeout.IsNull() {
+		if plan.ConsumerTimeout.ValueInt64() == -1 {
+			data.ConsumerTimeout = utils.Pointer(model.ConsumerTimeoutValue{IsEnabled: false})
+		} else {
+			data.ConsumerTimeout = utils.Pointer(model.ConsumerTimeoutValue{IsEnabled: true, Value: plan.ConsumerTimeout.ValueInt64()})
+		}
+	}
+
+	if !plan.VmMemoryHighWatermark.IsNull() {
+		data.VmMemoryHighWatermark = utils.Pointer(plan.VmMemoryHighWatermark.ValueFloat64())
+	}
+
+	if !plan.QueueIndexEmbedMsgsBelow.IsNull() {
+		data.QueueIndexEmbedMsgsBelow = utils.Pointer(plan.QueueIndexEmbedMsgsBelow.ValueInt64())
+	}
+
+	if !plan.MaxMessageSize.IsNull() {
+		data.MaxMessageSize = utils.Pointer(plan.MaxMessageSize.ValueInt64())
+	}
+
+	if !plan.LogExchangeLevel.IsNull() {
+		data.LogExchangeLevel = plan.LogExchangeLevel.ValueString()
+	}
+
+	if !plan.ClusterPartitionHandling.IsNull() {
+		data.ClusterPartitionHandling = plan.ClusterPartitionHandling.ValueString()
+	}
+
+	return data
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Issue with resource drift while setting default values from schema.

Reference: #368

### WHAT is this pull request doing?

- Adds generic retry for client library
- Updates default values for sleep/timeout and set on import
- Remove default value for arguments in schema and set on import
- Restructure populating API response/request <-> resource model

### HOW can this pull request be tested?

Manual testing during development.