### PR TITLE
Documentation about LavinMQ in-place shared to dedicated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ DEPENDENCIES:
 * Bumped github.com/hashicorp/terraform-plugin-mux from 0.23.0 to 0.23.1 ([#486])
 
 [#432]: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/432
+[#453]: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/453
 [#482]: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/482
 [#485]: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/485
 [#486]: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/486
-[#453]: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/453
 
 ## 1.44.4 (14 Apr, 2026)
 

--- a/docs/guides/info_lavinmq_shared_to_dedicated.md
+++ b/docs/guides/info_lavinmq_shared_to_dedicated.md
@@ -1,0 +1,113 @@
+---
+layout: "cloudamqp"
+page_title: "CloudAMQP: LavinMQ shared to dedicated upgrade"
+subcategory: "info"
+description: |-
+  Guide on how to upgrade a LavinMQ shared instance to a dedicated plan in-place.
+---
+
+# LavinMQ shared to dedicated upgrade
+
+From v1.45.0 it is possible to upgrade a [**LavinMQ**] shared instance to a dedicated plan
+in-place. The instance ID is preserved, no resource replacement occurs, and existing definitions
+are kept. The upgrade is performed by changing the `plan` argument in your configuration and
+running `terraform apply`.
+
+~> This upgrade path is only available for **LavinMQ** instances. RabbitMQ shared instances cannot
+be upgraded in-place to dedicated plans and will require a new resource.
+
+## Shared LavinMQ plans
+
+The following LavinMQ shared plans are eligible for in-place upgrade to a dedicated plan:
+
+Plan       | Name
+-----------|----------------
+`lemming`  | Loyal Lemming
+`ermine`   | Elegant Ermine
+
+## Constraints
+
+* The cloud provider must remain the same. For example, moving between AWS regions is supported,
+  but moving from AWS to GCP is not.
+* The target plan must be a dedicated LavinMQ plan. See available [plans].
+* The reverse upgrade path (dedicated to shared) is **not** supported and will force a new
+  resource to be created.
+
+## What can change during the upgrade
+
+The following attributes can optionally be changed during the same `terraform apply` as the plan
+change:
+
+* `plan` — (Required) Must change to a dedicated LavinMQ plan (e.g. `puffin-1`, `penguin-1`,
+  `wolverine-1`).
+* `region` — (Optional) Can change to a different region within the same cloud provider.
+* `vpc_id` — (Optional) Place the dedicated instance in an existing VPC.
+* `vpc_subnet` — (Optional) Create a new VPC with the given subnet.
+* `preferred_az` — (Optional) Preferred availability zones for the dedicated nodes.
+
+## Upgrade example
+
+<details>
+  <summary>
+    <b>
+      <i>Upgrade a lemming instance to a dedicated wolverine plan</i>
+    </b>
+  </summary>
+
+Start with a shared LavinMQ instance:
+
+```hcl
+resource "cloudamqp_instance" "instance" {
+  name   = "terraform-cloudamqp-instance"
+  plan   = "lemming"
+  region = "amazon-web-services::eu-north-1"
+  tags   = ["terraform"]
+}
+```
+
+Change `plan` to a dedicated LavinMQ plan. Optionally change `region` within the same cloud
+provider:
+
+```hcl
+resource "cloudamqp_instance" "instance" {
+  name   = "terraform-cloudamqp-instance"
+  plan   = "wolverine-1"
+  region = "amazon-web-services::eu-west-1"
+  tags   = ["terraform"]
+}
+```
+
+Run `terraform apply`. The instance ID will remain the same and no resource replacement occurs.
+
+</details>
+
+<details>
+  <summary>
+    <b>
+      <i>Upgrade a lemming instance to dedicated and place it in a managed VPC</i>
+    </b>
+  </summary>
+
+```hcl
+resource "cloudamqp_vpc" "vpc" {
+  name   = "my-vpc"
+  region = "amazon-web-services::eu-west-1"
+  subnet = "10.56.72.0/24"
+  tags   = []
+}
+
+resource "cloudamqp_instance" "instance" {
+  name                = "terraform-cloudamqp-instance"
+  plan                = "wolverine-1"
+  region              = "amazon-web-services::eu-west-1"
+  tags                = ["terraform"]
+  vpc_id              = cloudamqp_vpc.vpc.id
+  keep_associated_vpc = true
+}
+```
+
+</details>
+
+[**LavinMQ**]: https://lavinmq.com
+[cloudamqp_instance]: ../resources/instance.md
+[plans]: ../guides/info_plan.md

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -219,16 +219,58 @@ resource "lavinmq_vhost" "new_vhost" {
 
 </details>
 
+<details>
+  <summary>
+    <b>
+      <i>LavinMQ shared to dedicated in-place upgrade, from v1.45.0</i>
+    </b>
+  </summary>
+
+```hcl
+# Initial shared LavinMQ instance
+resource "cloudamqp_instance" "instance" {
+  name   = "terraform-cloudamqp-instance"
+  plan   = "lemming"
+  region = "amazon-web-services::eu-north-1"
+  tags   = ["terraform"]
+}
+```
+
+```hcl
+# Upgraded to dedicated LavinMQ — region can change within the same cloud provider
+# No resource replacement occurs; the instance ID is preserved
+resource "cloudamqp_instance" "instance" {
+  name   = "terraform-cloudamqp-instance"
+  plan   = "wolverine-1"
+  region = "amazon-web-services::eu-west-1"
+  tags   = ["terraform"]
+}
+```
+
+</details>
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `name`    - (Required) Name of the CloudAMQP instance.
 * `plan`    - (Required) The subscription plan. See available [plans].
+
+  ***Note:*** Changing between a LavinMQ shared plan (`lemming`, `ermine`) and a dedicated LavinMQ
+              plan will **not** force resource replacement. The instance ID is preserved and existing
+              definitions are kept. See [LavinMQ shared to dedicated] for details.
+              All other plan type changes (e.g. shared to dedicated for RabbitMQ) will force a new
+              resource.
+
 * `region`  - (Required) The region to host the instance in. See available [regions].
 
   ***Note:*** Changing region will force the instance to be destroyed and a new created in the new
               region. All data will be lost and a new name assigned.
+
+  ***Note:*** Exception: when upgrading a LavinMQ shared instance to a dedicated plan, the region
+              can change without destroying the resource, as long as the cloud provider stays the
+              same (e.g. `amazon-web-services` → `amazon-web-services` is allowed, but
+              `amazon-web-services` → `google-compute-engine` is not).
 
 * `nodes`   - (Optional/Computed) Number of nodes, 1, 3 or 5 depending on plan used. Only needed for
               legacy plans, will otherwise be computed.
@@ -382,6 +424,49 @@ resource "cloudamqp_instance" "instance" {
 
 </details>
 
+## LavinMQ shared to dedicated upgrade
+
+From v1.45.0 it is possible to upgrade a LavinMQ shared instance (`lemming` or `ermine`) in-place
+to any dedicated LavinMQ plan without destroying and recreating the resource. The instance ID is
+preserved and existing definitions are kept. To upgrade, change the `plan` argument and apply.
+
+~> This upgrade path is only available for **LavinMQ** instances. RabbitMQ shared instances cannot
+be upgraded in-place to dedicated plans.
+
+Optionally, the following attributes can be changed in the same `terraform apply` during the
+upgrade: `region` (within the same cloud provider), `vpc_id`, `vpc_subnet`, and `preferred_az`.
+
+See the [LavinMQ shared to dedicated] guide for full details and more examples.
+
+<details>
+  <summary>
+    <b>
+      <i>Upgrade LavinMQ shared instance to dedicated, from v1.45.0</i>
+    </b>
+  </summary>
+
+```hcl
+# Initial shared LavinMQ instance
+resource "cloudamqp_instance" "instance" {
+  name   = "instance"
+  plan   = "lemming"
+  region = "amazon-web-services::eu-north-1"
+  tags   = ["terraform"]
+}
+```
+
+```hcl
+# Upgraded to dedicated — instance ID is preserved, no resource replacement
+resource "cloudamqp_instance" "instance" {
+  name   = "instance"
+  plan   = "wolverine-1"
+  region = "amazon-web-services::eu-west-1"
+  tags   = ["terraform"]
+}
+```
+
+</details>
+
 ## Copy settings to a new dedicated instance
 
 With copy settings it's possible to create a new dedicated instance with settings such as alarms,
@@ -456,6 +541,7 @@ resource "cloudamqp_instance" "bunny_instance" {
 [CloudAMQP plans]: https://www.cloudamqp.com/plans.html
 [copy settings]: #copy-settings-to-a-new-dedicated-instance
 [example]: ../guides/info_vpc_existing.md
+[LavinMQ shared to dedicated]: ../guides/info_lavinmq_shared_to_dedicated.md
 [regions]: ../guides/info_region.md
 [**LavinMQ**]: https://lavinmq.com
 [Managed VPC]: ../guides/info_managed_vpc#dedicated-instance-and-vpc_subnet


### PR DESCRIPTION
### WHY are these changes introduced?

Missing documentation of new feature.

### WHAT is this pull request doing?

- Updates `docs/resources/instance.md` with LavinMQ shared to dedicated
- Adds new guide about LavinMQ shared to dedicated 

### HOW was this pull request tested?

Viewed with https://registry.terraform.io/tools/doc-preview
