### PR TITLE
Clean up the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ instance before a new one is created. All data will be lost and a new hostname w
 
 ---
 
-### Debug Logging
+## Debug Logging
 
 Enable detailed debug output (includes CloudAMQP provider and underlying HTTP client logs):
 


### PR DESCRIPTION
Spring cleaning of README file with Claude. Rewrote the README top-to-bottom to make it easier to follow for both Terraform users and contributors.

Complete change can be found here: [README](https://github.com/cloudamqp/terraform-provider-cloudamqp/blob/clean-readme/README.md)