### PR TITLE
Preserve type from credentials file

### DIFF
--- a/cloudamqp/resource_cloudamqp_integration_metric_prometheus.go
+++ b/cloudamqp/resource_cloudamqp_integration_metric_prometheus.go
@@ -378,7 +378,7 @@ func extractStackdriverCredentials(credentials string) (map[string]string, error
 		return nil, fmt.Errorf("failed to parse stackdriver credentials JSON: %s", err)
 	}
 
-	requiredFields := []string{"client_email", "private_key_id", "private_key", "project_id"}
+	requiredFields := []string{"type", "client_email", "private_key_id", "private_key", "project_id"}
 	for _, field := range requiredFields {
 		if jsonMap[field] == nil || jsonMap[field] == "" {
 			return nil, fmt.Errorf("required field '%s' is missing from credentials JSON", field)
@@ -386,6 +386,7 @@ func extractStackdriverCredentials(credentials string) (map[string]string, error
 	}
 
 	return map[string]string{
+		"type":           jsonMap["type"].(string),
 		"client_email":   jsonMap["client_email"].(string),
 		"private_key_id": jsonMap["private_key_id"].(string),
 		"private_key":    jsonMap["private_key"].(string),


### PR DESCRIPTION
### WHY are these changes introduced?

The new otel-collector uses the upstream `googlecloudexporter`, which authenticates via Google's standard auth library. That library validates the credentials JSON and rejects it with `missing 'type' field in credentials` if `type` is absent, refusing to start the exporter.

The provider previously parsed the uploaded service-account JSON but stripped `type` before forwarding to the API, so prometheus Stackdriver integrations created via Terraform ended up with credentials the new exporter won't accept.

### WHAT is this pull request doing?

In `extractStackdriverCredentials`:
  - Add `type` to the list of required fields validated in the input JSON.
  - Forward `type` along with the existing fields to the API.

Google's service-account key JSON always includes `"type": "service_account"`, so any legitimate file pasted in will validate. 