### PR TITLE
Migrate cloudamqp_alarm resource/data sources towards Terraform plugin framework

### DIFF
--- a/api/alarms.go
+++ b/api/alarms.go
@@ -6,19 +6,19 @@ import (
 	"strconv"
 	"time"
 
+	model "github.com/cloudamqp/terraform-provider-cloudamqp/api/models/monitoring"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func (api *API) CreateAlarm(ctx context.Context, instanceID int, params map[string]any) (
-	map[string]any, error) {
+func (api *API) CreateAlarm(ctx context.Context, instanceID int64, params model.AlarmRequest) (string, error) {
 
 	var (
-		data   map[string]any
+		data   model.AlarmResponse
 		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/alarms", instanceID)
 	)
 
-	tflog.Debug(ctx, fmt.Sprintf("method=POST path=%s", path), params)
+	tflog.Info(ctx, fmt.Sprintf("method=POST path=%s params=%+v", path, params))
 	err := api.callWithRetry(ctx, api.sling.New().Post(path).BodyJSON(params), retryRequest{
 		functionName: "CreateAlarm",
 		resourceName: "Alarm",
@@ -28,27 +28,22 @@ func (api *API) CreateAlarm(ctx context.Context, instanceID int, params map[stri
 		failed:       &failed,
 	})
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	if id, ok := data["id"]; ok {
-		data["id"] = strconv.FormatFloat(id.(float64), 'f', 0, 64)
-	} else {
-		return nil, fmt.Errorf("invalid identifier=%v", data["id"])
-	}
-	return data, nil
+	id := strconv.FormatInt(data.ID, 10)
+	return id, nil
 }
 
-func (api *API) ReadAlarm(ctx context.Context, instanceID int, alarmID string) (
-	map[string]any, error) {
+func (api *API) ReadAlarm(ctx context.Context, instanceID int64, alarmID string) (*model.AlarmResponse, error) {
 
 	var (
-		data   map[string]any
+		data   *model.AlarmResponse
 		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/alarms/%s", instanceID, alarmID)
 	)
 
-	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s", path))
+	tflog.Info(ctx, fmt.Sprintf("method=GET path=%s", path))
 	err := api.callWithRetry(ctx, api.sling.New().Get(path), retryRequest{
 		functionName: "ReadAlarm",
 		resourceName: "Alarm",
@@ -61,22 +56,22 @@ func (api *API) ReadAlarm(ctx context.Context, instanceID int, alarmID string) (
 		return nil, err
 	}
 
+	tflog.Info(ctx, fmt.Sprintf("method=GET path=%s data=%+v", path, data))
 	// Handle resource drift
-	if len(data) == 0 {
+	if data == nil {
 		return nil, nil
 	}
-
 	return data, nil
 }
 
-func (api *API) ListAlarms(ctx context.Context, instanceID int) ([]map[string]any, error) {
+func (api *API) ListAlarms(ctx context.Context, instanceID int64) ([]model.AlarmResponse, error) {
 	var (
-		data   []map[string]any
+		data   []model.AlarmResponse
 		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/alarms", instanceID)
 	)
 
-	tflog.Debug(ctx, fmt.Sprintf("method=GET path=%s", path))
+	tflog.Info(ctx, fmt.Sprintf("method=GET path=%s", path))
 	err := api.callWithRetry(ctx, api.sling.New().Get(path), retryRequest{
 		functionName: "ListAlarms",
 		resourceName: "Alarm",
@@ -89,17 +84,18 @@ func (api *API) ListAlarms(ctx context.Context, instanceID int) ([]map[string]an
 		return nil, err
 	}
 
+	tflog.Debug(ctx, fmt.Sprintf("response data=%+v", data))
 	return data, nil
 }
 
-func (api *API) UpdateAlarm(ctx context.Context, instanceID int, params map[string]any) error {
+func (api *API) UpdateAlarm(ctx context.Context, instanceID int64, alarmID string, params model.AlarmRequest) error {
 	var (
 		failed map[string]any
-		path   = fmt.Sprintf("/api/instances/%d/alarms/%s", instanceID, params["id"].(string))
+		path   = fmt.Sprintf("/api/instances/%d/alarms/%s", instanceID, alarmID)
 	)
 
-	tflog.Debug(ctx, fmt.Sprintf("method=PUT path=%s", path), params)
-	return api.callWithRetry(ctx, api.sling.New().Put(path).BodyJSON(params), retryRequest{
+	tflog.Info(ctx, fmt.Sprintf("method=PUT path=%s params=%+v", path, params))
+	err := api.callWithRetry(ctx, api.sling.New().Put(path).BodyJSON(params), retryRequest{
 		functionName: "UpdateAlarm",
 		resourceName: "Alarm",
 		attempt:      1,
@@ -107,16 +103,20 @@ func (api *API) UpdateAlarm(ctx context.Context, instanceID int, params map[stri
 		data:         nil,
 		failed:       &failed,
 	})
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
-func (api *API) DeleteAlarm(ctx context.Context, instanceID int, alarmID string) error {
+func (api *API) DeleteAlarm(ctx context.Context, instanceID int64, alarmID string) error {
 	var (
 		failed map[string]any
 		path   = fmt.Sprintf("/api/instances/%d/alarms/%s", instanceID, alarmID)
 	)
 
-	tflog.Debug(ctx, fmt.Sprintf("method=DELETE path=%s", path))
-	return api.callWithRetry(ctx, api.sling.New().Delete(path), retryRequest{
+	tflog.Info(ctx, fmt.Sprintf("method=DELETE path=%s", path))
+	err := api.callWithRetry(ctx, api.sling.New().Delete(path), retryRequest{
 		functionName: "DeleteAlarm",
 		resourceName: "Alarm",
 		attempt:      1,
@@ -124,4 +124,8 @@ func (api *API) DeleteAlarm(ctx context.Context, instanceID int, alarmID string)
 		data:         nil,
 		failed:       &failed,
 	})
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/api/models/monitoring/alarm.go
+++ b/api/models/monitoring/alarm.go
@@ -1,0 +1,28 @@
+package monitoring
+
+type AlarmRequest struct {
+	Type             string   `json:"type"`
+	Enabled          bool     `json:"enabled"`
+	ReminderInterval *int64   `json:"reminder_interval,omitempty"`
+	ValueThreshold   *int64   `json:"value_threshold,omitempty"`
+	ValueCalculation string   `json:"value_calculation,omitempty"`
+	TimeThreshold    *int64   `json:"time_threshold,omitempty"`
+	VhostRegex       string   `json:"vhost_regex,omitempty"`
+	QueueRegex       string   `json:"queue_regex,omitempty"`
+	MessageType      string   `json:"message_type,omitempty"`
+	Recipients       *[]int64 `json:"recipients,omitempty"`
+}
+
+type AlarmResponse struct {
+	ID               int64    `json:"id"`
+	Type             string   `json:"type"`
+	Enabled          bool     `json:"enabled"`
+	ReminderInterval *int64   `json:"reminder_interval,omitempty"`
+	ValueThreshold   *int64   `json:"value_threshold,omitempty"`
+	ValueCalculation *string  `json:"value_calculation,omitempty"`
+	TimeThreshold    *int64   `json:"time_threshold,omitempty"`
+	VhostRegex       *string  `json:"vhost_regex,omitempty"`
+	QueueRegex       *string  `json:"queue_regex,omitempty"`
+	MessageType      *string  `json:"message_type,omitempty"`
+	Recipients       *[]int64 `json:"recipients,omitempty"`
+}

--- a/cloudamqp/data_source_cloudamqp_alarm.go
+++ b/cloudamqp/data_source_cloudamqp_alarm.go
@@ -3,140 +3,252 @@ package cloudamqp
 import (
 	"context"
 	"fmt"
-	"strconv"
+	"time"
 
 	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	model "github.com/cloudamqp/terraform-provider-cloudamqp/api/models/monitoring"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func dataSourceAlarm() *schema.Resource {
-	return &schema.Resource{
-		ReadContext: dataSourceAlarmRead,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Schema: map[string]*schema.Schema{
-			"instance_id": {
-				Type:        schema.TypeInt,
+var (
+	_ datasource.DataSource              = &alarmDataSource{}
+	_ datasource.DataSourceWithConfigure = &alarmDataSource{}
+)
+
+type alarmDataSource struct {
+	client *api.API
+}
+
+func NewAlarmDataSource() datasource.DataSource {
+	return &alarmDataSource{}
+}
+
+type alarmDataSourceModel struct {
+	ID               types.String `tfsdk:"id"`
+	InstanceID       types.Int64  `tfsdk:"instance_id"`
+	AlarmID          types.Int64  `tfsdk:"alarm_id"`
+	Type             types.String `tfsdk:"type"`
+	Enabled          types.Bool   `tfsdk:"enabled"`
+	ReminderInterval types.Int64  `tfsdk:"reminder_interval"`
+	ValueThreshold   types.Int64  `tfsdk:"value_threshold"`
+	ValueCalculation types.String `tfsdk:"value_calculation"`
+	TimeThreshold    types.Int64  `tfsdk:"time_threshold"`
+	VhostRegex       types.String `tfsdk:"vhost_regex"`
+	QueueRegex       types.String `tfsdk:"queue_regex"`
+	MessageType      types.String `tfsdk:"message_type"`
+	Recipients       types.List   `tfsdk:"recipients"`
+}
+
+func (d *alarmDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "cloudamqp_alarm"
+}
+
+func (d *alarmDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:        "Use this data source to retrieve information about default or created alarms. Either use alarm_id or type to retrieve the alarm.",
+		DeprecationMessage: "Use 'cloudamqp_alarms' data source instead. This data source will be removed in a future version.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The identifier for this data source",
+			},
+			"instance_id": schema.Int64Attribute{
 				Required:    true,
 				Description: "Instance identifier",
 			},
-			"alarm_id": {
-				Type:        schema.TypeInt,
+			"alarm_id": schema.Int64Attribute{
 				Optional:    true,
 				Description: "Alarm identifier",
+				Validators: []validator.Int64{
+					int64validator.ConflictsWith(path.MatchRoot("type")),
+				},
 			},
-			"type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Type of the alarm",
-				ValidateDiagFunc: validateAlarmType(),
+			"type": schema.StringAttribute{
+				Optional:    true,
+				Description: "Type of the alarm",
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						"cpu",
+						"memory",
+						"disk",
+						"queue",
+						"connection",
+						"flow",
+						"consumer",
+						"netsplit",
+						"ssh",
+						"notice",
+						"server_unreachable",
+					),
+					stringvalidator.ConflictsWith(path.MatchRoot("alarm_id")),
+				},
 			},
-			"enabled": {
-				Type:        schema.TypeBool,
+			"enabled": schema.BoolAttribute{
 				Computed:    true,
 				Description: "Enable or disable an alarm",
 			},
-			"reminder_interval": {
-				Type:        schema.TypeInt,
+			"reminder_interval": schema.Int64Attribute{
 				Computed:    true,
 				Description: "The reminder interval (in seconds) to resend the alarm if not resolved. Set to 0 for no reminders",
 			},
-			"value_threshold": {
-				Type:        schema.TypeInt,
+			"value_threshold": schema.Int64Attribute{
 				Computed:    true,
 				Description: "What value to trigger the alarm for",
 			},
-			"value_calculation": {
-				Type:        schema.TypeString,
-				Optional:    true,
+			"value_calculation": schema.StringAttribute{
+				Computed:    true,
 				Description: "Disk value threshold calculation. Fixed or percentage of disk space remaining",
 			},
-			"time_threshold": {
-				Type:        schema.TypeInt,
+			"time_threshold": schema.Int64Attribute{
 				Computed:    true,
 				Description: "For how long (in seconds) the value_threshold should be active before trigger alarm",
 			},
-			"vhost_regex": {
-				Type:        schema.TypeString,
+			"vhost_regex": schema.StringAttribute{
 				Computed:    true,
 				Description: "Regex for which vhost the queues are in",
 			},
-			"queue_regex": {
-				Type:        schema.TypeString,
+			"queue_regex": schema.StringAttribute{
 				Computed:    true,
 				Description: "Regex for which queues to check",
 			},
-			"message_type": {
-				Type:        schema.TypeString,
+			"message_type": schema.StringAttribute{
 				Computed:    true,
 				Description: "Message types (total, unacked, ready) of the queue to trigger the alarm",
 			},
-			"recipients": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeInt,
-				},
+			"recipients": schema.ListAttribute{
+				ElementType: types.Int64Type,
+				Computed:    true,
 				Description: "Identifiers for recipients to be notified.",
 			},
 		},
 	}
 }
 
-func dataSourceAlarmRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	var (
-		data       map[string]any
-		instanceID = d.Get("instance_id").(int)
-		err        error
-	)
+func (d *alarmDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*api.API)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *api.API, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}
 
-	// Multiple purpose read. To be used when using data source either by declaring alarm id or type.
-	if d.Get("alarm_id") != 0 {
-		data, err = dataSourceAlarmIDRead(ctx, instanceID, d.Get("alarm_id").(int), meta)
-	} else if d.Get("type") != "" {
-		data, err = dataSourceAlarmTypeRead(ctx, instanceID, d.Get("type").(string), meta)
+func (d *alarmDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config alarmDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if err != nil {
-		return diag.FromErr(err)
+	if config.AlarmID.IsNull() && config.Type.IsNull() {
+		resp.Diagnostics.AddError(
+			"Either alarm_id or type must be specified",
+			"Please specify at least one of the attributes to lookup the alarm.",
+		)
+		return
 	}
-	d.SetId(fmt.Sprintf("%v", data["id"]))
-	d.Set("alarm_id", data["id"])
-	for k, v := range data {
-		if validateAlarmSchemaAttribute(k) {
-			if err = d.Set(k, v); err != nil {
-				return diag.Errorf("error setting %s for resource %s: %s", k, d.Id(), err)
+
+	instanceID := config.InstanceID.ValueInt64()
+	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	if !config.AlarmID.IsNull() {
+		alarmID := fmt.Sprintf("%d", config.AlarmID.ValueInt64())
+		alarm, err := d.client.ReadAlarm(timeoutCtx, instanceID, alarmID)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Failed to Read Alarm by ID",
+				fmt.Sprintf("Could not read alarm with ID %s for instance %d: %s", alarmID, instanceID, err.Error()),
+			)
+			return
+		}
+		d.populateResourceModel(ctx, *alarm, &config)
+	} else if !config.Type.IsNull() {
+		alarmType := config.Type.ValueString()
+		alarms, err := d.client.ListAlarms(timeoutCtx, instanceID)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Failed to Read Alarm by Type",
+				fmt.Sprintf("Could not read alarm with type %s for instance %d: %s", alarmType, instanceID, err.Error()),
+			)
+			return
+		}
+
+		for _, alarm := range alarms {
+			if alarm.Type == alarmType {
+				d.populateResourceModel(ctx, alarm, &config)
+				break
 			}
 		}
 	}
 
-	return diag.Diagnostics{}
+	config.ID = types.StringValue(fmt.Sprintf("%d", config.AlarmID.ValueInt64()))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
 }
 
-func dataSourceAlarmIDRead(ctx context.Context, instanceID int, alarmID int, meta any) (
-	map[string]any, error) {
+func (d *alarmDataSource) populateResourceModel(ctx context.Context, data model.AlarmResponse, config *alarmDataSourceModel) {
+	config.AlarmID = types.Int64Value(int64(data.ID))
+	config.Type = types.StringValue(data.Type)
+	config.Enabled = types.BoolValue(data.Enabled)
 
-	api := meta.(*api.API)
-	id := strconv.Itoa(alarmID)
-	alarm, err := api.ReadAlarm(ctx, instanceID, id)
-	return alarm, err
-}
-
-func dataSourceAlarmTypeRead(ctx context.Context, instanceID int, alarmType string,
-	meta any) (map[string]any, error) {
-
-	api := meta.(*api.API)
-	alarms, err := api.ListAlarms(ctx, instanceID)
-
-	if err != nil {
-		return nil, err
+	if data.ReminderInterval != nil {
+		config.ReminderInterval = types.Int64Value(*data.ReminderInterval)
+	} else {
+		config.ReminderInterval = types.Int64Null()
 	}
-	for _, alarm := range alarms {
-		if alarm["type"] == alarmType {
-			return alarm, nil
-		}
+
+	if data.ValueThreshold != nil {
+		config.ValueThreshold = types.Int64Value(*data.ValueThreshold)
+	} else {
+		config.ValueThreshold = types.Int64Null()
 	}
-	return nil, nil
+
+	if data.ValueCalculation != nil {
+		config.ValueCalculation = types.StringValue(*data.ValueCalculation)
+	} else {
+		config.ValueCalculation = types.StringNull()
+	}
+
+	if data.TimeThreshold != nil {
+		config.TimeThreshold = types.Int64Value(*data.TimeThreshold)
+	} else {
+		config.TimeThreshold = types.Int64Null()
+	}
+
+	if data.VhostRegex != nil {
+		config.VhostRegex = types.StringValue(*data.VhostRegex)
+	} else {
+		config.VhostRegex = types.StringNull()
+	}
+
+	if data.QueueRegex != nil {
+		config.QueueRegex = types.StringValue(*data.QueueRegex)
+	} else {
+		config.QueueRegex = types.StringNull()
+	}
+
+	if data.MessageType != nil {
+		config.MessageType = types.StringValue(*data.MessageType)
+	} else {
+		config.MessageType = types.StringNull()
+	}
+
+	if data.Recipients != nil {
+		recipientsList, _ := types.ListValueFrom(ctx, types.Int64Type, *data.Recipients)
+		config.Recipients = recipientsList
+	} else {
+		config.Recipients = types.ListNull(types.Int64Type)
+	}
 }

--- a/cloudamqp/data_source_cloudamqp_alarm.go
+++ b/cloudamqp/data_source_cloudamqp_alarm.go
@@ -199,7 +199,7 @@ func (d *alarmDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 }
 
 func (d *alarmDataSource) populateResourceModel(ctx context.Context, data model.AlarmResponse, config *alarmDataSourceModel) {
-	config.AlarmID = types.Int64Value(int64(data.ID))
+	config.AlarmID = types.Int64Value(data.ID)
 	config.Type = types.StringValue(data.Type)
 	config.Enabled = types.BoolValue(data.Enabled)
 

--- a/cloudamqp/data_source_cloudamqp_alarms.go
+++ b/cloudamqp/data_source_cloudamqp_alarms.go
@@ -3,93 +3,134 @@ package cloudamqp
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	model "github.com/cloudamqp/terraform-provider-cloudamqp/api/models/monitoring"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func dataSourceAlarms() *schema.Resource {
-	return &schema.Resource{
-		ReadContext: dataSourceAlarmsRead,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Schema: map[string]*schema.Schema{
-			"instance_id": {
-				Type:        schema.TypeInt,
+var (
+	_ datasource.DataSource              = &alarmsDataSource{}
+	_ datasource.DataSourceWithConfigure = &alarmsDataSource{}
+)
+
+type alarmsDataSource struct {
+	client *api.API
+}
+
+func NewAlarmsDataSource() datasource.DataSource {
+	return &alarmsDataSource{}
+}
+
+type alarmsDataSourceModel struct {
+	ID         types.String          `tfsdk:"id"`
+	InstanceID types.Int64           `tfsdk:"instance_id"`
+	Type       types.String          `tfsdk:"type"`
+	Alarms     []alarmDataSourceItem `tfsdk:"alarms"`
+}
+
+type alarmDataSourceItem struct {
+	AlarmID          types.Int64  `tfsdk:"alarm_id"`
+	Type             types.String `tfsdk:"type"`
+	Enabled          types.Bool   `tfsdk:"enabled"`
+	ReminderInterval types.Int64  `tfsdk:"reminder_interval"`
+	ValueThreshold   types.Int64  `tfsdk:"value_threshold"`
+	ValueCalculation types.String `tfsdk:"value_calculation"`
+	TimeThreshold    types.Int64  `tfsdk:"time_threshold"`
+	VhostRegex       types.String `tfsdk:"vhost_regex"`
+	QueueRegex       types.String `tfsdk:"queue_regex"`
+	MessageType      types.String `tfsdk:"message_type"`
+	Recipients       types.List   `tfsdk:"recipients"`
+}
+
+func (d *alarmsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "cloudamqp_alarms"
+}
+
+func (d *alarmsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to retrieve a list of pre-defined or created alarms.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The identifier for this data source",
+			},
+			"instance_id": schema.Int64Attribute{
 				Required:    true,
 				Description: "Instance identifier",
 			},
-			"type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Type of the alarm",
-				ValidateDiagFunc: validateAlarmType(),
+			"type": schema.StringAttribute{
+				Optional:    true,
+				Description: "Type of the alarm to filter by",
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						"cpu",
+						"memory",
+						"disk",
+						"queue",
+						"connection",
+						"flow",
+						"consumer",
+						"netsplit",
+						"ssh",
+						"notice",
+						"server_unreachable",
+					),
+				},
 			},
-			"alarms": {
-				Type:        schema.TypeList,
-				Computed:    true,
-				Description: "List of alarms",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"alarm_id": {
-							Type:        schema.TypeInt,
-							Optional:    true,
+		},
+		Blocks: map[string]schema.Block{
+			"alarms": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"alarm_id": schema.Int64Attribute{
+							Computed:    true,
 							Description: "Alarm identifier",
 						},
-						"type": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Description:      "Type of the alarm",
-							ValidateDiagFunc: validateAlarmType(),
+						"type": schema.StringAttribute{
+							Computed:    true,
+							Description: "Type of the alarm",
 						},
-						"enabled": {
-							Type:        schema.TypeBool,
+						"enabled": schema.BoolAttribute{
 							Computed:    true,
 							Description: "Enable or disable an alarm",
 						},
-						"reminder_interval": {
-							Type:        schema.TypeInt,
+						"reminder_interval": schema.Int64Attribute{
 							Computed:    true,
 							Description: "The reminder interval (in seconds) to resend the alarm if not resolved. Set to 0 for no reminders",
 						},
-						"value_threshold": {
-							Type:        schema.TypeInt,
+						"value_threshold": schema.Int64Attribute{
 							Computed:    true,
 							Description: "What value to trigger the alarm for",
 						},
-						"value_calculation": {
-							Type:        schema.TypeString,
-							Optional:    true,
+						"value_calculation": schema.StringAttribute{
+							Computed:    true,
 							Description: "Disk value threshold calculation. Fixed or percentage of disk space remaining",
 						},
-						"time_threshold": {
-							Type:        schema.TypeInt,
+						"time_threshold": schema.Int64Attribute{
 							Computed:    true,
 							Description: "For how long (in seconds) the value_threshold should be active before trigger alarm",
 						},
-						"vhost_regex": {
-							Type:        schema.TypeString,
+						"vhost_regex": schema.StringAttribute{
 							Computed:    true,
 							Description: "Regex for which vhost the queues are in",
 						},
-						"queue_regex": {
-							Type:        schema.TypeString,
+						"queue_regex": schema.StringAttribute{
 							Computed:    true,
 							Description: "Regex for which queues to check",
 						},
-						"message_type": {
-							Type:        schema.TypeString,
+						"message_type": schema.StringAttribute{
 							Computed:    true,
 							Description: "Message types (total, unacked, ready) of the queue to trigger the alarm",
 						},
-						"recipients": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeInt,
-							},
+						"recipients": schema.ListAttribute{
+							ElementType: types.Int64Type,
+							Computed:    true,
 							Description: "Identifiers for recipients to be notified.",
 						},
 					},
@@ -99,53 +140,112 @@ func dataSourceAlarms() *schema.Resource {
 	}
 }
 
-func dataSourceAlarmsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	var (
-		data       []map[string]any
-		instanceID = d.Get("instance_id").(int)
-		err        error
-	)
-
-	api := meta.(*api.API)
-	data, err = api.ListAlarms(ctx, instanceID)
-
-	if err != nil {
-		return diag.FromErr(err)
+func (d *alarmsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
 	}
-
-	if d.Get("type") != "" {
-		d.SetId(fmt.Sprintf("%v.%v.alarms", instanceID, d.Get("type")))
-		filteredAlarms := make([]map[string]any, 0)
-		for _, alarm := range data {
-			if alarm["type"] == d.Get("type") {
-				filteredAlarms = append(filteredAlarms, alarm)
-			}
-		}
-		data = filteredAlarms
-	} else {
-		d.SetId(fmt.Sprintf("%v.alarms", instanceID))
+	client, ok := req.ProviderData.(*api.API)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *api.API, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
 	}
-
-	alarms := make([]map[string]any, len(data))
-	for k, v := range data {
-		alarms[k] = readAlarm(v)
-	}
-
-	if err = d.Set("alarms", alarms); err != nil {
-		return diag.Errorf("error setting alarms for resource %s: %s", d.Id(), err)
-	}
-
-	return diag.Diagnostics{}
+	d.client = client
 }
 
-func readAlarm(data map[string]any) map[string]any {
-	alarm := make(map[string]any)
-	for k, v := range data {
-		if k == "id" {
-			alarm["alarm_id"] = int(v.(float64))
-		} else if validateAlarmSchemaAttribute(k) {
-			alarm[k] = v
-		}
+func (d *alarmsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config alarmsDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
+
+	instanceID := config.InstanceID.ValueInt64()
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	alarms, err := d.client.ListAlarms(timeoutCtx, instanceID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to List Alarms",
+			fmt.Sprintf("Could not list alarms: %s", err),
+		)
+		return
+	}
+
+	if !config.Type.IsNull() {
+		for _, alarm := range alarms {
+			if alarm.Type == config.Type.ValueString() {
+				config.Alarms = append(config.Alarms, d.populateResourceModel(ctx, alarm))
+			}
+		}
+		config.ID = types.StringValue(fmt.Sprintf("%d.%s.alarms", instanceID, config.Type.ValueString()))
+	} else {
+		for _, alarm := range alarms {
+			config.Alarms = append(config.Alarms, d.populateResourceModel(ctx, alarm))
+		}
+		config.ID = types.StringValue(fmt.Sprintf("%d.alarms", instanceID))
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}
+
+func (d *alarmsDataSource) populateResourceModel(ctx context.Context, data model.AlarmResponse) alarmDataSourceItem {
+	alarm := alarmDataSourceItem{}
+	alarm.AlarmID = types.Int64Value(int64(data.ID))
+	alarm.Type = types.StringValue(data.Type)
+	alarm.Enabled = types.BoolValue(data.Enabled)
+
+	if data.ReminderInterval != nil {
+		alarm.ReminderInterval = types.Int64Value(*data.ReminderInterval)
+	} else {
+		alarm.ReminderInterval = types.Int64Null()
+	}
+
+	if data.ValueThreshold != nil {
+		alarm.ValueThreshold = types.Int64Value(*data.ValueThreshold)
+	} else {
+		alarm.ValueThreshold = types.Int64Null()
+	}
+
+	if data.ValueCalculation != nil {
+		alarm.ValueCalculation = types.StringValue(*data.ValueCalculation)
+	} else {
+		alarm.ValueCalculation = types.StringNull()
+	}
+
+	if data.TimeThreshold != nil {
+		alarm.TimeThreshold = types.Int64Value(*data.TimeThreshold)
+	} else {
+		alarm.TimeThreshold = types.Int64Null()
+	}
+
+	if data.VhostRegex != nil {
+		alarm.VhostRegex = types.StringValue(*data.VhostRegex)
+	} else {
+		alarm.VhostRegex = types.StringNull()
+	}
+
+	if data.QueueRegex != nil {
+		alarm.QueueRegex = types.StringValue(*data.QueueRegex)
+	} else {
+		alarm.QueueRegex = types.StringNull()
+	}
+
+	if data.MessageType != nil {
+		alarm.MessageType = types.StringValue(*data.MessageType)
+	} else {
+		alarm.MessageType = types.StringNull()
+	}
+
+	if data.Recipients != nil {
+		recipientsList, _ := types.ListValueFrom(ctx, types.Int64Type, *data.Recipients)
+		alarm.Recipients = recipientsList
+	} else {
+		alarm.Recipients = types.ListNull(types.Int64Type)
+	}
+
 	return alarm
 }

--- a/cloudamqp/provider.go
+++ b/cloudamqp/provider.go
@@ -96,18 +96,22 @@ func (p *cloudamqpProvider) Configure(ctx context.Context, request provider.Conf
 }
 
 func (p *cloudamqpProvider) DataSources(_ context.Context) []func() datasource.DataSource {
-	return []func() datasource.DataSource{}
+	return []func() datasource.DataSource{
+		NewAlarmDataSource,
+		NewAlarmsDataSource,
+	}
 }
 
 func (p *cloudamqpProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewAccountActionsResource,
+		NewAlarmResource,
 		NewAwsEventBridgeResource,
 		NewCustomCertificateResource,
 		NewIntegrationLogResource,
 		NewIntegrationMetricResource,
 		NewNodeActionsResource,
-    NewOAuth2ConfigurationResource,
+		NewOAuth2ConfigurationResource,
 		NewRabbitMqConfigurationResource,
 		NewTrustStoreResource,
 		NewVpcResource,
@@ -147,8 +151,6 @@ func Provider(v string, client *http.Client) *schemaSdk.Provider {
 		DataSourcesMap: map[string]*schemaSdk.Resource{
 			"cloudamqp_account_vpcs":        dataSourceAccountVpcs(),
 			"cloudamqp_account":             dataSourceAccount(),
-			"cloudamqp_alarm":               dataSourceAlarm(),
-			"cloudamqp_alarms":              dataSourceAlarms(),
 			"cloudamqp_credentials":         dataSourceCredentials(),
 			"cloudamqp_instance":            dataSourceInstance(),
 			"cloudamqp_nodes":               dataSourceNodes(),
@@ -161,7 +163,6 @@ func Provider(v string, client *http.Client) *schemaSdk.Provider {
 			"cloudamqp_vpc_info":            dataSourceVpcInfo(),
 		},
 		ResourcesMap: map[string]*schemaSdk.Resource{
-			"cloudamqp_alarm":                         resourceAlarm(),
 			"cloudamqp_custom_domain":                 resourceCustomDomain(),
 			"cloudamqp_extra_disk_size":               resourceExtraDiskSize(),
 			"cloudamqp_instance":                      resourceInstance(),

--- a/cloudamqp/resource_cloudamqp_alarm.go
+++ b/cloudamqp/resource_cloudamqp_alarm.go
@@ -5,259 +5,425 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
+	model "github.com/cloudamqp/terraform-provider-cloudamqp/api/models/monitoring"
+	"github.com/cloudamqp/terraform-provider-cloudamqp/cloudamqp/utils"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func resourceAlarm() *schema.Resource {
-	return &schema.Resource{
-		CreateContext: resourceAlarmCreate,
-		ReadContext:   resourceAlarmRead,
-		UpdateContext: resourceAlarmUpdate,
-		DeleteContext: resourceAlarmDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Schema: map[string]*schema.Schema{
-			"instance_id": {
-				Type:        schema.TypeInt,
+var (
+	_ resource.Resource                = &alarmResource{}
+	_ resource.ResourceWithConfigure   = &alarmResource{}
+	_ resource.ResourceWithImportState = &alarmResource{}
+)
+
+type alarmResource struct {
+	client *api.API
+}
+
+func NewAlarmResource() resource.Resource {
+	return &alarmResource{}
+}
+
+type alarmResourceModel struct {
+	ID               types.String `tfsdk:"id"`
+	InstanceID       types.Int64  `tfsdk:"instance_id"`
+	Type             types.String `tfsdk:"type"`
+	Enabled          types.Bool   `tfsdk:"enabled"`
+	ReminderInterval types.Int64  `tfsdk:"reminder_interval"`
+	ValueThreshold   types.Int64  `tfsdk:"value_threshold"`
+	ValueCalculation types.String `tfsdk:"value_calculation"`
+	TimeThreshold    types.Int64  `tfsdk:"time_threshold"`
+	VhostRegex       types.String `tfsdk:"vhost_regex"`
+	QueueRegex       types.String `tfsdk:"queue_regex"`
+	MessageType      types.String `tfsdk:"message_type"`
+	Recipients       types.List   `tfsdk:"recipients"`
+}
+
+func (r *alarmResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "cloudamqp_alarm"
+}
+
+func (r *alarmResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This resource allows you to create and manage alarms to trigger based on a set of conditions. " +
+			"Once triggered a notification will be sent to the assigned recipients.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The resource identifier",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"instance_id": schema.Int64Attribute{
 				Required:    true,
-				ForceNew:    true,
-				Description: "Instance identifier",
+				Description: "The instance identifier",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
 			},
-			"type": {
-				Type:             schema.TypeString,
-				Required:         true,
-				Description:      "Type of the alarm, valid options are: cpu, memory, disk_usage, queue_length, connection_count, consumers_count, net_split",
-				ValidateDiagFunc: validateAlarmType(),
+			"type": schema.StringAttribute{
+				Required:    true,
+				Description: "Type of the alarme",
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						"cpu",
+						"memory",
+						"disk",
+						"queue",
+						"connection",
+						"flow",
+						"consumer",
+						"netsplit",
+						"ssh",
+						"notice",
+						"server_unreachable",
+					),
+				},
 			},
-			"enabled": {
-				Type:        schema.TypeBool,
+			"enabled": schema.BoolAttribute{
 				Required:    true,
 				Description: "Enable or disable an alarm",
 			},
-			"reminder_interval": {
-				Type:        schema.TypeInt,
+			"reminder_interval": schema.Int64Attribute{
 				Optional:    true,
-				Default:     0,
-				Description: "The reminder interval (in seconds) to resend the alarm if not resolved. Set to 0 for no reminders. The Default is 0.",
+				Computed:    true,
+				Description: "The reminder interval (in seconds) to resend the alarm if not resolved. Set to 0 for no reminders.",
+				Default:     int64default.StaticInt64(0),
 			},
-			"value_threshold": {
-				Type:        schema.TypeInt,
+			"value_threshold": schema.Int64Attribute{
 				Optional:    true,
 				Description: "What value to trigger the alarm for",
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
 			},
-			"value_calculation": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Disk value threshold calculation. Fixed or percentage of disk space remaining",
-				ValidateDiagFunc: validateValueCalculation(),
+			"value_calculation": schema.StringAttribute{
+				Optional:    true,
+				Description: "Disk value threshold calculation. Fixed or percentage of disk space remaining",
+				Validators: []validator.String{
+					stringvalidator.OneOf("fixed", "percentage"),
+				},
 			},
-			"time_threshold": {
-				Type:        schema.TypeInt,
+			"time_threshold": schema.Int64Attribute{
 				Optional:    true,
 				Description: "For how long (in seconds) the value_threshold should be active before trigger alarm",
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
 			},
-			"vhost_regex": {
-				Type:        schema.TypeString,
+			"vhost_regex": schema.StringAttribute{
 				Optional:    true,
 				Description: "Regex for which vhost the queues are in",
 			},
-			"queue_regex": {
-				Type:        schema.TypeString,
+			"queue_regex": schema.StringAttribute{
 				Optional:    true,
 				Description: "Regex for which queues to check",
 			},
-			"message_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Description:      "Message types (total, unacked, ready) of the queue to trigger the alarm",
-				ValidateDiagFunc: validateMessageType(),
-			},
-			"recipients": {
-				Type:     schema.TypeList,
-				Required: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeInt,
+			"message_type": schema.StringAttribute{
+				Optional:    true,
+				Description: "Message types of the queue to trigger the alarm",
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						"total", "unacked", "ready", "ack", "ack_rate", "deliver", "deliver_rate", "deliver_get",
+						"deliver_get_rate", "deliver_no_ack", "deliver_no_ack_rate", "get", "get_rate",
+						"get_empty", "get_empty_rate", "get_no_ack", "get_no_ack_rate", "publish", "publish_rate",
+						"redeliver", "redeliver_rate"),
 				},
+			},
+			"recipients": schema.ListAttribute{
+				ElementType: types.Int64Type,
+				Required:    true,
 				Description: "Identifiers for recipients to be notified.",
 			},
 		},
 	}
 }
 
-func resourceAlarmCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	api := meta.(*api.API)
-	keys := alarmAttributeKeys()
-	params := make(map[string]any)
-	for _, k := range keys {
-		if v := d.Get(k); v != nil {
-			params[k] = v
-		}
+func (r *alarmResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*api.API)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider Data Type",
+			fmt.Sprintf("Expected *api.API, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+func (r *alarmResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	tflog.Info(ctx, fmt.Sprintf("ImportState: ID=%s", req.ID))
+	if !strings.Contains(req.ID, ",") {
+		resp.Diagnostics.AddError("Invalid import ID format", "Expected format: {alarm_id},{instance_id}")
+		return
 	}
 
-	if d.Get("type") == "notice" {
-		tflog.Info(ctx, "alarm type is 'notice', skip creation, retrieve existing alarm and update")
-		alarms, err := api.ListAlarms(ctx, d.Get("instance_id").(int))
+	idSplit := strings.Split(req.ID, ",")
+	if len(idSplit) != 2 {
+		resp.Diagnostics.AddError("Invalid import ID format", "Expected format: {alarm_id},{instance_id}")
+		return
+	}
+	instanceID, err := strconv.ParseInt(idSplit[1], 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid instance_id in import ID", fmt.Sprintf("Could not convert instance_id to int: %s", err))
+		return
+	}
 
+	resp.State.SetAttribute(ctx, path.Root("id"), idSplit[0])
+	resp.State.SetAttribute(ctx, path.Root("instance_id"), instanceID)
+	// Default values for computed attributes
+	resp.State.SetAttribute(ctx, path.Root("reminder_interval"), 0)
+}
+
+func (r *alarmResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan alarmResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	instanceID := plan.InstanceID.ValueInt64()
+	params := r.populateRequest(ctx, plan)
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	var alarmID string
+	if params.Type == "notice" {
+		tflog.Info(ctx, "alarm type is 'notice', skip creation, retrieve existing alarm and update")
+		alarms, err := r.client.ListAlarms(timeoutCtx, instanceID)
 		if err != nil {
-			return diag.FromErr(err)
+			resp.Diagnostics.AddError(
+				"Failed to List Alarms",
+				fmt.Sprintf("Could not list alarms to find 'notice' alarm: %s", err),
+			)
+			return
 		}
 
 		for _, alarm := range alarms {
-			if alarm["type"] == "notice" {
-				d.SetId(strconv.FormatFloat(alarm["id"].(float64), 'f', 0, 64))
-				tflog.Debug(ctx, fmt.Sprintf("retrieve existing 'notice' alarm with identifier: %s and invoke an update",
-					d.Id()))
-				return resourceAlarmUpdate(ctx, d, meta)
+			if alarm.Type == "notice" {
+				alarmID = fmt.Sprintf("%d", alarm.ID)
+				break
 			}
 		}
 
-		return diag.Errorf("couldn't find notice alarm for instance_id: %s", d.Get("instance_id"))
-	} else {
-		data, err := api.CreateAlarm(ctx, d.Get("instance_id").(int), params)
+		if alarmID == "" {
+			resp.Diagnostics.AddError(
+				"Notice Alarm Not Found",
+				"Could not find existing 'notice' alarm to update.",
+			)
+			return
+		}
+
+		err = r.client.UpdateAlarm(timeoutCtx, instanceID, alarmID, params)
 		if err != nil {
-			return diag.FromErr(err)
+			resp.Diagnostics.AddError(
+				"Failed to Update Alarm",
+				fmt.Sprintf("Could not update alarm: %s", err),
+			)
+			return
 		}
-		if data["id"] != nil {
-			d.SetId(data["id"].(string))
+	} else {
+		var err error
+		alarmID, err = r.client.CreateAlarm(timeoutCtx, instanceID, params)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Failed to Create Alarm",
+				fmt.Sprintf("Could not create alarm: %s", err),
+			)
+			return
 		}
 	}
 
-	return resourceAlarmRead(ctx, d, meta)
+	plan.ID = types.StringValue(alarmID)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func resourceAlarmRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	if strings.Contains(d.Id(), ",") {
-		tflog.Debug(ctx, fmt.Sprintf("import alarm from input identifier: %s", d.Id()))
-		s := strings.Split(d.Id(), ",")
-		d.SetId(s[0])
-		instanceID, _ := strconv.Atoi(s[1])
-		d.Set("instance_id", instanceID)
-	}
-	if d.Get("instance_id").(int) == 0 {
-		return diag.Errorf("missing input identifier for import: {resource_id},{instance_id}")
+func (r *alarmResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state alarmResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	api := meta.(*api.API)
-	data, err := api.ReadAlarm(ctx, d.Get("instance_id").(int), d.Id())
+	instanceID := state.InstanceID.ValueInt64()
+	alarmID := state.ID.ValueString()
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	data, err := r.client.ReadAlarm(timeoutCtx, instanceID, alarmID)
 	if err != nil {
-		return diag.FromErr(err)
+		resp.Diagnostics.AddError(
+			"Failed to Read Alarm",
+			fmt.Sprintf("Could not read alarm: %s", err),
+		)
+		return
 	}
 
-	// Resource drift: instance or resource not found, trigger re-creation
 	if data == nil {
-		tflog.Info(ctx, fmt.Sprintf("alarm not found, resource will be recreated: %s", d.Id()))
-		d.SetId("")
-		return nil
+		tflog.Warn(ctx, fmt.Sprintf("Resource drift detected for alarm ID %s or instance ID %d", alarmID, instanceID))
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
-	for k, v := range data {
-		if validateAlarmSchemaAttribute(k) {
-			if err = d.Set(k, v); err != nil {
-				return diag.Errorf("error setting %s for resource %s: %s", k, d.Id(), err)
-			}
-		}
-	}
-
-	return nil
+	r.populateResourceModel(ctx, *data, &state)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func resourceAlarmUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	api := meta.(*api.API)
-	keys := alarmAttributeKeys()
-	params := make(map[string]any)
-	params["id"] = d.Id()
-
-	for _, k := range keys {
-		if v := d.Get(k); v != nil {
-			params[k] = v
-		}
+func (r *alarmResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan alarmResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if err := api.UpdateAlarm(ctx, d.Get("instance_id").(int), params); err != nil {
-		return diag.FromErr(err)
+	params := r.populateRequest(ctx, plan)
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	err := r.client.UpdateAlarm(timeoutCtx, plan.InstanceID.ValueInt64(), plan.ID.ValueString(), params)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to Update Alarm",
+			fmt.Sprintf("Could not update alarm: %s", err),
+		)
+		return
 	}
 
-	return resourceAlarmRead(ctx, d, meta)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func resourceAlarmDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	if d.Get("type") == "notice" {
+func (r *alarmResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state alarmResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if state.Type.ValueString() == "notice" {
 		tflog.Debug(ctx, "alarm type is 'notice', skip deletion and just remove from state")
-		return diag.Diagnostics{}
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
-	api := meta.(*api.API)
-	if err := api.DeleteAlarm(ctx, d.Get("instance_id").(int), d.Id()); err != nil {
-		return diag.FromErr(err)
+	instanceID := state.InstanceID.ValueInt64()
+	alarmID := state.ID.ValueString()
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	err := r.client.DeleteAlarm(timeoutCtx, instanceID, alarmID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to Delete Alarm",
+			fmt.Sprintf("Could not delete alarm: %s", err),
+		)
+		return
 	}
-	return diag.Diagnostics{}
 }
 
-func validateAlarmType() schema.SchemaValidateDiagFunc {
-	return validation.ToDiagFunc(validation.StringInSlice([]string{
-		"cpu",
-		"memory",
-		"disk",
-		"queue",
-		"connection",
-		"flow",
-		"consumer",
-		"netsplit",
-		"ssh",
-		"notice",
-		"server_unreachable",
-	}, true))
-}
+func (r *alarmResource) populateRequest(ctx context.Context, plan alarmResourceModel) model.AlarmRequest {
+	params := model.AlarmRequest{}
+	params.Type = plan.Type.ValueString()
+	params.Enabled = plan.Enabled.ValueBool()
 
-func validateAlarmSchemaAttribute(key string) bool {
-	switch key {
-	case "type",
-		"enabled",
-		"reminder_interval",
-		"value_threshold",
-		"value_calculation",
-		"time_threshold",
-		"vhost_regex",
-		"queue_regex",
-		"message_type",
-		"recipients":
-		return true
+	if !plan.ReminderInterval.IsUnknown() && !plan.ReminderInterval.IsNull() {
+		params.ReminderInterval = plan.ReminderInterval.ValueInt64Pointer()
 	}
-	return false
+
+	if !plan.ValueThreshold.IsUnknown() && !plan.ValueThreshold.IsNull() {
+		params.ValueThreshold = plan.ValueThreshold.ValueInt64Pointer()
+	}
+	if !plan.ValueCalculation.IsNull() {
+		params.ValueCalculation = plan.ValueCalculation.ValueString()
+	}
+	if !plan.TimeThreshold.IsUnknown() && !plan.TimeThreshold.IsNull() {
+		params.TimeThreshold = plan.TimeThreshold.ValueInt64Pointer()
+	}
+	if !plan.VhostRegex.IsUnknown() && !plan.VhostRegex.IsNull() {
+		params.VhostRegex = plan.VhostRegex.ValueString()
+	}
+	if !plan.QueueRegex.IsUnknown() && !plan.QueueRegex.IsNull() {
+		params.QueueRegex = plan.QueueRegex.ValueString()
+	}
+	if !plan.MessageType.IsUnknown() && !plan.MessageType.IsNull() {
+		params.MessageType = plan.MessageType.ValueString()
+	}
+	if !plan.Recipients.IsUnknown() && !plan.Recipients.IsNull() {
+		var recipients = []int64{}
+		plan.Recipients.ElementsAs(ctx, &recipients, false)
+		params.Recipients = utils.Pointer(recipients)
+	}
+
+	return params
 }
 
-func validateMessageType() schema.SchemaValidateDiagFunc {
-	return validation.ToDiagFunc(validation.StringInSlice([]string{
-		"total",
-		"unacked",
-		"ready",
-	}, true))
-}
+func (a *alarmResource) populateResourceModel(ctx context.Context, data model.AlarmResponse, state *alarmResourceModel) {
+	state.Type = types.StringValue(data.Type)
+	state.Enabled = types.BoolValue(data.Enabled)
 
-func validateValueCalculation() schema.SchemaValidateDiagFunc {
-	return validation.ToDiagFunc(validation.StringInSlice([]string{
-		"fixed",
-		"percentage",
-	}, true))
-}
+	if data.ReminderInterval != nil {
+		state.ReminderInterval = types.Int64Value(*data.ReminderInterval)
+	} else {
+		state.ReminderInterval = types.Int64Null()
+	}
 
-func alarmAttributeKeys() []string {
-	return []string{
-		"type",
-		"enabled",
-		"reminder_interval",
-		"value_threshold",
-		"value_calculation",
-		"time_threshold",
-		"vhost_regex",
-		"queue_regex",
-		"message_type",
-		"recipients",
+	if data.ValueThreshold != nil {
+		state.ValueThreshold = types.Int64Value(*data.ValueThreshold)
+	} else {
+		state.ValueThreshold = types.Int64Null()
+	}
+
+	if data.ValueCalculation != nil {
+		state.ValueCalculation = types.StringValue(*data.ValueCalculation)
+	} else {
+		state.ValueCalculation = types.StringNull()
+	}
+
+	if data.TimeThreshold != nil {
+		state.TimeThreshold = types.Int64Value(*data.TimeThreshold)
+	} else {
+		state.TimeThreshold = types.Int64Null()
+	}
+
+	if data.VhostRegex != nil {
+		state.VhostRegex = types.StringValue(*data.VhostRegex)
+	} else {
+		state.VhostRegex = types.StringNull()
+	}
+
+	if data.QueueRegex != nil {
+		state.QueueRegex = types.StringValue(*data.QueueRegex)
+	} else {
+		state.QueueRegex = types.StringNull()
+	}
+
+	if data.MessageType != nil {
+		state.MessageType = types.StringValue(*data.MessageType)
+	} else {
+		state.MessageType = types.StringNull()
+	}
+
+	if data.Recipients != nil {
+		recipientsList, _ := types.ListValueFrom(ctx, types.Int64Type, *data.Recipients)
+		state.Recipients = recipientsList
+	} else {
+		state.Recipients = types.ListNull(types.Int64Type)
 	}
 }

--- a/docs/data-sources/alarm.md
+++ b/docs/data-sources/alarm.md
@@ -7,6 +7,8 @@ description: |-
 
 # cloudamqp_alarm
 
+~> **Deprecated** This data source will be removed in next major version (v2.0). Use the `cloudamqp_alarms` data source instead.
+
 Use this data source to retrieve information about default or created alarms. Either use `alarm_id`
 or `type` to retrieve the alarm.
 

--- a/test/fixtures/vcr/TestAccAlarm_Notice.yaml
+++ b/test/fixtures/vcr/TestAccAlarm_Notice.yaml
@@ -48,10 +48,10 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - 84b88089-2a70-4771-8a03-9353c5f22550
+                - 4e6fc1f6-04f4-4177-8753-37307034e47b
         status: 200 OK
         code: 200
-        duration: 20.958853ms
+        duration: 24.353402ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -99,10 +99,10 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - 2ceb6cd7-39c2-4858-b521-fae8eb23dd67
+                - 75a42008-d130-485e-a3a8-f23f49e83cf3
         status: 200 OK
         code: 200
-        duration: 3.800979ms
+        duration: 5.13456ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -150,10 +150,10 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - 0ed814ad-59f5-4567-b78f-596704374a26
+                - 1e0ed06e-c2bb-47aa-8195-ad8ab53c0171
         status: 200 OK
         code: 200
-        duration: 22.932644ms
+        duration: 23.352215ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -201,10 +201,10 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - f578fd84-2a49-409f-8cf5-52a2ce418a19
+                - 79130e2c-e339-48cf-a82b-367ded2be5a1
         status: 200 OK
         code: 200
-        duration: 3.715417ms
+        duration: 3.92479ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -252,10 +252,10 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - 6502b252-1dfa-4a5c-925d-74ae9be9d8f9
+                - f2d846a6-d691-4d45-9dee-d112c5d0721c
         status: 200 OK
         code: 200
-        duration: 18.58486ms
+        duration: 13.558414ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -303,10 +303,10 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - 407eb30f-e14c-4f82-8701-2a7d60690785
+                - 17055b4b-bba2-4b1f-9c4f-355658d14c6b
         status: 200 OK
         code: 200
-        duration: 5.19724ms
+        duration: 4.609399ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -338,7 +338,7 @@ interactions:
         trailer: {}
         content_length: 246
         uncompressed: false
-        body: '{"id":896,"message":"Your dedicated instance will be available within a couple of minutes","apikey":"5a129c67-1f9a-48f6-80cf-5b1a72ce48a4","url":"amqps://moqfknnn:***@dev-white-swallow.lmq.dev.cloudamqp.com/moqfknnn"}'
+        body: '{"id":897,"message":"Your dedicated instance will be available within a couple of minutes","apikey":"7f1f3df5-5571-471a-8fbe-7f071f428153","url":"amqps://xbksgsug:***@dev-slushy-parrot.lmq.dev.cloudamqp.com/xbksgsug"}'
         headers:
             Cache-Control:
                 - no-cache
@@ -357,10 +357,10 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - 331720f9-c8ab-4815-89e8-3244c905f688
+                - 5f5c403a-fd07-4245-9932-b9e2bd0a6a46
         status: 200 OK
         code: 200
-        duration: 53.899016ms
+        duration: 74.219405ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -379,7 +379,7 @@ interactions:
                 - REDACTED
             User-Agent:
                 - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896
+        url: http://localhost:9393/api/instances/897
         method: GET
       response:
         proto: HTTP/1.1
@@ -389,7 +389,7 @@ interactions:
         trailer: {}
         content_length: 753
         uncompressed: false
-        body: '{"id":896,"name":"TestAccAlarm_Basic","plan":"penguin-1","region":"amazon-web-services::us-east-1","tags":["vcr-test"],"providerid":"8ac712a3-a2f0-457f-93e5-0658b9b979c2","url":"amqps://moqfknnn:***@dev-white-swallow.lmq.dev.cloudamqp.com/moqfknnn","ready":true,"apikey":"5a129c67-1f9a-48f6-80cf-5b1a72ce48a4","backend":"lavinmq","nodes":1,"urls":{"external":"amqps://moqfknnn:***@dev-white-swallow.lmq.dev.cloudamqp.com/moqfknnn","internal":"amqp://moqfknnn:***@dev-white-swallow.in.lmq.dev.cloudamqp.com/moqfknnn"},"rmq_version":"2.6.1","hostname_external":"dev-white-swallow.lmq.dev.cloudamqp.com","hostname_internal":"dev-white-swallow.in.lmq.dev.cloudamqp.com"}'
+        body: '{"id":897,"name":"TestAccAlarm_Basic","plan":"penguin-1","region":"amazon-web-services::us-east-1","tags":["vcr-test"],"providerid":"bb74e5d5-da16-4c74-bc54-96694efeeed4","url":"amqps://xbksgsug:***@dev-slushy-parrot.lmq.dev.cloudamqp.com/xbksgsug","ready":true,"apikey":"7f1f3df5-5571-471a-8fbe-7f071f428153","backend":"lavinmq","nodes":1,"urls":{"external":"amqps://xbksgsug:***@dev-slushy-parrot.lmq.dev.cloudamqp.com/xbksgsug","internal":"amqp://xbksgsug:***@dev-slushy-parrot.in.lmq.dev.cloudamqp.com/xbksgsug"},"rmq_version":"2.6.1","hostname_external":"dev-slushy-parrot.lmq.dev.cloudamqp.com","hostname_internal":"dev-slushy-parrot.in.lmq.dev.cloudamqp.com"}'
         headers:
             Cache-Control:
                 - no-cache
@@ -408,10 +408,10 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - f4296e33-4dfe-414f-acda-7434a05b2eb5
+                - 5ec3cd47-26e2-4986-ae46-bf3cdb3cc9a3
         status: 200 OK
         code: 200
-        duration: 25.439274ms
+        duration: 27.383601ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -430,7 +430,7 @@ interactions:
                 - REDACTED
             User-Agent:
                 - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896
+        url: http://localhost:9393/api/instances/897
         method: GET
       response:
         proto: HTTP/1.1
@@ -440,7 +440,7 @@ interactions:
         trailer: {}
         content_length: 753
         uncompressed: false
-        body: '{"id":896,"name":"TestAccAlarm_Basic","plan":"penguin-1","region":"amazon-web-services::us-east-1","tags":["vcr-test"],"providerid":"8ac712a3-a2f0-457f-93e5-0658b9b979c2","url":"amqps://moqfknnn:***@dev-white-swallow.lmq.dev.cloudamqp.com/moqfknnn","ready":true,"apikey":"5a129c67-1f9a-48f6-80cf-5b1a72ce48a4","backend":"lavinmq","nodes":1,"urls":{"external":"amqps://moqfknnn:***@dev-white-swallow.lmq.dev.cloudamqp.com/moqfknnn","internal":"amqp://moqfknnn:***@dev-white-swallow.in.lmq.dev.cloudamqp.com/moqfknnn"},"rmq_version":"2.6.1","hostname_external":"dev-white-swallow.lmq.dev.cloudamqp.com","hostname_internal":"dev-white-swallow.in.lmq.dev.cloudamqp.com"}'
+        body: '{"id":897,"name":"TestAccAlarm_Basic","plan":"penguin-1","region":"amazon-web-services::us-east-1","tags":["vcr-test"],"providerid":"bb74e5d5-da16-4c74-bc54-96694efeeed4","url":"amqps://xbksgsug:***@dev-slushy-parrot.lmq.dev.cloudamqp.com/xbksgsug","ready":true,"apikey":"7f1f3df5-5571-471a-8fbe-7f071f428153","backend":"lavinmq","nodes":1,"urls":{"external":"amqps://xbksgsug:***@dev-slushy-parrot.lmq.dev.cloudamqp.com/xbksgsug","internal":"amqp://xbksgsug:***@dev-slushy-parrot.in.lmq.dev.cloudamqp.com/xbksgsug"},"rmq_version":"2.6.1","hostname_external":"dev-slushy-parrot.lmq.dev.cloudamqp.com","hostname_internal":"dev-slushy-parrot.in.lmq.dev.cloudamqp.com"}'
         headers:
             Cache-Control:
                 - no-cache
@@ -459,10 +459,10 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - 871d79c3-4519-498b-8900-cc803f348511
+                - e966e59f-028b-4cad-8496-1b8b43f70b3f
         status: 200 OK
         code: 200
-        duration: 14.219162ms
+        duration: 22.531287ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -481,7 +481,7 @@ interactions:
                 - REDACTED
             User-Agent:
                 - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/recipients
+        url: http://localhost:9393/api/instances/897/alarms/recipients
         method: GET
       response:
         proto: HTTP/1.1
@@ -491,7 +491,7 @@ interactions:
         trailer: {}
         content_length: 107
         uncompressed: false
-        body: '[{"id":661,"type":"email","value":"tobias@84codes.com","name":"Default","options":null,"last_status":null}]'
+        body: '[{"id":663,"type":"email","value":"tobias@84codes.com","name":"Default","options":null,"last_status":null}]'
         headers:
             Cache-Control:
                 - no-cache
@@ -510,65 +510,11 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - 7ed20fcc-eb05-44bd-b0e0-5529c7dd628b
+                - a7c3702c-2a77-4c58-b176-b4444e2ce9f0
         status: 200 OK
         code: 200
-        duration: 27.963905ms
+        duration: 23.38986ms
     - id: 10
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 71
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"name":"test","options":{},"type":"email","value":"test@example.com"}
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            Content-Type:
-                - application/json
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/recipients
-        method: POST
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 98
-        uncompressed: false
-        body: '{"id":662,"type":"email","value":"test@example.com","name":"test","options":{},"last_status":null}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "98"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - 426ed0d8-7f83-4055-86e0-7ef4e1f5b804
-        status: 201 Created
-        code: 201
-        duration: 34.987672ms
-    - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -586,7 +532,7 @@ interactions:
                 - REDACTED
             User-Agent:
                 - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms
+        url: http://localhost:9393/api/instances/897/alarms
         method: GET
       response:
         proto: HTTP/1.1
@@ -596,7 +542,7 @@ interactions:
         trailer: {}
         content_length: 84
         uncompressed: false
-        body: '[{"reminder_interval":null,"id":679,"type":"notice","recipients":[],"enabled":true}]'
+        body: '[{"reminder_interval":null,"id":681,"type":"notice","recipients":[],"enabled":true}]'
         headers:
             Cache-Control:
                 - no-cache
@@ -615,65 +561,11 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - a0dcfc73-9654-4635-a95d-c70ece63403f
+                - c879c380-99d9-4c3d-807a-bfe773bb963a
         status: 200 OK
         code: 200
-        duration: 17.457182ms
-    - id: 12
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 113
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"type":"cpu","enabled":true,"reminder_interval":0,"value_threshold":90,"time_threshold":600,"recipients":[662]}
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            Content-Type:
-                - application/json
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms
-        method: POST
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 121
-        uncompressed: false
-        body: '{"time_threshold":600,"value_threshold":90,"reminder_interval":0,"id":680,"type":"cpu","recipients":[662],"enabled":true}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "121"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - 69aa8e0e-8322-421a-905c-9437c9f0cc8a
-        status: 201 Created
-        code: 201
-        duration: 29.596717ms
-    - id: 13
+        duration: 18.58826ms
+    - id: 11
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -685,7 +577,7 @@ interactions:
         remote_addr: ""
         request_uri: ""
         body: |
-            {"type":"notice","enabled":true,"reminder_interval":0,"recipients":[661]}
+            {"type":"notice","enabled":true,"reminder_interval":0,"recipients":[663]}
         form: {}
         headers:
             Authorization:
@@ -694,7 +586,7 @@ interactions:
                 - application/json
             User-Agent:
                 - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/679
+        url: http://localhost:9393/api/instances/897/alarms/681
         method: PUT
       response:
         proto: HTTP/1.1
@@ -704,7 +596,7 @@ interactions:
         trailer: {}
         content_length: 82
         uncompressed: false
-        body: '{"reminder_interval":0,"id":679,"type":"notice","recipients":[661],"enabled":true}'
+        body: '{"reminder_interval":0,"id":681,"type":"notice","recipients":[663],"enabled":true}'
         headers:
             Cache-Control:
                 - no-cache
@@ -723,10 +615,112 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - b132b1ab-da55-4a68-a772-4d28ed91d77b
+                - dfba2731-3a37-4789-9cfd-d56fe9a5dd58
         status: 201 Created
         code: 201
-        duration: 28.314927ms
+        duration: 28.308902ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: localhost:9393
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - REDACTED
+            User-Agent:
+                - terraform-provider-cloudamqp_v1.0
+        url: http://localhost:9393/api/instances/897/alarms/recipients
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 107
+        uncompressed: false
+        body: '[{"id":663,"type":"email","value":"tobias@84codes.com","name":"Default","options":null,"last_status":null}]'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "107"
+            Content-Type:
+                - application/json
+            Nel:
+                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+            Report-To:
+                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
+            Set-Cookie:
+                - REDACTED
+            X-Content-Type-Options:
+                - nosniff
+            X-Request-Id:
+                - e3f5b389-9b5f-4815-8987-ec35d62ec12f
+        status: 200 OK
+        code: 200
+        duration: 17.923553ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: localhost:9393
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            Authorization:
+                - REDACTED
+            User-Agent:
+                - terraform-provider-cloudamqp_v1.0
+        url: http://localhost:9393/api/instances/897
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: 753
+        uncompressed: false
+        body: '{"id":897,"name":"TestAccAlarm_Basic","plan":"penguin-1","region":"amazon-web-services::us-east-1","tags":["vcr-test"],"providerid":"bb74e5d5-da16-4c74-bc54-96694efeeed4","url":"amqps://xbksgsug:***@dev-slushy-parrot.lmq.dev.cloudamqp.com/xbksgsug","ready":true,"apikey":"7f1f3df5-5571-471a-8fbe-7f071f428153","backend":"lavinmq","nodes":1,"urls":{"external":"amqps://xbksgsug:***@dev-slushy-parrot.lmq.dev.cloudamqp.com/xbksgsug","internal":"amqp://xbksgsug:***@dev-slushy-parrot.in.lmq.dev.cloudamqp.com/xbksgsug"},"rmq_version":"2.6.1","hostname_external":"dev-slushy-parrot.lmq.dev.cloudamqp.com","hostname_internal":"dev-slushy-parrot.in.lmq.dev.cloudamqp.com"}'
+        headers:
+            Cache-Control:
+                - no-cache
+            Content-Length:
+                - "753"
+            Content-Type:
+                - application/json
+            Nel:
+                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+            Report-To:
+                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
+            Set-Cookie:
+                - REDACTED
+            X-Content-Type-Options:
+                - nosniff
+            X-Request-Id:
+                - a1663224-5d33-4694-9a79-170af3930ce6
+        status: 200 OK
+        code: 200
+        duration: 15.768773ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -745,7 +739,7 @@ interactions:
                 - REDACTED
             User-Agent:
                 - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/recipients
+        url: http://localhost:9393/api/instances/897/alarms/recipients
         method: GET
       response:
         proto: HTTP/1.1
@@ -753,14 +747,14 @@ interactions:
         proto_minor: 1
         transfer_encoding: []
         trailer: {}
-        content_length: 206
+        content_length: 107
         uncompressed: false
-        body: '[{"id":661,"type":"email","value":"tobias@84codes.com","name":"Default","options":null,"last_status":null},{"id":662,"type":"email","value":"test@example.com","name":"test","options":{},"last_status":null}]'
+        body: '[{"id":663,"type":"email","value":"tobias@84codes.com","name":"Default","options":null,"last_status":null}]'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "206"
+                - "107"
             Content-Type:
                 - application/json
             Nel:
@@ -774,10 +768,10 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - 0eab0817-f68d-4b6f-b51f-4c08b3515e90
+                - da31b186-305a-4af9-be41-26171b6d1915
         status: 200 OK
         code: 200
-        duration: 19.4678ms
+        duration: 19.767366ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -796,7 +790,7 @@ interactions:
                 - REDACTED
             User-Agent:
                 - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896
+        url: http://localhost:9393/api/instances/897/alarms/681
         method: GET
       response:
         proto: HTTP/1.1
@@ -804,14 +798,14 @@ interactions:
         proto_minor: 1
         transfer_encoding: []
         trailer: {}
-        content_length: 753
+        content_length: 82
         uncompressed: false
-        body: '{"id":896,"name":"TestAccAlarm_Basic","plan":"penguin-1","region":"amazon-web-services::us-east-1","tags":["vcr-test"],"providerid":"8ac712a3-a2f0-457f-93e5-0658b9b979c2","url":"amqps://moqfknnn:***@dev-white-swallow.lmq.dev.cloudamqp.com/moqfknnn","ready":true,"apikey":"5a129c67-1f9a-48f6-80cf-5b1a72ce48a4","backend":"lavinmq","nodes":1,"urls":{"external":"amqps://moqfknnn:***@dev-white-swallow.lmq.dev.cloudamqp.com/moqfknnn","internal":"amqp://moqfknnn:***@dev-white-swallow.in.lmq.dev.cloudamqp.com/moqfknnn"},"rmq_version":"2.6.1","hostname_external":"dev-white-swallow.lmq.dev.cloudamqp.com","hostname_internal":"dev-white-swallow.in.lmq.dev.cloudamqp.com"}'
+        body: '{"reminder_interval":0,"id":681,"type":"notice","recipients":[663],"enabled":true}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "753"
+                - "82"
             Content-Type:
                 - application/json
             Nel:
@@ -825,10 +819,10 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - 6898c8e6-6451-449d-a9e7-d9fd9d3b177e
+                - ef70f9bf-5bbe-4242-bfd5-1f7a81d7adcf
         status: 200 OK
         code: 200
-        duration: 22.910423ms
+        duration: 12.751824ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -847,7 +841,7 @@ interactions:
                 - REDACTED
             User-Agent:
                 - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/recipients
+        url: http://localhost:9393/api/instances/897/alarms/recipients
         method: GET
       response:
         proto: HTTP/1.1
@@ -855,14 +849,14 @@ interactions:
         proto_minor: 1
         transfer_encoding: []
         trailer: {}
-        content_length: 206
+        content_length: 107
         uncompressed: false
-        body: '[{"id":661,"type":"email","value":"tobias@84codes.com","name":"Default","options":null,"last_status":null},{"id":662,"type":"email","value":"test@example.com","name":"test","options":{},"last_status":null}]'
+        body: '[{"id":663,"type":"email","value":"tobias@84codes.com","name":"Default","options":null,"last_status":null}]'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "206"
+                - "107"
             Content-Type:
                 - application/json
             Nel:
@@ -876,10 +870,10 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - 661b8056-694a-4a9c-b3a2-002b17587a8f
+                - 1c350a40-d4b5-4f28-b658-fd011c0b7aea
         status: 200 OK
         code: 200
-        duration: 28.035734ms
+        duration: 16.707487ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -898,7 +892,7 @@ interactions:
                 - REDACTED
             User-Agent:
                 - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/recipients/662
+        url: http://localhost:9393/api/instances/897/alarms/681
         method: GET
       response:
         proto: HTTP/1.1
@@ -906,14 +900,14 @@ interactions:
         proto_minor: 1
         transfer_encoding: []
         trailer: {}
-        content_length: 98
+        content_length: 82
         uncompressed: false
-        body: '{"id":662,"type":"email","value":"test@example.com","name":"test","options":{},"last_status":null}'
+        body: '{"reminder_interval":0,"id":681,"type":"notice","recipients":[663],"enabled":true}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "98"
+                - "82"
             Content-Type:
                 - application/json
             Nel:
@@ -927,10 +921,10 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - 6390a123-8313-4a10-b23f-473d22111574
+                - 9f9fe6eb-e1cf-437b-9e7b-71847fc02ff1
         status: 200 OK
         code: 200
-        duration: 30.117276ms
+        duration: 13.739897ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -949,24 +943,20 @@ interactions:
                 - REDACTED
             User-Agent:
                 - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/679
-        method: GET
+        url: http://localhost:9393/api/instances/897?keep_vpc=false
+        method: DELETE
       response:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
         transfer_encoding: []
         trailer: {}
-        content_length: 82
+        content_length: 0
         uncompressed: false
-        body: '{"reminder_interval":0,"id":679,"type":"notice","recipients":[661],"enabled":true}'
+        body: ""
         headers:
             Cache-Control:
                 - no-cache
-            Content-Length:
-                - "82"
-            Content-Type:
-                - application/json
             Nel:
                 - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
             Referrer-Policy:
@@ -978,10 +968,10 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - 7b2ac37f-938c-4948-8265-c289c5374864
-        status: 200 OK
-        code: 200
-        duration: 21.144062ms
+                - d116aa42-65e8-4401-ae53-e151e4a4855a
+        status: 204 No Content
+        code: 204
+        duration: 65.344954ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -1000,1222 +990,7 @@ interactions:
                 - REDACTED
             User-Agent:
                 - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/680
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 121
-        uncompressed: false
-        body: '{"time_threshold":600,"value_threshold":90,"reminder_interval":0,"id":680,"type":"cpu","recipients":[662],"enabled":true}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "121"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - 25c4dfab-0c3b-47e7-8fbb-00e27454b508
-        status: 200 OK
-        code: 200
-        duration: 20.592993ms
-    - id: 20
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/recipients
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 206
-        uncompressed: false
-        body: '[{"id":661,"type":"email","value":"tobias@84codes.com","name":"Default","options":null,"last_status":null},{"id":662,"type":"email","value":"test@example.com","name":"test","options":{},"last_status":null}]'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "206"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - f3c9381d-da03-4531-8297-0b0f6c71b8f0
-        status: 200 OK
-        code: 200
-        duration: 19.318793ms
-    - id: 21
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/680
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 121
-        uncompressed: false
-        body: '{"time_threshold":600,"value_threshold":90,"reminder_interval":0,"id":680,"type":"cpu","recipients":[662],"enabled":true}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "121"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - a1171135-e665-43d1-acfc-8eb7087ed961
-        status: 200 OK
-        code: 200
-        duration: 20.566503ms
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 753
-        uncompressed: false
-        body: '{"id":896,"name":"TestAccAlarm_Basic","plan":"penguin-1","region":"amazon-web-services::us-east-1","tags":["vcr-test"],"providerid":"8ac712a3-a2f0-457f-93e5-0658b9b979c2","url":"amqps://moqfknnn:***@dev-white-swallow.lmq.dev.cloudamqp.com/moqfknnn","ready":true,"apikey":"5a129c67-1f9a-48f6-80cf-5b1a72ce48a4","backend":"lavinmq","nodes":1,"urls":{"external":"amqps://moqfknnn:***@dev-white-swallow.lmq.dev.cloudamqp.com/moqfknnn","internal":"amqp://moqfknnn:***@dev-white-swallow.in.lmq.dev.cloudamqp.com/moqfknnn"},"rmq_version":"2.6.1","hostname_external":"dev-white-swallow.lmq.dev.cloudamqp.com","hostname_internal":"dev-white-swallow.in.lmq.dev.cloudamqp.com"}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "753"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - d6b94bf8-665d-49d4-8dd7-fc7d603059d4
-        status: 200 OK
-        code: 200
-        duration: 18.50794ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/recipients
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 206
-        uncompressed: false
-        body: '[{"id":661,"type":"email","value":"tobias@84codes.com","name":"Default","options":null,"last_status":null},{"id":662,"type":"email","value":"test@example.com","name":"test","options":{},"last_status":null}]'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "206"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - e33b9657-28ac-4960-8ca1-c97ad0731b94
-        status: 200 OK
-        code: 200
-        duration: 21.425104ms
-    - id: 24
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/recipients/662
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 98
-        uncompressed: false
-        body: '{"id":662,"type":"email","value":"test@example.com","name":"test","options":{},"last_status":null}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "98"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - 46a286b4-12a7-4879-aec8-7c76be3e650b
-        status: 200 OK
-        code: 200
-        duration: 22.149465ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/679
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 82
-        uncompressed: false
-        body: '{"reminder_interval":0,"id":679,"type":"notice","recipients":[661],"enabled":true}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "82"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - e643ae76-4a58-4913-a79d-301335fbc8b7
-        status: 200 OK
-        code: 200
-        duration: 21.630546ms
-    - id: 26
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/680
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 121
-        uncompressed: false
-        body: '{"time_threshold":600,"value_threshold":90,"reminder_interval":0,"id":680,"type":"cpu","recipients":[662],"enabled":true}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "121"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - f3da5cff-dcbf-43fe-8bec-ca2316dfe9d4
-        status: 200 OK
-        code: 200
-        duration: 21.051105ms
-    - id: 27
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/recipients
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 206
-        uncompressed: false
-        body: '[{"id":661,"type":"email","value":"tobias@84codes.com","name":"Default","options":null,"last_status":null},{"id":662,"type":"email","value":"test@example.com","name":"test","options":{},"last_status":null}]'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "206"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - f730664a-e1f9-449d-87f8-b901aa52faa1
-        status: 200 OK
-        code: 200
-        duration: 16.786684ms
-    - id: 28
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 113
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: |
-            {"type":"cpu","enabled":true,"reminder_interval":0,"value_threshold":50,"time_threshold":450,"recipients":[662]}
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            Content-Type:
-                - application/json
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/680
-        method: PUT
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 121
-        uncompressed: false
-        body: '{"time_threshold":450,"value_threshold":50,"reminder_interval":0,"id":680,"type":"cpu","recipients":[662],"enabled":true}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "121"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - 3dc55b10-0d07-42c4-98c7-e5821974428f
-        status: 201 Created
-        code: 201
-        duration: 25.830724ms
-    - id: 29
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 206
-        uncompressed: false
-        body: '[{"reminder_interval":0,"id":679,"type":"notice","recipients":[661],"enabled":true},{"time_threshold":450,"value_threshold":50,"reminder_interval":0,"id":680,"type":"cpu","recipients":[662],"enabled":true}]'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "206"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - 9ad9f21d-adb9-4a97-b76c-9b0503a8397f
-        status: 200 OK
-        code: 200
-        duration: 14.634345ms
-    - id: 30
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/recipients
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 206
-        uncompressed: false
-        body: '[{"id":661,"type":"email","value":"tobias@84codes.com","name":"Default","options":null,"last_status":null},{"id":662,"type":"email","value":"test@example.com","name":"test","options":{},"last_status":null}]'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "206"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - 89a9dcbd-cd88-4b80-9f72-2d3420f8cbb9
-        status: 200 OK
-        code: 200
-        duration: 16.9902ms
-    - id: 31
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 206
-        uncompressed: false
-        body: '[{"reminder_interval":0,"id":679,"type":"notice","recipients":[661],"enabled":true},{"time_threshold":450,"value_threshold":50,"reminder_interval":0,"id":680,"type":"cpu","recipients":[662],"enabled":true}]'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "206"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - 6de859d9-011b-4c3e-8b14-923066df99a9
-        status: 200 OK
-        code: 200
-        duration: 19.102437ms
-    - id: 32
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 753
-        uncompressed: false
-        body: '{"id":896,"name":"TestAccAlarm_Basic","plan":"penguin-1","region":"amazon-web-services::us-east-1","tags":["vcr-test"],"providerid":"8ac712a3-a2f0-457f-93e5-0658b9b979c2","url":"amqps://moqfknnn:***@dev-white-swallow.lmq.dev.cloudamqp.com/moqfknnn","ready":true,"apikey":"5a129c67-1f9a-48f6-80cf-5b1a72ce48a4","backend":"lavinmq","nodes":1,"urls":{"external":"amqps://moqfknnn:***@dev-white-swallow.lmq.dev.cloudamqp.com/moqfknnn","internal":"amqp://moqfknnn:***@dev-white-swallow.in.lmq.dev.cloudamqp.com/moqfknnn"},"rmq_version":"2.6.1","hostname_external":"dev-white-swallow.lmq.dev.cloudamqp.com","hostname_internal":"dev-white-swallow.in.lmq.dev.cloudamqp.com"}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "753"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - e558b54f-7e25-4b38-9636-6c3064dd6bef
-        status: 200 OK
-        code: 200
-        duration: 18.067964ms
-    - id: 33
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/recipients
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 206
-        uncompressed: false
-        body: '[{"id":661,"type":"email","value":"tobias@84codes.com","name":"Default","options":null,"last_status":null},{"id":662,"type":"email","value":"test@example.com","name":"test","options":{},"last_status":null}]'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "206"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - 5a6bd27d-c348-485b-8b4f-13a83d461792
-        status: 200 OK
-        code: 200
-        duration: 22.85371ms
-    - id: 34
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/recipients/662
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 98
-        uncompressed: false
-        body: '{"id":662,"type":"email","value":"test@example.com","name":"test","options":{},"last_status":null}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "98"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - f2584c3f-0101-4fc4-8b97-68ba1bf8890a
-        status: 200 OK
-        code: 200
-        duration: 24.511863ms
-    - id: 35
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/679
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 82
-        uncompressed: false
-        body: '{"reminder_interval":0,"id":679,"type":"notice","recipients":[661],"enabled":true}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "82"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - 3ece2a36-2a00-4555-97c2-9195a3dd9e33
-        status: 200 OK
-        code: 200
-        duration: 25.352978ms
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/680
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 121
-        uncompressed: false
-        body: '{"time_threshold":450,"value_threshold":50,"reminder_interval":0,"id":680,"type":"cpu","recipients":[662],"enabled":true}'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "121"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - 86f0d76f-64ff-4ccb-bdf1-6db19f08999e
-        status: 200 OK
-        code: 200
-        duration: 22.731372ms
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 206
-        uncompressed: false
-        body: '[{"reminder_interval":0,"id":679,"type":"notice","recipients":[661],"enabled":true},{"time_threshold":450,"value_threshold":50,"reminder_interval":0,"id":680,"type":"cpu","recipients":[662],"enabled":true}]'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "206"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - b7e979a2-45df-42da-8c6a-ddda1da5764f
-        status: 200 OK
-        code: 200
-        duration: 19.730963ms
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/recipients
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 206
-        uncompressed: false
-        body: '[{"id":661,"type":"email","value":"tobias@84codes.com","name":"Default","options":null,"last_status":null},{"id":662,"type":"email","value":"test@example.com","name":"test","options":{},"last_status":null}]'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "206"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - e01371f9-0bd5-4d3d-8a8e-20d5092102a0
-        status: 200 OK
-        code: 200
-        duration: 25.221797ms
-    - id: 39
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 206
-        uncompressed: false
-        body: '[{"reminder_interval":0,"id":679,"type":"notice","recipients":[661],"enabled":true},{"time_threshold":450,"value_threshold":50,"reminder_interval":0,"id":680,"type":"cpu","recipients":[662],"enabled":true}]'
-        headers:
-            Cache-Control:
-                - no-cache
-            Content-Length:
-                - "206"
-            Content-Type:
-                - application/json
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - 166247c3-6b65-4e4b-8169-5b4f6e2ac769
-        status: 200 OK
-        code: 200
-        duration: 27.633094ms
-    - id: 40
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/680
-        method: DELETE
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Cache-Control:
-                - no-cache
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - d7c95269-b1af-447e-b824-6b549c4c1b13
-        status: 204 No Content
-        code: 204
-        duration: 24.437848ms
-    - id: 41
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896/alarms/recipients/662
-        method: DELETE
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Cache-Control:
-                - no-cache
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - 710172fe-a0c7-4031-8ca0-efa30ba69a1c
-        status: 204 No Content
-        code: 204
-        duration: 26.507727ms
-    - id: 42
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896?keep_vpc=false
-        method: DELETE
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        transfer_encoding: []
-        trailer: {}
-        content_length: 0
-        uncompressed: false
-        body: ""
-        headers:
-            Cache-Control:
-                - no-cache
-            Nel:
-                - '{"report_to":"default","max_age":31536000,"include_subdomains":true}'
-            Referrer-Policy:
-                - strict-origin-when-cross-origin
-            Report-To:
-                - '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://84codes.report-uri.com/a/t/g"}],"include_subdomains":true}'
-            Set-Cookie:
-                - REDACTED
-            X-Content-Type-Options:
-                - nosniff
-            X-Request-Id:
-                - 58b11d0c-fbd4-479c-8fad-cc16afec6bda
-        status: 204 No Content
-        code: 204
-        duration: 65.432937ms
-    - id: 43
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        transfer_encoding: []
-        trailer: {}
-        host: localhost:9393
-        remote_addr: ""
-        request_uri: ""
-        body: ""
-        form: {}
-        headers:
-            Authorization:
-                - REDACTED
-            User-Agent:
-                - terraform-provider-cloudamqp_v1.0
-        url: http://localhost:9393/api/instances/896
+        url: http://localhost:9393/api/instances/897
         method: GET
       response:
         proto: HTTP/1.1
@@ -2244,7 +1019,7 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Request-Id:
-                - 8adc0cec-64e9-4d49-9c56-d56089c6000b
+                - 91487f49-32ec-4c01-a727-3d8ebaa1d3d7
         status: 404 Not Found
         code: 404
-        duration: 8.349067ms
+        duration: 4.002303ms


### PR DESCRIPTION
### WHY are these changes introduced?

Part of Terraform plugin framework migration #281.

### WHAT is this pull request doing?

- Adds API model for alarm
- Migrates `cloudamqp_alarm`, `data_source_alarm` and `data_source_alarms` to framework
- Adds new notice VCR test case

### HOW was this pull request tested?

VCR-test check and manual runs during implementation.
