### PR TITLE
Add Timeouts block to cloudamqp_plugin

### DIFF
--- a/cloudamqp/resource_cloudamqp_plugin.go
+++ b/cloudamqp/resource_cloudamqp_plugin.go
@@ -3,7 +3,6 @@ package cloudamqp
 import (
 	"context"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -127,8 +126,6 @@ func resourcePluginRead(ctx context.Context, d *schema.ResourceData, meta any) d
 		return diag.Errorf("missing instance identifier: {resource_id},{instance_id}")
 	}
 
-	log.Printf("[DEBUG] import plugin instanceID: %v, name: %v, sleep: %v, timeout: %v",
-		instanceID, name, sleep, timeout)
 	data, err := api.ReadPlugin(ctx, instanceID, name, sleep, timeout)
 	if err != nil {
 		// If instance not found (404), return nil to indicate resource not found
@@ -184,7 +181,7 @@ func resourcePluginDelete(ctx context.Context, d *schema.ResourceData, meta any)
 	)
 
 	if enableFasterInstanceDestroy {
-		log.Printf("[DEBUG] cloudamqp::resource::plugin::delete skip calling backend.")
+		tflog.Debug(ctx, "cloudamqp::resource::plugin::delete skip calling backend.")
 		return diag.Diagnostics{}
 	}
 

--- a/cloudamqp/resource_cloudamqp_plugin.go
+++ b/cloudamqp/resource_cloudamqp_plugin.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cloudamqp/terraform-provider-cloudamqp/api"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -21,6 +22,12 @@ func resourcePlugin() *schema.Resource {
 		DeleteContext: resourcePluginDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Read:   schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
 			"instance_id": {


### PR DESCRIPTION
### WHY are these changes introduced?

Similar context use as `cloudamqp_plugin_community` and user reported
issues with context deadline, while using Pulumi Terraform bridge #488

### WHAT is this pull request doing?

- Adds a schema Timeouts block (60m Create/Read/Update/Delete) to `cloudamqp_plugin`

### HOW was this pull request tested?

Manual run with Terraform CLI for plugins and community plugins.
