### PR TITLE
fix: importing community plugin resource

### DIFF
--- a/cloudamqp/resource_cloudamqp_plugin_community.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community.go
@@ -206,7 +206,8 @@ func validateCommunityPluginSchemaAttribute(key string) bool {
 	switch key {
 	case "name",
 		"require",
-		"description":
+		"description",
+		"enabled":
 		return true
 	}
 	return false

--- a/cloudamqp/resource_cloudamqp_plugin_community.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community.go
@@ -64,7 +64,7 @@ func resourcePluginCommunity() *schema.Resource {
 			"timeout": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     1800,
+				Default:     3600,
 				Description: "Configurable timeout time in seconds for plugins",
 			},
 		},
@@ -121,7 +121,7 @@ func resourcePluginCommunityRead(ctx context.Context, d *schema.ResourceData, me
 		d.Set("instance_id", instanceID)
 		// Set default values for optional arguments
 		d.Set("sleep", 10)
-		d.Set("timeout", 1800)
+		d.Set("timeout", 3600)
 	}
 	if instanceID == 0 {
 		return diag.Errorf("missing instance identifier: {resource_id},{instance_id}")

--- a/cloudamqp/resource_cloudamqp_plugin_community.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community.go
@@ -129,10 +129,10 @@ func resourcePluginCommunityRead(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("missing instance identifier: {resource_id},{instance_id}")
 	}
 
-	data, err := api.ReadPluginCommunity(ctx, instanceID, name, sleep, timeout)
 	timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 	defer cancel()
 
+	data, err := api.ReadPlugin(timeoutCtx, instanceID, name, sleep, timeout)
 	if err != nil {
 		// If instance not found (404), return nil to indicate resource not found
 		// This allows Terraform to recreate the resource when the instance is recreated

--- a/cloudamqp/resource_cloudamqp_plugin_community.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community.go
@@ -121,13 +121,17 @@ func resourcePluginCommunityRead(ctx context.Context, d *schema.ResourceData, me
 		d.Set("instance_id", instanceID)
 		// Set default values for optional arguments
 		d.Set("sleep", 10)
-		sleep = 10
 		d.Set("timeout", 1800)
-		timeout = 1800
 	}
 	if instanceID == 0 {
 		return diag.Errorf("missing instance identifier: {resource_id},{instance_id}")
 	}
+
+	// Read values after import setup to ensure defaults are applied
+	instanceID = d.Get("instance_id").(int)
+	name = d.Get("name").(string)
+	sleep = d.Get("sleep").(int)
+	timeout = d.Get("timeout").(int)
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 	defer cancel()

--- a/cloudamqp/resource_cloudamqp_plugin_community.go
+++ b/cloudamqp/resource_cloudamqp_plugin_community.go
@@ -121,13 +121,18 @@ func resourcePluginCommunityRead(ctx context.Context, d *schema.ResourceData, me
 		d.Set("instance_id", instanceID)
 		// Set default values for optional arguments
 		d.Set("sleep", 10)
+		sleep = 10
 		d.Set("timeout", 1800)
+		timeout = 1800
 	}
 	if instanceID == 0 {
 		return diag.Errorf("missing instance identifier: {resource_id},{instance_id}")
 	}
 
 	data, err := api.ReadPluginCommunity(ctx, instanceID, name, sleep, timeout)
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+	defer cancel()
+
 	if err != nil {
 		// If instance not found (404), return nil to indicate resource not found
 		// This allows Terraform to recreate the resource when the instance is recreated


### PR DESCRIPTION
### WHY are these changes introduced?

Importing community plugin fails.

Reference: #501

### WHAT is this pull request doing?

- Sets values for sleep/timeout after import
- Creates context with timeout
- Uses correct endpoint to fetch plugin information once installed

### HOW was this pull request tested?

Manual run.
