### PR TITLE
fix(maintenance_window): preserve automatic_updates state when API returns nil

### DIFF
--- a/cloudamqp/resource_cloudamqp_maintenance_window.go
+++ b/cloudamqp/resource_cloudamqp_maintenance_window.go
@@ -94,6 +94,9 @@ func (r *maintenanceWindowResource) Schema(ctx context.Context, req resource.Sch
 				Optional:    true,
 				Computed:    true,
 				Description: "Enable automatic updates (only available for LavinMQ)",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.String{
 					stringvalidator.OneOf("on", "off"),
 				},
@@ -179,7 +182,7 @@ func (r *maintenanceWindowResource) Create(ctx context.Context, req resource.Cre
 			} else {
 				plan.AutomaticUpdates = types.StringValue("off")
 			}
-		} else {
+		} else if plan.AutomaticUpdates.IsUnknown() {
 			plan.AutomaticUpdates = types.StringNull()
 		}
 	}
@@ -236,7 +239,7 @@ func (r *maintenanceWindowResource) Read(ctx context.Context, req resource.ReadR
 		} else {
 			state.AutomaticUpdates = types.StringValue("off")
 		}
-	} else {
+	} else if state.AutomaticUpdates.IsUnknown() {
 		state.AutomaticUpdates = types.StringNull()
 	}
 
@@ -302,7 +305,7 @@ func (r *maintenanceWindowResource) Update(ctx context.Context, req resource.Upd
 			} else {
 				plan.AutomaticUpdates = types.StringValue("off")
 			}
-		} else {
+		} else if plan.AutomaticUpdates.IsUnknown() {
 			plan.AutomaticUpdates = types.StringNull()
 		}
 	}


### PR DESCRIPTION
### WHY are these changes introduced?

The `automatic_updates` currently only supported for LavinMQ brokers. RabbitMQ accept it as NOOP and omit the read response. This was handled before Framework migration, after causes two issue after.

1. Provider produced inconsistent result after apply the plan held the user's configured value (e.g. "on"), but after the post-apply refresh the state was overwritten with null.
2. Perpetual drift on subsequent plans, state held "on" while the refresh returned null, causing Terraform to always propose an update.

Reference: #499

### WHAT is this pull request doing?

- Adds `schema.UseStateForUnknown` to the automatic_updates schema attribute.
- In Create(), Update(), and Read(), when the API returns nil for automatic_updates, the existing plan/state value is now left unchanged.
- Sets value to null if values is still unknown.

### HOW was this pull request tested?

VCR-test check and manual runs (v1.44.0 and upgrade to version with changes)
