### PR TITLE
Add Timeouts block to cloudamqp_plugin_community

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 1.x.x (Unreleased)
+
+BUG FIXES:
+
+* resource/cloudamqp_plugin_community: Added schema `Timeouts` block to prevent context deadline cancellation when used via the Pulumi Terraform bridge ([#487])
+
+[#487]: https://github.com/cloudamqp/terraform-provider-cloudamqp/issues/487
+
 ## 1.44.3 (13 Apr, 2026)
 
 NOTES:

--- a/cloudamqp/resource_cloudamqp_plugin_community.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -20,6 +21,12 @@ func resourcePluginCommunity() *schema.Resource {
 		DeleteContext: resourcePluginCommunityDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Read:   schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
 			"instance_id": {


### PR DESCRIPTION
## Summary

- Adds a schema `Timeouts` block (60m Create/Read/Update/Delete) to `cloudamqp_plugin_community`.
- Fixes context deadline cancellation when the resource is used via the Pulumi Terraform bridge, which sources operation deadlines from the schema rather than running without a deadline like Terraform CLI.
- No observable effect for Terraform CLI users.

Fixes #487

## Test plan

- [ ] `go build ./...` passes
- [ ] Existing Terraform CLI flows unaffected
- [ ] Pulumi bridge usage no longer cancels at ~20m when `timeout` is set higher

🤖 Generated with [Claude Code](https://claude.com/claude-code)