### PR TITLE
Fix: Handle more 400 responses with retry for VPC GCE peering

### DIFF
--- a/api/vpc_gcp_peering_withvpcid.go
+++ b/api/vpc_gcp_peering_withvpcid.go
@@ -50,25 +50,11 @@ func (api *API) UpdateVpcGcpPeeringWithVpcId(ctx context.Context, vpcID string, 
 }
 
 // RemoveVpcGcpPeeringWithVpcId: removes the VPC peering from the API
-func (api *API) RemoveVpcGcpPeeringWithVpcId(ctx context.Context, vpcID, peerID string) error {
-	var (
-		failed map[string]any
-		path   = fmt.Sprintf("/api/vpcs/%s/vpc-peering/%s", vpcID, peerID)
-	)
+func (api *API) RemoveVpcGcpPeeringWithVpcId(ctx context.Context, vpcID, peerID string, sleep, timeout int) error {
 
-	tflog.Debug(ctx, fmt.Sprintf("method=DELETE path=%s ", path))
-	response, err := api.sling.New().Delete(path).Receive(nil, &failed)
-	if err != nil {
-		return err
-	}
-
-	switch response.StatusCode {
-	case 204:
-		return nil
-	default:
-		return fmt.Errorf("failed to remove VPC peering, status=%d message=%s ",
-			response.StatusCode, failed)
-	}
+	path := fmt.Sprintf("/api/vpcs/%s/vpc-peering/%s", vpcID, peerID)
+	tflog.Debug(ctx, fmt.Sprintf("method=DELETE path=%s sleep=%d timeout=%d ", path, sleep, timeout))
+	return api.removeVpcGcpPeeringWithRetry(ctx, path, 1, sleep, timeout)
 }
 
 // ReadVpcGcpInfoWithVpcId: reads the VPC info from the API

--- a/cloudamqp/resource_cloudamqp_vpc_gcp_peering.go
+++ b/cloudamqp/resource_cloudamqp_vpc_gcp_peering.go
@@ -244,16 +244,18 @@ func resourceDeleteVpcGcpPeering(ctx context.Context, d *schema.ResourceData, me
 		api        = meta.(*api.API)
 		instanceID = d.Get("instance_id").(int)
 		vpcID      = d.Get("vpc_id").(string)
+		sleep      = d.Get("sleep").(int)
+		timeout    = d.Get("timeout").(int)
 	)
 
 	if instanceID == 0 && vpcID == "" {
 		return diag.Errorf("you need to specify either instance_id or vpc_id")
 	} else if instanceID != 0 {
-		if err := api.RemoveVpcGcpPeering(ctx, instanceID, d.Id()); err != nil {
+		if err := api.RemoveVpcGcpPeering(ctx, instanceID, d.Id(), sleep, timeout); err != nil {
 			return diag.FromErr(err)
 		}
 	} else if vpcID != "" {
-		if err := api.RemoveVpcGcpPeeringWithVpcId(ctx, vpcID, d.Id()); err != nil {
+		if err := api.RemoveVpcGcpPeeringWithVpcId(ctx, vpcID, d.Id(), sleep, timeout); err != nil {
 			return diag.FromErr(err)
 		}
 	} else {


### PR DESCRIPTION
### WHY are these changes introduced?

Found more cases that need retries.

### WHAT is this pull request doing?

Add more cases when the peering need to be retried.

- While firewall configuration is currently ongoing
- Another peering operation in progress

Also add retry when removing a peering.

### HOW was this pull request be tested?

Manual runs locally