### PR TITLE
Fix: Avoid parallel test race condition in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,15 @@ jobs:
         with:
           go-version-file: .go-version
 
+      - uses: hashicorp/setup-terraform@v3
+        id: setup-terraform
+        with:
+          terraform_wrapper: false
+
       - name: Run tests
         run: make test
+        env:
+          TF_ACC_TERRAFORM_PATH: ${{ steps.setup-terraform.outputs.terraform_path }}
 
       - name: Build for single target with GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0


### PR DESCRIPTION
Pre-install Terraform binary to avoid 'text file busy' error when multiple parallel tests try to access shared temp binary installation.

Set TF_ACC_TERRAFORM_PATH to use pre-installed binary instead of letting terraform-plugin-testing framework download it per test.
