### PR TITLE
Add changelog entry for stackdriver credentials type fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ IMPROVEMENTS:
 
 * data_source/cloudamqp_plugins: Added new filter attributes to filter plugins ([#522])
 
+BUG FIXES:
+
+* resource/cloudamqp_integration_metric_prometheus: Preserve the `type` field from the Stackdriver credentials file, without it the metrics exporter fails to start ([#517])
+
 DEPENDENCIES:
 
 * Bumped actions/checkout from 6 to 7 ([#524])
@@ -27,6 +31,7 @@ DEPENDENCIES:
 * Bumped github.com/tidwall/gjson from 1.18.0 to 1.19.0 ([#515])
 
 [#515]: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/515
+[#517]: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/517
 [#518]: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/518
 [#521]: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/521
 [#522]: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/522


### PR DESCRIPTION
### WHY are these changes introduced?

The fix in #517 shipped in v1.46.0 but never got a CHANGELOG entry, so the release notes do not mention it. Users hitting the `missing 'type' field in credentials` failure have no way to tell from the changelog which version fixed it.

### WHAT is this pull request doing?

Adds the missing BUG FIXES entry for #517 under the `1.46.0` heading, which is the release that actually contains the commit, plus the corresponding link reference.

### HOW was this pull request tested?

`go test ./...` — passes. Documentation-only change, no provider code touched.