### PR TITLE
doc(prometheus): add the missing header

### DIFF
--- a/docs/resources/integration_metric_prometheus.md
+++ b/docs/resources/integration_metric_prometheus.md
@@ -1,3 +1,10 @@
+---
+layout: "cloudamqp"
+page_title: "CloudAMQP: cloudamqp_integration_metric_prometheus"
+description: |-
+  Creates and manages third party prometheus metrics integration for a CloudAMQP instance.
+---
+
 # cloudamqp_integration_metric_prometheus
 
 This resource allows you to create and manage Prometheus-compatible metric integrations for CloudAMQP instances. Currently supported integrations include New Relic v3, Datadog v3, Azure Monitor, Splunk v2, Dynatrace, CloudWatch v3, and Stackdriver v2.


### PR DESCRIPTION
We are using this provider with crossplane and used upjet to generate our [crossplane provider](https://github.com/Evaneos/provider-cloudamqp).

But this missing header is preventing us from updating to the latest version of this provider as the scraping fails with a parse error on the doc.