### PR TITLE
Redact credentials from integration log and metric request logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ IMPROVEMENTS:
 * resource/cloudamqp_integration_metric_prometheus: Added oauth2 authentication to the Prometheus Remote Write metric integration ([#542])
 * docs/resource/integration_log_agent: Clarified CloudWatch IAM permissions and log stream setup ([#544])
 
+BUG FIXES:
+
+* resource/cloudamqp_integration_log, resource/cloudamqp_integration_metric: Redact credentials from debug logging of create and update requests ([#545])
+
 [#542]: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/542
 [#544]: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/544
+[#545]: https://github.com/cloudamqp/terraform-provider-cloudamqp/pull/545
 
 ## 1.48.0 (3 Sep, 2026)
 

--- a/api/integration_log.go
+++ b/api/integration_log.go
@@ -18,7 +18,7 @@ func (api *API) CreateIntegrationLog(ctx context.Context, instanceID int64, intN
 		path   = fmt.Sprintf("/api/instances/%d/integrations/logs/%s", instanceID, intName)
 	)
 
-	tflog.Debug(ctx, fmt.Sprintf("method=POST path=%s params=%+v ", path, params))
+	tflog.Debug(ctx, fmt.Sprintf("method=POST path=%s params=%+v ", path, params.Sanitized()))
 	err := api.callWithRetry(ctx, api.sling.New().Post(path).BodyJSON(params), retryRequest{
 		functionName: "CreateIntegrationLog",
 		resourceName: "IntegrationLog",
@@ -74,7 +74,7 @@ func (api *API) UpdateIntegrationLog(ctx context.Context, instanceID int64, logI
 		path   = fmt.Sprintf("/api/instances/%d/integrations/logs/%s", instanceID, logID)
 	)
 
-	tflog.Debug(ctx, fmt.Sprintf("method=PUT path=%s params=%v ", path, params))
+	tflog.Debug(ctx, fmt.Sprintf("method=PUT path=%s params=%v ", path, params.Sanitized()))
 	return api.callWithRetry(ctx, api.sling.New().Put(path).BodyJSON(params), retryRequest{
 		functionName: "UpdateIntegrationLog",
 		resourceName: "IntegrationLog",

--- a/api/integration_metric.go
+++ b/api/integration_metric.go
@@ -18,7 +18,7 @@ func (api *API) CreateIntegrationMetric(ctx context.Context, instanceID int64, i
 		path   = fmt.Sprintf("/api/instances/%d/integrations/metrics/%s", instanceID, intName)
 	)
 
-	tflog.Debug(ctx, fmt.Sprintf("method=POST path=%s params=%+v ", path, params))
+	tflog.Debug(ctx, fmt.Sprintf("method=POST path=%s params=%+v ", path, params.Sanitized()))
 	err := api.callWithRetry(ctx, api.sling.New().Post(path).BodyJSON(params), retryRequest{
 		functionName: "CreateIntegrationMetric",
 		resourceName: "IntegrationMetric",
@@ -73,7 +73,7 @@ func (api *API) UpdateIntegrationMetric(ctx context.Context, instanceID int64, m
 		path   = fmt.Sprintf("/api/instances/%d/integrations/metrics/%s", instanceID, metricID)
 	)
 
-	tflog.Debug(ctx, fmt.Sprintf("method=PUT path=%s params=%v ", path, params))
+	tflog.Debug(ctx, fmt.Sprintf("method=PUT path=%s params=%v ", path, params.Sanitized()))
 	return api.callWithRetry(ctx, api.sling.New().Put(path).BodyJSON(params), retryRequest{
 		functionName: "UpdateIntegrationMetric",
 		resourceName: "IntegrationMetric",

--- a/api/models/integrations/log.go
+++ b/api/models/integrations/log.go
@@ -59,3 +59,16 @@ type LogConfigResponse struct {
 	Token             *string `json:"token,omitempty"`
 	URL               *string `json:"url,omitempty"`
 }
+
+// Sanitized returns a copy safe for logging, with credential fields redacted.
+func (r LogRequest) Sanitized() LogRequest {
+	sanitized := r
+	sanitized.AccessKeyID = redactedString(r.AccessKeyID)
+	sanitized.APIKey = redactedString(r.APIKey)
+	sanitized.ApplicationSecret = redactedString(r.ApplicationSecret)
+	sanitized.PrivateKey = redactedString(r.PrivateKey)
+	sanitized.PrivateKeyID = redactedString(r.PrivateKeyID)
+	sanitized.SecretAccessKey = redactedString(r.SecretAccessKey)
+	sanitized.Token = redactedString(r.Token)
+	return sanitized
+}

--- a/api/models/integrations/metric.go
+++ b/api/models/integrations/metric.go
@@ -47,3 +47,15 @@ type MetricConfigResponse struct {
 	Token           *string `json:"token,omitempty"`
 	VhostRegex      *string `json:"vhost_regex,omitempty"`
 }
+
+// Sanitized returns a copy safe for logging, with credential fields redacted.
+func (r MetricRequest) Sanitized() MetricRequest {
+	sanitized := r
+	sanitized.AccessKeyID = redactedString(r.AccessKeyID)
+	sanitized.APIKey = redactedString(r.APIKey)
+	sanitized.PrivateKey = redactedString(r.PrivateKey)
+	sanitized.PrivateKeyID = redactedString(r.PrivateKeyID)
+	sanitized.SecretAccessKey = redactedString(r.SecretAccessKey)
+	sanitized.Token = redactedString(r.Token)
+	return sanitized
+}

--- a/api/models/integrations/sanitize_test.go
+++ b/api/models/integrations/sanitize_test.go
@@ -1,0 +1,62 @@
+package integrations
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestLogRequestSanitizedRedactsCredentials(t *testing.T) {
+	secrets := []string{"akid", "apikey", "appsecret", "pkey", "pkeyid", "sak", "tok"}
+	r := LogRequest{
+		AccessKeyID:       secrets[0],
+		APIKey:            secrets[1],
+		ApplicationSecret: secrets[2],
+		PrivateKey:        secrets[3],
+		PrivateKeyID:      secrets[4],
+		SecretAccessKey:   secrets[5],
+		Token:             secrets[6],
+		Region:            "eu-west-1",
+	}
+
+	out := fmt.Sprintf("%+v", r.Sanitized())
+
+	for _, s := range secrets {
+		if strings.Contains(out, s) {
+			t.Errorf("sanitized output leaks %q: %s", s, out)
+		}
+	}
+	if !strings.Contains(out, "Region:eu-west-1") {
+		t.Errorf("sanitized output lost non-secret field: %s", out)
+	}
+	if r.Token != "tok" {
+		t.Error("Sanitized must not mutate the receiver")
+	}
+}
+
+func TestMetricRequestSanitizedRedactsCredentials(t *testing.T) {
+	secrets := []string{"akid", "apikey", "pkey", "pkeyid", "sak", "tok"}
+	r := MetricRequest{
+		AccessKeyID:     secrets[0],
+		APIKey:          secrets[1],
+		PrivateKey:      secrets[2],
+		PrivateKeyID:    secrets[3],
+		SecretAccessKey: secrets[4],
+		Token:           secrets[5],
+		Region:          "eu-west-1",
+	}
+
+	out := fmt.Sprintf("%+v", r.Sanitized())
+
+	for _, s := range secrets {
+		if strings.Contains(out, s) {
+			t.Errorf("sanitized output leaks %q: %s", s, out)
+		}
+	}
+	if !strings.Contains(out, "Region:eu-west-1") {
+		t.Errorf("sanitized output lost non-secret field: %s", out)
+	}
+	if r.Token != "tok" {
+		t.Error("Sanitized must not mutate the receiver")
+	}
+}


### PR DESCRIPTION
CreateIntegrationLog, UpdateIntegrationLog, CreateIntegrationMetric and UpdateIntegrationMetric logged the full request body at debug level. The body carries third-party credentials (AWS keys, GCP private keys, API tokens, Azure application secrets) that the resource schemas mark as sensitive, so TF_LOG_PROVIDER=DEBUG wrote them in cleartext.

The SDKv2 path in api/integration.go already masked these keys via tflog; the masking was lost when the resources moved to the plugin framework in v1.37.0. Add Sanitized() to LogRequest and MetricRequest, following the existing LogAgentRequest convention, and use it at the four log sites.

Fixes GHSA-cmmm-q6vp-gqc7.